### PR TITLE
fix: made on_tool_end recognize the tool output without the langchain metadata

### DIFF
--- a/src/galileo/handlers/langchain.py
+++ b/src/galileo/handlers/langchain.py
@@ -428,7 +428,7 @@ class GalileoCallback(BaseCallbackHandler):
 
     def on_tool_end(self, output: str, *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any) -> Any:
         """Langchain callback when a tool node ends."""
-        self._end_node(run_id, output=serialize_to_str(output))
+        self._end_node(run_id, output=serialize_to_str(output.content))
 
     def on_retriever_start(
         self, query: str, *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any


### PR DESCRIPTION
Previously Galileo's tool output would include LangChain metadata as well:

![image](https://github.com/user-attachments/assets/2903c603-e366-425e-868b-a37be500f633)

> Only `content` should be included, as that is what the tool returned. The rest of the fields were added by LangChain

This change makes the output correctly just `output_of_my_tool`. This is important because tool outputs are used to compute some metrics such as correctness, where having extra data could negatively impact performance.