### PR TITLE
fix: Ierror handling in Experiments.get

### DIFF
--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -53,7 +53,7 @@ class Experiments(BaseClientModel):
         return experiment
 
     def get(self, project_id: str, experiment_name: str) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
-        experiments = self.list(project_id=project_id)
+        experiments = self.list(project_id=project_id) or []
 
         for experiment in experiments:
             if experiment.name == experiment_name:

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -170,6 +170,13 @@ class TestExperiments:
         assert experiments[0].name == experiment_response().name
         list_experiments_mock.sync.assert_called_once_with(project_id=str(UUID(int=0)), client=ANY)
 
+    @patch("galileo.experiments.list_experiments_v2_projects_project_id_experiments_get")
+    def test_get_experiment_not_found(self, list_experiments_mock: Mock):
+        list_experiments_mock.sync = Mock(return_value=None)
+        experiment = get_experiment(experiment_name=experiment_response().name, project_id=str(UUID(int=0)))
+        assert experiment is None
+        list_experiments_mock.sync.assert_called_once_with(project_id=str(UUID(int=0)), client=ANY)
+
     @patch.object(galileo.datasets.Datasets, "get")
     def test_get_dataset_and_records_by_id(self, mock_get_dataset):
         mock_get_dataset_instance = mock_get_dataset.return_value


### PR DESCRIPTION
This PR improves error handling of:
```
results = run_experiment(
	"travel-experiment",
	dataset=get_dataset(name="travel-durations"),
	prompt_template=prompt_template,
	prompt_settings={
		"model_alias": "GPT-4o",
	},
    project=project_name,
	metrics=["Sentence Density"],
)
```

and Experiments.get api returns None:

```
Traceback (most recent call last):
  File "/Users/pawandeshpande/dev/sdk-demo-streamlit/experiment.py", line 52, in <module>
    results = run_experiment(
              ^^^^^^^^^^^^^^^
  File "/Users/pawandeshpande/dev/sdk-demo-streamlit/env/lib/python3.12/site-packages/galileo/experiments.py", line 235, in run_experiment
    experiment_obj = Experiments().get_or_create(project_obj.id, experiment_name)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pawandeshpande/dev/sdk-demo-streamlit/env/lib/python3.12/site-packages/galileo/experiments.py", line 64, in get_or_create
    experiment = self.get(project_id, experiment_name)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pawandeshpande/dev/sdk-demo-streamlit/env/lib/python3.12/site-packages/galileo/experiments.py", line 57, in get
    for experiment in experiments:
                      ^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```