### PR TITLE
fix: Set correct openai status code for successful run

### DIFF
--- a/src/galileo/openai.py
+++ b/src/galileo/openai.py
@@ -486,6 +486,9 @@ def _wrap(
                 num_output_tokens=usage.get("completion_tokens", 0),
                 total_tokens=usage.get("total_tokens", 0),
                 metadata={str(k): str(v) for k, v in input_data.model_parameters.items()},
+                # openai client library doesn't return http_status code, so we only can hardcode it here
+                # because we if we parsed and extracted data from response it means we get it and it's 200OK
+                status_code=200,
             )
 
             # Conclude the trace if this is the top-level call
@@ -585,6 +588,7 @@ class ResponseGeneratorSync:
             num_output_tokens=usage.get("completion_tokens", 0),
             total_tokens=usage.get("total_tokens", 0),
             metadata={str(k): str(v) for k, v in self.input_data.model_parameters.items()},
+            status_code=200,
         )
 
         # Conclude the trace if this is the top-level call

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -57,6 +57,7 @@ def test_basic_openai_call(
     assert len(payload.traces) == 1
     assert len(payload.traces[0].spans) == 1
     assert isinstance(payload.traces[0].spans[0], LlmSpan)
+    assert payload.traces[0].spans[0].status_code == 200
     assert payload.traces[0].input == '[{"role": "user", "content": "Say this is a test"}]'
     assert payload.traces[0].spans[0].input == [Message(content="Say this is a test", role=MessageRole.user)]
     assert payload.traces[0].spans[0].output == Message(content="The mock is working! ;)", role=MessageRole.assistant)
@@ -110,6 +111,7 @@ def test_streamed_openai_call(
     assert isinstance(payload.traces[0].spans[0], LlmSpan)
     assert payload.traces[0].input == '[{"role": "user", "content": "Say this is a test"}]'
     assert payload.traces[0].output == "Hello"
+    assert payload.traces[0].spans[0].status_code == 200
     assert payload.traces[0].spans[0].input == [Message(content="Say this is a test", role=MessageRole.user)]
     assert payload.traces[0].spans[0].output == Message(content="Hello", role=MessageRole.assistant)
 
@@ -156,6 +158,7 @@ def test_openai_api_calls_as_parent_span(
 
     assert len(payload.traces[0].spans[0].spans) == 1
     assert isinstance(payload.traces[0].spans[0].spans[0], LlmSpan)
+    assert payload.traces[0].spans[0].status_code == 200
     assert payload.traces[0].spans[0].spans[0].input == [Message(content="Say this is a test", role=MessageRole.user)]
     assert payload.traces[0].spans[0].spans[0].output == Message(
         content="The mock is working! ;)", role=MessageRole.assistant

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -158,7 +158,7 @@ def test_openai_api_calls_as_parent_span(
 
     assert len(payload.traces[0].spans[0].spans) == 1
     assert isinstance(payload.traces[0].spans[0].spans[0], LlmSpan)
-    assert payload.traces[0].spans[0].status_code == 200
+    assert payload.traces[0].spans[0].spans[0].status_code == 200
     assert payload.traces[0].spans[0].spans[0].input == [Message(content="Say this is a test", role=MessageRole.user)]
     assert payload.traces[0].spans[0].spans[0].output == Message(
         content="The mock is working! ;)", role=MessageRole.assistant


### PR DESCRIPTION
resolves https://app.shortcut.com/galileo/story/26598/qa2-0-logstreams-metrics-status-code-is-0-instead-of-200-for-successful-run