### PR TITLE
feat: add dataset version methods

### DIFF
--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -14,7 +14,7 @@ from galileo.resources.api.datasets import (
     update_dataset_content_datasets_dataset_id_content_patch,
     upload_dataset_datasets_post,
 )
-from galileo.resources.models import ListDatasetVersionParams
+from galileo.resources.models import ListDatasetVersionParams, ListDatasetVersionResponse
 from galileo.resources.models.body_upload_dataset_datasets_post import BodyUploadDatasetDatasetsPost
 from galileo.resources.models.dataset_content import DatasetContent
 from galileo.resources.models.dataset_db import DatasetDB
@@ -392,7 +392,27 @@ def create_dataset(name: str, content: DatasetType) -> Dataset:
     return Datasets().create(name=name, content=content)
 
 
-def get_dataset_version_history(dataset_name: str = None, dataset_id: str = None):
+def get_dataset_version_history(
+    dataset_name: str = None, dataset_id: str = None
+) -> Optional[Union[HTTPValidationError, ListDatasetVersionResponse]]:
+    """
+    Retrieves a dataset version history by dataset name or dataset id.
+
+    Parameters
+    ----------
+    dataset_name: str
+        The name of the dataset.
+    dataset_id: str
+        The id of the dataset.
+
+    Returns
+    -------
+    ListDatasetVersionResponse
+
+    Raises
+    ------
+    HTTPValidationError
+    """
     if dataset_name is None and dataset_id is None:
         raise ValueError("Either dataset_name or dataset_id must be provided.")
 
