### PR TITLE
test: dont ignore async test

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1654,6 +1654,25 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.9"
+groups = ["test"]
+files = [
+    {file = "pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3"},
+    {file = "pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a"},
+]
+
+[package.dependencies]
+pytest = ">=8.2,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "6.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -2445,4 +2464,4 @@ openai = ["openai"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9,<3.14"
-content-hash = "bd5c972d23a3f6f13af3d874f03318a70577738569413b40eb975734e88d21e3"
+content-hash = "6713b0ef93f3b3f085faf60f9ceae068b37424421c6624e7b4c8047ddc947c1b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ coverage = "^7.2.3"
 pytest-cov = "^6.0.0"
 pytest-xdist = "^3.3.1"
 pytest-socket = "^0.7"
+pytest-asyncio = "^0.25.3"
 requests-mock = "^1.11.0"
 galileo-core = { extras = ["testing"], version = "^3.5.0" }
 pytest-env = "^1.1.5"


### PR DESCRIPTION
We ignore async test, because we doesn't have pytest-asyncio deps for testing.