### PR TITLE
feat: use @log with ThreadPoolExecutor

### DIFF
--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -168,6 +168,7 @@ class GalileoDecorator:
             exc_value: Exception value if an exception was raised in the context
             traceback: Traceback if an exception was raised in the context
         """
+        _logger.debug("create new GalileoDecorator __exit__")
         # Flush the logger instance
         self.get_logger_instance(
             project=_project_context.get(),
@@ -195,6 +196,7 @@ class GalileoDecorator:
         Returns:
             GalileoDecorator: The decorator instance configured with the provided parameters
         """
+        _logger.debug("create new GalileoDecorator __call__")
         self._project = project
         self._log_stream = log_stream
         self._experiment_id = experiment_id
@@ -502,6 +504,7 @@ class GalileoDecorator:
             span_params: Parameters for the span
         """
         client_instance = self.get_logger_instance()
+        _logger.debug(f"client_instance {id(client_instance)} {client_instance}")
 
         stack = _span_stack_context.get().copy()
         trace = _trace_context.get()
@@ -612,12 +615,14 @@ class GalileoDecorator:
             logger = self.get_logger_instance()
 
             # If the span type is a workflow, conclude it
+            _logger.debug(f"{span_type=} {stack=} {span_params=}")
             if span_type == "workflow" or not span_type:
                 if stack:
                     stack.pop()
                     _span_stack_context.set(stack)
 
                 status_code = span_params.get("status_code", None)
+                _logger.debug(f"conclude {output=} {status_code=}")
                 logger.conclude(output=output, duration_ns=span_params["duration_ns"], status_code=status_code)
             else:
                 # If the span type is not a workflow, add it to the current parent (trace or span)
@@ -812,6 +817,7 @@ class GalileoDecorator:
 
         This method clears all context variables and resets the logger singleton.
         """
+        _logger.debug("running reset")
         GalileoLoggerSingleton().reset(
             project=_project_context.get(),
             log_stream=_log_stream_context.get(),

--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -168,7 +168,6 @@ class GalileoDecorator:
             exc_value: Exception value if an exception was raised in the context
             traceback: Traceback if an exception was raised in the context
         """
-        _logger.debug("create new GalileoDecorator __exit__")
         # Flush the logger instance
         self.get_logger_instance(
             project=_project_context.get(),
@@ -196,7 +195,6 @@ class GalileoDecorator:
         Returns:
             GalileoDecorator: The decorator instance configured with the provided parameters
         """
-        _logger.debug("create new GalileoDecorator __call__")
         self._project = project
         self._log_stream = log_stream
         self._experiment_id = experiment_id
@@ -817,7 +815,6 @@ class GalileoDecorator:
 
         This method clears all context variables and resets the logger singleton.
         """
-        _logger.debug("running reset")
         GalileoLoggerSingleton().reset(
             project=_project_context.get(),
             log_stream=_log_stream_context.get(),

--- a/src/galileo/utils/singleton.py
+++ b/src/galileo/utils/singleton.py
@@ -1,9 +1,12 @@
+import logging
 import threading
 from os import getenv
 from typing import Optional
 
 from galileo.constants import DEFAULT_LOG_STREAM_NAME, DEFAULT_PROJECT_NAME
 from galileo.logger import GalileoLogger
+
+_logger = logging.getLogger(__name__)
 
 
 class GalileoLoggerSingleton:
@@ -56,15 +59,21 @@ class GalileoLoggerSingleton:
         Returns:
             Tuple[str, str]: A tuple key (project, log_stream) used for caching.
         """
+        _logger.debug("current thread is %s", threading.current_thread().name)
+
+        # GalileoLoggerSingleton must NOT be shared across different threads
+        current_thread_name = threading.current_thread().name
+        key = (current_thread_name,)
+
         if project is None:
             project = getenv("GALILEO_PROJECT", DEFAULT_PROJECT_NAME)
         if log_stream is None:
             log_stream = getenv("GALILEO_LOG_STREAM", DEFAULT_LOG_STREAM_NAME)
 
         if experiment_id is not None:
-            return project, experiment_id
+            return key + (project, experiment_id)
 
-        return project, log_stream
+        return key + (project, log_stream)
 
     def get(
         self, *, project: Optional[str] = None, log_stream: Optional[str] = None, experiment_id: Optional[str] = None
@@ -86,10 +95,6 @@ class GalileoLoggerSingleton:
         """
         # Compute the key based on provided parameters or environment variables.
         key = GalileoLoggerSingleton._get_key(project, log_stream, experiment_id)
-
-        # First check without acquiring lock for performance.
-        if key in self._galileo_loggers:
-            return self._galileo_loggers[key]
 
         # Acquire lock for thread-safe creation of new logger.
         with self._lock:

--- a/src/galileo/utils/singleton.py
+++ b/src/galileo/utils/singleton.py
@@ -96,6 +96,11 @@ class GalileoLoggerSingleton:
         # Compute the key based on provided parameters or environment variables.
         key = GalileoLoggerSingleton._get_key(project, log_stream, experiment_id)
 
+        # First check without acquiring lock for performance.
+        if key in self._galileo_loggers:
+            return self._galileo_loggers[key]
+
+
         # Acquire lock for thread-safe creation of new logger.
         with self._lock:
             # Double-check in case another thread created the logger while waiting.

--- a/src/galileo/utils/singleton.py
+++ b/src/galileo/utils/singleton.py
@@ -100,7 +100,6 @@ class GalileoLoggerSingleton:
         if key in self._galileo_loggers:
             return self._galileo_loggers[key]
 
-
         # Acquire lock for thread-safe creation of new logger.
         with self._lock:
             # Double-check in case another thread created the logger while waiting.


### PR DESCRIPTION
How to test:

```
@log
def _call_llm_galileo(messages: list[dict]) -> str:
    client = OpenAI()
    response = client.chat.completions.create(model="gpt-4o", messages=messages)
    return response.choices[0].message.content

messages = [{"role": "user", "content": "Hey bot"}]

# This one works fine
c = _call_llm_galileo(messages)
print("run 1", c)


# # This one does not -- even with 1 single input (works fine without the log though)
inputs = [{"messages": messages} for _ in range(2)]
with ThreadPoolExecutor(max_workers=1) as executor:
    futures = [
        executor.submit(_call_llm_galileo, **input_) for input_ in inputs
    ]

    contents = []
    for future in as_completed(futures):
        c = future.result()
        contents.append(c)
print("run 2", contents)

```

> Note: to understand the change I recommend to enable DEBUG logs (for galileo):


```
LOGGING_CONFIG = {
    "version": 1,
    "handlers": {
        "default": {
            "class": "logging.StreamHandler",
            "formatter": "http",
            "stream": "ext://sys.stderr"
        }
    },
    "formatters": {
        "http": {
            "format": "%(levelname)s [%(asctime)s] %(name)s - %(message)s",
            "datefmt": "%Y-%m-%d %H:%M:%S",
        }
    },
    'loggers': {
        'httpx': {
            'handlers': ['default'],
            'level': 'DEBUG',
        },
        'galileo': {
            'handlers': ['default'],
            'level': 'DEBUG',
        },
        'httpcore': {
            'handlers': ['default'],
            'level': 'INFO',
        },
    }
}
logging.config.dictConfig(LOGGING_CONFIG
```

