### PR TITLE
feat: improve error handling for create_dataset

### DIFF
--- a/src/galileo/resources/models/http_validation_error.py
+++ b/src/galileo/resources/models/http_validation_error.py
@@ -45,10 +45,12 @@ class HTTPValidationError:
         d = src_dict.copy()
         detail = []
         _detail = d.pop("detail", UNSET)
-        for detail_item_data in _detail or []:
-            detail_item = ValidationError.from_dict(detail_item_data)
 
-            detail.append(detail_item)
+        if isinstance(_detail, list):
+            for detail_item_data in _detail:
+                detail_item = ValidationError.from_dict(detail_item_data)
+
+                detail.append(detail_item)
 
         http_validation_error = cls(detail=detail)
 


### PR DESCRIPTION
### Description 

this PR resolves https://app.shortcut.com/galileo/story/27771/python-sdk-expected-dataset-dictionary-format-not-transparent


### How to test?

```
test_data = [{}]
# Create the dataset_
print("Creating dataset")
dataset = create_dataset(
   name = "my_dataset_name",
   content=test_data,
)

```

it gives your nice exception:

```
Creating dataset
INFO [2025-04-08 21:22:11] httpx - HTTP Request: POST https://api-galileo-v2-staging.gcp-dev.galileo.ai/datasets?format=csv "HTTP/1.1 422 unknown"
Traceback (most recent call last):
  File "/Users/andriisoldatenko/work/rungalileo/galileo-python/downloads/dataset_examples.py", line 56, in <module>
    dataset = create_dataset(
  File "/Users/andriisoldatenko/work/rungalileo/galileo-python/src/galileo/datasets.py", line 396, in create_dataset
    return Datasets().create(name=name, content=content)
  File "/Users/andriisoldatenko/work/rungalileo/galileo-python/src/galileo/datasets.py", line 286, in create
    raise DatasetAPIException(detailed_response.content)
galileo.datasets.DatasetAPIException: Invalid CSV data: CSV parse error: Empty CSV file or block: cannot infer number of columns

Process finished with exit code 1
```