### PR TITLE
fix: improve error handling and print better error when create prompt template fails

### DIFF
--- a/src/galileo/prompts.py
+++ b/src/galileo/prompts.py
@@ -15,8 +15,13 @@ from galileo.resources.models import (
     HTTPValidationError,
     Message,
 )
+from galileo.utils.exceptions import APIException
 
 _logger = logging.getLogger(__name__)
+
+
+class PromptTemplateAPIException(APIException):
+    pass
 
 
 class PromptTemplate(BasePromptTemplateResponse):
@@ -97,9 +102,12 @@ class PromptTemplates(BaseClientModel):
             body=body,
         )
 
+        if response.status_code != 200:
+            raise PromptTemplateAPIException(response.content)
+
         if not response.parsed or isinstance(response.parsed, HTTPValidationError):
             _logger.error(response)
-            raise response
+            raise PromptTemplateAPIException(response.content)
 
         return PromptTemplate(prompt_template=response.parsed)
 

--- a/src/galileo/utils/exceptions.py
+++ b/src/galileo/utils/exceptions.py
@@ -1,0 +1,15 @@
+import json
+
+
+class APIException(Exception):
+    """
+    APIException is base exception for all API errors. It tries to parse content.detail
+    and put it to message.
+    """
+
+    def __init__(self, message):
+        try:
+            self.message = json.loads(message)["detail"]
+        except (KeyError, TypeError, ValueError):
+            self.message = message
+        super().__init__(self.message)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,97 @@
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+import pytest
+
+from galileo.prompts import PromptTemplateAPIException, create_prompt_template
+from galileo.resources.models import BasePromptTemplateResponse, Message, MessageRole, ProjectDB
+from galileo.resources.types import Response
+
+
+def project():
+    return [
+        ProjectDB.from_dict(
+            {
+                "created_by_user": {"id": "01ce18ac-3960-46e1-bb79-0e4965069add"},
+                "created_at": "2025-03-03T21:17:44.232862+00:00",
+                "created_by": "01ce18ac-3960-46e1-bb79-0e4965069add",
+                "id": "e343ea54-4df3-4d0b-9bc5-7e8224be348f",
+                "runs": [],
+                "updated_at": "2025-03-03T21:17:44.232864+00:00",
+                "bookmark": False,
+                "name": "andrii-new-project",
+                "permissions": [],
+                "type": "gen_ai",
+            }
+        )
+    ]
+
+
+def prompt_template():
+    return BasePromptTemplateResponse.from_dict(
+        {
+            "all_available_versions": [0],
+            "id": "4793f4b9-eb56-4495-88a9-8cf57bfe737b",
+            "max_version": 0,
+            "name": "andrii-good-prompt",
+            "selected_version": {
+                "id": "03487fd7-1032-4317-ac43-a68401c07ee9",
+                "template": '[{"content":"you are a helpful assistant","role":"system"},{"content":"why is sky blue?","role":"user"}]',
+                "version": 0,
+            },
+            "selected_version_id": "03487fd7-1032-4317-ac43-a68401c07ee9",
+            "template": '[{"content":"you are a helpful assistant","role":"system"},{"content":"why is sky blue?","role":"user"}]',
+            "total_versions": 1,
+            "all_versions": [
+                {
+                    "id": "03487fd7-1032-4317-ac43-a68401c07ee9",
+                    "template": '[{"content":"you are a helpful assistant","role":"system"},{"content":"why is sky blue?","role":"user"}]',
+                    "version": 0,
+                }
+            ],
+        }
+    )
+
+
+@patch("galileo.projects.get_projects_projects_get")
+@patch("galileo.prompts.create_prompt_template_with_version_projects_project_id_templates_post")
+def test_create_prompt(create_prompt_template_mock: Mock, get_projects_projects_get_mock: Mock):
+    create_prompt_template_mock.sync_detailed.return_value = Response(
+        content=b"", status_code=HTTPStatus.OK, headers={}, parsed=prompt_template()
+    )
+    get_projects_projects_get_mock.sync.return_value = project()
+    tmpl = create_prompt_template(
+        name="andrii-good-prompt",
+        project="andrii-new-project",
+        messages=[
+            Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"),
+            Message(role=MessageRole.USER, content="why is sky blue?"),
+        ],
+    )
+
+    assert tmpl.name == "andrii-good-prompt"
+    create_prompt_template_mock.sync_detailed.assert_called_once()
+    get_projects_projects_get_mock.sync.assert_called_once()
+
+
+@patch("galileo.projects.get_projects_projects_get")
+@patch("galileo.prompts.create_prompt_template_with_version_projects_project_id_templates_post")
+def test_create_prompt_bad_request(create_prompt_template_mock: Mock, get_projects_projects_get_mock: Mock):
+    create_prompt_template_mock.sync_detailed.return_value = Response(
+        content=b'{"detail":"Prompt template with name storyteller-prompt already exists (ID 3e3d48fa-0aae-433c-be2c-b3f7fb53c9e2)."}',
+        status_code=HTTPStatus.BAD_REQUEST,
+        headers={},
+        parsed=None,
+    )
+    get_projects_projects_get_mock.sync.return_value = project()
+    with pytest.raises(PromptTemplateAPIException):
+        create_prompt_template(
+            name="andrii-good-prompt",
+            project="andrii-new-project",
+            messages=[
+                Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"),
+                Message(role=MessageRole.USER, content="why is sky blue?"),
+            ],
+        )
+    create_prompt_template_mock.sync_detailed.assert_called_once()
+    get_projects_projects_get_mock.sync.assert_called_once()


### PR DESCRIPTION
This PR fixes https://app.shortcut.com/galileo/story/26778/typeerror-exceptions-must-derive-from-baseexception-in-python-client


How to test:
run create_prompt_template 2 times
```
tmpl = create_prompt_template(
    name="andrii-good-prompt1111",
    project="andrii-new-project",
    messages=[Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"), Message(role=MessageRole.USER, content="why is sky blue?")]
)


tmpl = create_prompt_template(
    name="andrii-good-prompt1111",
    project="andrii-new-project",
    messages=[Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"), Message(role=MessageRole.USER, content="why is sky blue?")]
)


```

output:
```
python /Users/andrii/work/rungalileo/galileo-python/downloads/promt_template.py 
Traceback (most recent call last):
  File "/Users/andrii/work/rungalileo/galileo-python/downloads/promt_template.py", line 15, in <module>
    tmpl = create_prompt_template(
  File "/Users/andrii/work/rungalileo/galileo-python/src/galileo/prompts.py", line 116, in create_prompt_template
    return PromptTemplates().create(name=name, project_name=project, template=messages)
  File "/Users/andrii/work/rungalileo/galileo-python/src/galileo/prompts.py", line 106, in create
    raise PromptTemplateAPIException(response.content)
galileo.prompts.PromptTemplateAPIException: Prompt template with name andrii-good-prompt1111 already exists (ID 4793f4b9-eb56-4495-88a9-8cf57bfe737b).

Process finished with exit code 1

```