### PR TITLE
chore: Enum name normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,14 +251,14 @@ Run an experiment with a prompt template:
 from galileo.datasets import get_dataset
 from galileo.experiments import run_experiment
 from galileo.prompts import create_prompt_template
-from galileo.resources.models import MessageRole, Message
+from galileo_core.schemas.logging.llm import Message, MessageRole
 
 prompt = create_prompt_template(
     name="my-prompt",
     project="new-project",
     messages=[
-        Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"),
-        Message(role=MessageRole.USER, content="why is sky blue?")
+        Message(role=MessageRole.system, content="you are a helpful assistant"),
+        Message(role=MessageRole.user, content="why is sky blue?")
     ]
 )
 

--- a/src/galileo/prompts.py
+++ b/src/galileo/prompts.py
@@ -13,9 +13,9 @@ from galileo.resources.models import (
     BasePromptTemplateResponse,
     CreatePromptTemplateWithVersionRequestBody,
     HTTPValidationError,
-    Message,
 )
 from galileo.utils.exceptions import APIException
+from galileo_core.schemas.logging.llm import Message
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,8 +5,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from galileo.prompts import PromptTemplateAPIException, create_prompt_template
-from galileo.resources.models import BasePromptTemplateResponse, Message, MessageRole, ProjectDB
+from galileo.resources.models import BasePromptTemplateResponse, ProjectDB
 from galileo.resources.types import Response
+from galileo_core.schemas.logging.llm import Message, MessageRole
 
 
 def projects_response():
@@ -69,8 +70,8 @@ def test_create_prompt(create_prompt_template_mock: Mock, get_projects_projects_
         name="andrii-good-prompt",
         project="andrii-new-project",
         messages=[
-            Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"),
-            Message(role=MessageRole.USER, content="why is sky blue?"),
+            Message(role=MessageRole.system, content="you are a helpful assistant"),
+            Message(role=MessageRole.user, content="why is sky blue?"),
         ],
     )
 
@@ -94,8 +95,8 @@ def test_create_prompt_bad_request(create_prompt_template_mock: Mock, get_projec
             name="andrii-good-prompt",
             project="andrii-new-project",
             messages=[
-                Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"),
-                Message(role=MessageRole.USER, content="why is sky blue?"),
+                Message(role=MessageRole.system, content="you are a helpful assistant"),
+                Message(role=MessageRole.user, content="why is sky blue?"),
             ],
         )
     create_prompt_template_mock.sync_detailed.assert_called_once()


### PR DESCRIPTION
### Summary

[Shortcut #27505: Standardize the message role enum](https://app.shortcut.com/galileo/story/27505/g2-0-python-sdk-standardize-the-messagerole-models)

### Details

Searching [github](https://github.com/search?q=org%3Arungalileo+%2F%28%3F-i%29MessageRole%5C.%2F&type=code) for `MessageRole` enum indicates that all repositories apart from this use lower casing for this enum. So, we are going to lower case this enum and its usages to be consistent across the board.