### PR TITLE
re-adding a fix that was wiped out by a merge

### DIFF
--- a/python/galileo/openai.py
+++ b/python/galileo/openai.py
@@ -1,8 +1,8 @@
 import logging
 from dataclasses import dataclass
-from inspect import isclass
-from typing import Optional, Dict, Any, Callable
 from datetime import datetime
+from inspect import isclass
+from typing import Any, Callable, Optional
 
 import openai.resources
 from openai._types import NotGiven
@@ -98,7 +98,7 @@ class OpenAiArgsExtractor:
 
 def _galileo_wrapper(func: Callable) -> Callable:
     def _with_galileo(open_ai_definitions: OpenAiModuleDefinition, initialize: Callable) -> Callable:
-        def wrapper(wrapped: Callable, args: dict, kwargs: dict) -> Any:
+        def wrapper(wrapped: Callable, instance: Any, args: dict, kwargs: dict) -> Any:
             return func(open_ai_definitions, initialize, wrapped, args, kwargs)
 
         return wrapper
@@ -106,7 +106,7 @@ def _galileo_wrapper(func: Callable) -> Callable:
     return _with_galileo
 
 
-def _extract_chat_prompt(kwargs: Dict) -> list | dict:
+def _extract_chat_prompt(kwargs: dict) -> list | dict:
     """Extracts the user input from prompts. Returns a list of messages or dict with messages and functions"""
     prompt = {}
 
@@ -127,7 +127,7 @@ def _extract_chat_prompt(kwargs: Dict) -> list | dict:
         return [message for message in kwargs.get("messages", [])]
 
 
-def _extract_chat_response(kwargs: Dict) -> dict:
+def _extract_chat_response(kwargs: dict) -> dict:
     """Extracts the llm output from the response."""
     response = {"role": kwargs.get("role", None)}
 

--- a/python/galileo/utils/core_api_client.py
+++ b/python/galileo/utils/core_api_client.py
@@ -1,22 +1,17 @@
-from importlib.metadata import version
-from os import getenv
-from time import time
-from typing import Any, Optional
-
-import jwt
 import logging
-from httpx import Client, AsyncClient, HTTPError, Response, Timeout, URL
+from os import getenv
+from typing import Any, Optional
 from urllib.parse import urljoin
+from uuid import UUID
 
-from galileo_core.constants.request_method import RequestMethod
-from galileo_core.helpers.execution import async_run
-from galileo_core.helpers.api_client import ApiClient as CoreApiClient
-from galileo.constants.routes import Routes
-from galileo.schema.trace import TracesIngestRequest, TracesIngestResponse
-from galileo.utils.request import HttpHeaders, make_request
+from httpx import Client, Timeout
+
 from galileo.api_client import GalileoApiClient
-from galileo.projects import Projects
-from galileo.log_streams import LogStreams
+from galileo.constants.routes import Routes
+from galileo.schema.trace import TracesIngestRequest
+from galileo.utils.request import HttpHeaders, make_request
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient as CoreApiClient
 
 _logger = logging.getLogger(__name__)
 
@@ -119,16 +114,16 @@ class GalileoCoreApiClient:
         )
 
     async def ingest_traces(self, traces_ingest_request: TracesIngestRequest) -> dict[str, str]:
-        traces_ingest_request.log_stream_id = self.log_stream_id
-        json = traces_ingest_request.model_dump()
+        traces_ingest_request.log_stream_id = UUID(self.log_stream_id)
+        json = traces_ingest_request.model_dump(mode="json")
 
         return await self._make_async_request(
             RequestMethod.POST, endpoint=Routes.traces.format(project_id=self.project_id), json=json
         )
 
     def ingest_traces_sync(self, traces_ingest_request: TracesIngestRequest) -> dict[str, str]:
-        traces_ingest_request.log_stream_id = self.log_stream_id
-        json = traces_ingest_request.model_dump()
+        traces_ingest_request.log_stream_id = UUID(self.log_stream_id)
+        json = traces_ingest_request.model_dump(mode="json")
 
         return self._make_request(
             RequestMethod.POST, endpoint=Routes.traces.format(project_id=self.project_id), json=json


### PR DESCRIPTION
- Fixing warnings on flush()
- `instance` might have been accidentally removed from the OpenAI wrapper