### PR TITLE
fix: update add_llm_span example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ logger.add_llm_span(
     input="Say this is a test",
     output="Hello, this is a test",
     model="gpt-4o",
-    input_tokens=10,
-    output_tokens=3,
+    num_input_tokens=10,
+    num_output_tokens=3,
     total_tokens=13,
     duration_ns=1000,
 )


### PR DESCRIPTION
This PR fixes sample:
```
/Users/andrii/Library/Caches/pypoetry/virtualenvs/galileo-Akae5rpx-py3.10/bin/python /Users/andrii/work/rungalileo/openai-samples/main.py 
Traceback (most recent call last):
  File "/Users/andrii/work/rungalileo/openai-samples/main.py", line 38, in <module>
    logger.add_llm_span(
TypeError: GalileoLogger.add_llm_span() got an unexpected keyword argument 'input_tokens'
```