@@ -405,7 +425,27 @@ def get_dataset_version_history(dataset_name: str = None, dataset_id: str = None
         return dataset.get_version_history()
 
 
-def get_dataset_version(version_index: int, dataset_name: str = None, dataset_id: str = None) -> DatasetContent:
+def get_dataset_version(
+    version_index: int, dataset_name: str = None, dataset_id: str = None
+) -> Optional[DatasetContent]:
+    """
+    Retrieves a dataset version by dataset name or dataset id.
+
+    Parameters
+    ----------
+    version_index : int
+        The version of the dataset.
+
+    dataset_name: Optional[str]
+        The name of the dataset.
+
+    dataset_id: Optional[str]
+        The id of the dataset.
+
+    Returns
+    -------
+    DatasetContent
+    """
     if dataset_name is None and dataset_id is None:
         raise ValueError("Either dataset_name or dataset_id must be provided.")
 

--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -7,11 +7,12 @@ from galileo.resources.api.datasets import (
     delete_dataset_datasets_dataset_id_delete,
     get_dataset_content_datasets_dataset_id_content_get,
     get_dataset_datasets_dataset_id_get,
+    get_dataset_version_content_datasets_dataset_id_versions_version_index_content_get,
     list_datasets_datasets_get,
+    query_dataset_versions_datasets_dataset_id_versions_query_post,
     query_datasets_datasets_query_post,
     update_dataset_content_datasets_dataset_id_content_patch,
-    upload_dataset_datasets_post, query_dataset_versions_datasets_dataset_id_versions_query_post,
-    get_dataset_version_content_datasets_dataset_id_versions_version_index_content_get,
+    upload_dataset_datasets_post,
 )
 from galileo.resources.models import ListDatasetVersionParams
 from galileo.resources.models.body_upload_dataset_datasets_post import BodyUploadDatasetDatasetsPost
@@ -105,16 +106,14 @@ class Dataset(BaseClientModel, DecorateAllMethods):
 
     def get_version_history(self):
         list_dataset = query_dataset_versions_datasets_dataset_id_versions_query_post.sync(
-            dataset_id=self.dataset.id, client=self.client, body=ListDatasetVersionParams(),
+            dataset_id=self.dataset.id, client=self.client, body=ListDatasetVersionParams()
         )
         return list_dataset
-
 
     def load_version(self, version_index: int) -> DatasetContent:
         return get_dataset_version_content_datasets_dataset_id_versions_version_index_content_get.sync(
             dataset_id=self.dataset.id, version_index=version_index, client=self.client
         )
-
 
     def __getattr__(self, attr):
         """
@@ -285,7 +284,6 @@ class Datasets(BaseClientModel):
         return Dataset(dataset_db=response, client=self.client)
 
 
-
 #
 # Convenience methods
 #
@@ -407,7 +405,7 @@ def get_dataset_version_history(dataset_name: str = None, dataset_id: str = None
         return dataset.get_version_history()
 
 
-def get_dataset_version(version_index: int, dataset_name: str = None, dataset_id: str = None,) -> DatasetContent:
+def get_dataset_version(version_index: int, dataset_name: str = None, dataset_id: str = None) -> DatasetContent:
     if dataset_name is None and dataset_id is None:
         raise ValueError("Either dataset_name or dataset_id must be provided.")
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,18 +1,122 @@
-from unittest.mock import patch, Mock
+from unittest.mock import ANY, Mock, patch
+
+import pytest
 
 from galileo.datasets import get_dataset_version
-from galileo.resources.models import DatasetDB
+from galileo.resources.models import (
+    DatasetContent,
+    DatasetDB,
+    DatasetNameFilter,
+    DatasetNameFilterOperator,
+    DatasetRow,
+    DatasetUpdatedAtSort,
+    ListDatasetParams,
+    ListDatasetResponse,
+)
 
 
-def dataset_response():
-    return DatasetDB(
+def dataset_content():
+    row = DatasetRow(index=0, values=["Which continent is Spain in?", "Europe"])
+    row.additional_properties = {"values_dict": {"input": "Which continent is Spain in?", "expected": "Europe"}}
 
+    column_names = ["input", "expected"]
+    return DatasetContent(column_names=column_names, rows=[row])
+
+
+def dataset_db():
+    return DatasetDB.from_dict(
+        {
+            "draft": False,
+            "column_names": ["input", "output", "metadata"],
+            "created_at": "2025-03-10T15:25:03.088471+00:00",
+            "created_by_user": {
+                "email": "andriisoldatenko@galileo.ai",
+                "id": "01ce18ac-3960-46e1-bb79-0e4965069add",
+                "first_name": "",
+                "last_name": "",
+            },
+            "current_version_index": 2,
+            "id": "78e8035d-c429-47f2-8971-68f10e7e91c9",
+            "name": "storyteller-dataset",
+            "num_rows": 2,
+            "project_count": 2,
+            "updated_at": "2025-03-26T12:00:44.558105+00:00",
+            "permissions": [],
+        }
     )
 
 
-@patch("galileo.datasets.get_dataset_datasets_dataset_id_get")
-def test_get_dataset_version(get_dataset_datasets_dataset_id_get: Mock):
-    get_dataset_datasets_dataset_id_get.sync = Mock(return_value=dataset_response())
-    ds_version = get_dataset_version(1, dataset_name="test")
-    assert ds_version == ""
+def dataset_response():
+    return ListDatasetResponse.from_dict(
+        {
+            "datasets": [
+                {
+                    "draft": False,
+                    "column_names": ["input", "output", "metadata"],
+                    "created_at": "2025-03-10T15:25:03.088471+00:00",
+                    "created_by_user": {
+                        "email": "andriisoldatenko@galileo.ai",
+                        "id": "01ce18ac-3960-46e1-bb79-0e4965069add",
+                        "first_name": "",
+                        "last_name": "",
+                    },
+                    "current_version_index": 2,
+                    "id": "78e8035d-c429-47f2-8971-68f10e7e91c9",
+                    "name": "storyteller-dataset",
+                    "num_rows": 2,
+                    "project_count": 2,
+                    "updated_at": "2025-03-26T12:00:44.558105+00:00",
+                    "permissions": [],
+                }
+            ],
+            "limit": 1,
+            "next_starting_token": 1,
+            "paginated": True,
+            "starting_token": 0,
+        }
+    )
 
+
+@patch("galileo.datasets.get_dataset_version_content_datasets_dataset_id_versions_version_index_content_get")
+@patch("galileo.datasets.get_dataset_datasets_dataset_id_get")
+def test_get_dataset_version_using_dataset_id(
+    get_dataset_datasets_dataset_id_get: Mock, get_dataset_version_mock: Mock
+):
+    get_dataset_datasets_dataset_id_get.sync.return_value = dataset_db()
+    get_dataset_version_mock.sync.return_value = dataset_content()
+
+    result = get_dataset_version(1, dataset_id="78e8035d-c429-47f2-8971-68f10e7e91c9")
+    assert result == dataset_content()
+
+    get_dataset_datasets_dataset_id_get.sync.assert_called_once_with(
+        client=ANY, dataset_id="78e8035d-c429-47f2-8971-68f10e7e91c9"
+    )
+    get_dataset_version_mock.sync.assert_called_once_with(
+        client=ANY, version_index=1, dataset_id="78e8035d-c429-47f2-8971-68f10e7e91c9"
+    )
+
+
+@patch("galileo.datasets.get_dataset_version_content_datasets_dataset_id_versions_version_index_content_get")
+@patch("galileo.datasets.query_datasets_datasets_query_post")
+def test_get_dataset_version_using_dataset_name(
+    query_datasets_datasets_query_post: Mock, get_dataset_version_mock: Mock
+):
+    query_datasets_datasets_query_post.sync.return_value = dataset_response()
+    get_dataset_version_mock.sync.return_value = dataset_content()
+
+    result = get_dataset_version(1, dataset_name="test")
+    assert result == dataset_content()
+
+    ds_name_filter = DatasetNameFilter(operator=DatasetNameFilterOperator.EQ, value="test")
+    body = ListDatasetParams(filters=[ds_name_filter], sort=DatasetUpdatedAtSort(ascending=False))
+    query_datasets_datasets_query_post.sync.assert_called_once_with(client=ANY, body=body, limit=1)
+    # load dataset always by dataset_id
+    get_dataset_version_mock.sync.assert_called_once_with(
+        client=ANY, version_index=1, dataset_id="78e8035d-c429-47f2-8971-68f10e7e91c9"
+    )
+
+
+def test_get_dataset_version_wo_dataset_name_or_dataset_id():
+    with pytest.raises(ValueError) as exc_info:
+        get_dataset_version(version_index=1)
+    assert "Either dataset_name or dataset_id must be provided." in str(exc_info.value), str(exc_info)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch, Mock
+
+from galileo.datasets import get_dataset_version
+from galileo.resources.models import DatasetDB
+
+
+def dataset_response():
+    return DatasetDB(
+
+    )
+
+
+@patch("galileo.datasets.get_dataset_datasets_dataset_id_get")
+def test_get_dataset_version(get_dataset_datasets_dataset_id_get: Mock):
+    get_dataset_datasets_dataset_id_get.sync = Mock(return_value=dataset_response())
+    ds_version = get_dataset_version(1, dataset_name="test")
+    assert ds_version == ""
+

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,7 +2,7 @@ from unittest.mock import ANY, Mock, patch
 
 import pytest
 
-from galileo.datasets import get_dataset_version
+from galileo.datasets import get_dataset_version, get_dataset_version_history
 from galileo.resources.models import (
     DatasetContent,
     DatasetDB,
@@ -12,6 +12,8 @@ from galileo.resources.models import (
     DatasetUpdatedAtSort,
     ListDatasetParams,
     ListDatasetResponse,
+    ListDatasetVersionParams,
+    ListDatasetVersionResponse,
 )
 
 
@@ -77,6 +79,52 @@ def dataset_response():
     )
 
 
+def list_dataset_versions():
+    return ListDatasetVersionResponse.from_dict(
+        {
+            "versions": [
+                {
+                    "column_names": ["input", "output", "metadata"],
+                    "columns_added": 2,
+                    "columns_removed": 1,
+                    "columns_renamed": 0,
+                    "created_at": "2025-03-26T12:00:44.553576+00:00",
+                    "created_by_user": None,
+                    "name": "JSON column migration",
+                    "num_rows": 2,
+                    "rows_added": 0,
+                    "rows_edited": 2,
+                    "rows_removed": 0,
+                    "version_index": 2,
+                },
+                {
+                    "column_names": ["input", "expected"],
+                    "columns_added": 2,
+                    "columns_removed": 0,
+                    "columns_renamed": 0,
+                    "created_at": "2025-03-10T15:25:03.582730+00:00",
+                    "created_by_user": {
+                        "email": "andriisoldatenko@galileo.ai",
+                        "id": "01ce18ac-3960-46e1-bb79-0e4965069add",
+                        "first_name": "",
+                        "last_name": "",
+                    },
+                    "name": None,
+                    "num_rows": 2,
+                    "rows_added": 2,
+                    "rows_edited": 0,
+                    "rows_removed": 0,
+                    "version_index": 1,
+                },
+            ],
+            "limit": 100,
+            "next_starting_token": None,
+            "paginated": False,
+            "starting_token": 0,
+        }
+    )
+
+
 @patch("galileo.datasets.get_dataset_version_content_datasets_dataset_id_versions_version_index_content_get")
 @patch("galileo.datasets.get_dataset_datasets_dataset_id_get")
 def test_get_dataset_version_using_dataset_id(
@@ -119,4 +167,51 @@ def test_get_dataset_version_using_dataset_name(
 def test_get_dataset_version_wo_dataset_name_or_dataset_id():
     with pytest.raises(ValueError) as exc_info:
         get_dataset_version(version_index=1)
+    assert "Either dataset_name or dataset_id must be provided." in str(exc_info.value), str(exc_info)
+
+
+@patch("galileo.datasets.query_dataset_versions_datasets_dataset_id_versions_query_post")
+@patch("galileo.datasets.get_dataset_datasets_dataset_id_get")
+def test_get_dataset_version_history_using_dataset_id(
+    get_dataset_datasets_dataset_id_get: Mock, get_dataset_versions_mock: Mock
+):
+    get_dataset_datasets_dataset_id_get.sync.return_value = dataset_db()
+    get_dataset_versions_mock.sync.return_value = list_dataset_versions()
+
+    ds_history = get_dataset_version_history(dataset_id="78e8035d-c429-47f2-8971-68f10e7e91c9")
+
+    assert ds_history == list_dataset_versions()
+    get_dataset_datasets_dataset_id_get.sync.assert_called_once_with(
+        client=ANY, dataset_id="78e8035d-c429-47f2-8971-68f10e7e91c9"
+    )
+
+    get_dataset_versions_mock.sync.assert_called_once_with(
+        client=ANY, dataset_id="78e8035d-c429-47f2-8971-68f10e7e91c9", body=ListDatasetVersionParams()
+    )
+
+
+@patch("galileo.datasets.query_dataset_versions_datasets_dataset_id_versions_query_post")
+@patch("galileo.datasets.query_datasets_datasets_query_post")
+def test_get_dataset_version_history_using_dataset_name(
+    query_datasets_datasets_query_post: Mock, get_dataset_version_mock: Mock
+):
+    query_datasets_datasets_query_post.sync.return_value = dataset_response()
+    get_dataset_version_mock.sync.return_value = list_dataset_versions()
+
+    ds_history = get_dataset_version_history(dataset_name="test")
+
+    assert ds_history == list_dataset_versions()
+    ds_name_filter = DatasetNameFilter(operator=DatasetNameFilterOperator.EQ, value="test")
+    body = ListDatasetParams(filters=[ds_name_filter], sort=DatasetUpdatedAtSort(ascending=False))
+    query_datasets_datasets_query_post.sync.assert_called_once_with(client=ANY, body=body, limit=1)
+
+    # load dataset always by dataset_id
+    get_dataset_version_mock.sync.assert_called_once_with(
+        client=ANY, dataset_id="78e8035d-c429-47f2-8971-68f10e7e91c9", body=ListDatasetVersionParams()
+    )
+
+
+def test_get_dataset_version_history_wo_dataset_name_or_dataset_id():
+    with pytest.raises(ValueError) as exc_info:
+        get_dataset_version_history()
     assert "Either dataset_name or dataset_id must be provided." in str(exc_info.value), str(exc_info)

--- a/tests/test_openai_agents.py
+++ b/tests/test_openai_agents.py
@@ -57,7 +57,7 @@ triage_agent = Agent(
 os.environ["OPENAI_API_KEY"] = "sk-test"
 
 
-@pytest.skip("flaky test")
+@pytest.mark.skip("flaky test")
 @mark.asyncio
 @vcr.use_cassette(
     "tests/fixtures/openai_agents_complex.yaml",

--- a/tests/test_openai_agents.py
+++ b/tests/test_openai_agents.py
@@ -57,6 +57,7 @@ triage_agent = Agent(
 os.environ["OPENAI_API_KEY"] = "sk-test"
 
 
+@pytest.skip("flaky test")
 @mark.asyncio
 @vcr.use_cassette(
     "tests/fixtures/openai_agents_complex.yaml",


### PR DESCRIPTION
This PR resolves https://app.shortcut.com/galileo/story/26711/g2-0-python-sdk-add-dataset-version-methods

It adds 2 functions:

* `get_dataset_version_history(dataset_name=None, dataset_id=None)` returns a list of `DatasetVersion` (after calling `/datasets/{dataset_id}/versions/query` api ;
* `get_dataset_version(dataset_name=None, dataset_id=None, version_index)` - returns and loads if calling from the `Dataset` object the DatasetContent for the specific version (after calling `/datasets/{dataset_id}/versions/{version_index}/content` api.