### PR TITLE
feat: error if a non existent metric is specified

### DIFF
--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -86,7 +86,10 @@ class Experiments(BaseClientModel):
                 unknown_metrics.append(metric)
 
         if unknown_metrics:
-            raise ValueError(f"One or more non-existent metrics are specified: `{' '.join(unknown_metrics)}`")
+            raise ValueError(
+                "One or more non-existent metrics are specified:"
+                + ", ".join(f"'{metric}'" for metric in unknown_metrics)
+            )
 
         ScorerSettings().create(project_id=project_id, run_id=experiment_id, scorers=scorers)
         return scorers

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -83,6 +83,9 @@ class Experiments(BaseClientModel):
                     scorers.append(ScorerConfig.from_dict(scorer.to_dict()))
                     break
 
+        if not scorers:
+            raise ValueError(f"Non-existent metric is specified `{' '.join(metrics)}`")
+
         ScorerSettings().create(project_id=project_id, run_id=experiment_id, scorers=scorers)
         return scorers
 

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -77,14 +77,16 @@ class Experiments(BaseClientModel):
     ) -> builtins.list[ScorerConfig]:
         scorers = []
         all_scorers = Scorers().list()
+        known_metrics = {metric.name: metric for metric in all_scorers}
+        unknown_metrics = []
         for metric in metrics:
-            for scorer in all_scorers:
-                if metric == scorer.name:
-                    scorers.append(ScorerConfig.from_dict(scorer.to_dict()))
-                    break
+            if metric in known_metrics:
+                scorers.append(ScorerConfig.from_dict(known_metrics[metric].to_dict()))
+            else:
+                unknown_metrics.append(metric)
 
-        if not scorers:
-            raise ValueError(f"Non-existent metric is specified `{' '.join(metrics)}`")
+        if unknown_metrics:
+            raise ValueError(f"One or more non-existent metrics are specified: `{' '.join(unknown_metrics)}`")
 
         ScorerSettings().create(project_id=project_id, run_id=experiment_id, scorers=scorers)
         return scorers

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -481,11 +481,11 @@ class TestExperiments:
             Experiments.create_run_scorer_settings(
                 project_id="00000000", experiment_id="asd", metrics=["Non-ExistentMetric"]
             )
-        assert str(exc_info.value) == "One or more non-existent metrics are specified: `Non-ExistentMetric`"
+        assert str(exc_info.value) == "One or more non-existent metrics are specified:'Non-ExistentMetric'"
         scorer_list.assert_called_once()
 
     @patch("galileo.experiments.Scorers.list")
-    def test_create_run_scorer_settings_one_valid_one_non_existent_metric(self, scorer_list: Mock):
+    def test_create_run_scorer_settings_one_valid_two_non_existent_metric(self, scorer_list: Mock):
         scorer_list.return_value = [
             ScorerResponse.from_dict(
                 {
@@ -506,7 +506,12 @@ class TestExperiments:
         ]
         with pytest.raises(ValueError) as exc_info:
             Experiments.create_run_scorer_settings(
-                project_id="00000000", experiment_id="asd", metrics=["agentic_workflow_success", "Non-ExistentMetric"]
+                project_id="00000000",
+                experiment_id="asd",
+                metrics=["unknown_metric1", "agentic_workflow_success", "Non-ExistentMetric"],
             )
-        assert str(exc_info.value) == "One or more non-existent metrics are specified: `Non-ExistentMetric`"
+        assert (
+            str(exc_info.value)
+            == "One or more non-existent metrics are specified:'unknown_metric1', 'Non-ExistentMetric'"
+        )
         scorer_list.assert_called_once()

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -481,5 +481,32 @@ class TestExperiments:
             Experiments.create_run_scorer_settings(
                 project_id="00000000", experiment_id="asd", metrics=["Non-ExistentMetric"]
             )
-        assert str(exc_info.value) == "Non-existent metric is specified `Non-ExistentMetric`"
+        assert str(exc_info.value) == "One or more non-existent metrics are specified: `Non-ExistentMetric`"
+        scorer_list.assert_called_once()
+
+    @patch("galileo.experiments.Scorers.list")
+    def test_create_run_scorer_settings_one_valid_one_non_existent_metric(self, scorer_list: Mock):
+        scorer_list.return_value = [
+            ScorerResponse.from_dict(
+                {
+                    "created_at": "2025-03-28T18:54:02.848267+00:00",
+                    "created_by": "d351012a-dd92-4d0c-a356-57161b1377cd",
+                    "defaults": {"filters": None, "model_name": "GPT-4o", "num_judges": 5},
+                    "description": "Detects whether the user successfully accomplished or advanced towards their goal.",
+                    "id": "f7933a6d-7a65-4ce3-bfe4-b863109a04ee",
+                    "included_fields": ["model_name", "num_judges", "filters"],
+                    "label": "Action Advancement",
+                    "latest_version": None,
+                    "name": "agentic_workflow_success",
+                    "scorer_type": "preset",
+                    "tags": ["preset", "agents"],
+                    "updated_at": "2025-03-28T18:54:02.848269+00:00",
+                }
+            )
+        ]
+        with pytest.raises(ValueError) as exc_info:
+            Experiments.create_run_scorer_settings(
+                project_id="00000000", experiment_id="asd", metrics=["agentic_workflow_success", "Non-ExistentMetric"]
+            )
+        assert str(exc_info.value) == "One or more non-existent metrics are specified: `Non-ExistentMetric`"
         scorer_list.assert_called_once()

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -456,3 +456,30 @@ class TestExperiments:
             str(exc_info.value)
             == "A dataset record, id, or name of a dataset must be provided when a prompt_template is used"
         )
+
+    @patch("galileo.experiments.Scorers.list")
+    def test_create_run_scorer_settings_non_existent_metric(self, scorer_list: Mock):
+        scorer_list.return_value = [
+            ScorerResponse.from_dict(
+                {
+                    "created_at": "2025-03-28T18:54:02.848267+00:00",
+                    "created_by": "d351012a-dd92-4d0c-a356-57161b1377cd",
+                    "defaults": {"filters": None, "model_name": "GPT-4o", "num_judges": 5},
+                    "description": "Detects whether the user successfully accomplished or advanced towards their goal.",
+                    "id": "f7933a6d-7a65-4ce3-bfe4-b863109a04ee",
+                    "included_fields": ["model_name", "num_judges", "filters"],
+                    "label": "Action Advancement",
+                    "latest_version": None,
+                    "name": "agentic_workflow_success",
+                    "scorer_type": "preset",
+                    "tags": ["preset", "agents"],
+                    "updated_at": "2025-03-28T18:54:02.848269+00:00",
+                }
+            )
+        ]
+        with pytest.raises(ValueError) as exc_info:
+            Experiments.create_run_scorer_settings(
+                project_id="00000000", experiment_id="asd", metrics=["Non-ExistentMetric"]
+            )
+        assert str(exc_info.value) == "Non-existent metric is specified `Non-ExistentMetric`"
+        scorer_list.assert_called_once()


### PR DESCRIPTION
Resolves https://app.shortcut.com/galileo/story/27772/python-sdk-no-error-if-unknown-metrics-specified-in-experiments


## how to test

Run this sample:

```
import logging
import os
from random import choice
from string import ascii_letters

from galileo.datasets import create_dataset
from galileo.experiments import run_experiment
from galileo.projects import create_project
from galileo.prompts import create_prompt_template
from galileo.resources.models import Message, MessageRole


suffix=''.join(choice(ascii_letters) for _ in range(6))
project = f"My first project {suffix}"
create_project(project)
os.environ["GALILEO_PROJECT"] = project

prompt_template = create_prompt_template(
    name=f"storyteller-prompt-{suffix}",
    project=project,
    messages=[
        Message(role=MessageRole.SYSTEM, content="You are a great storyteller."),
        Message(role=MessageRole.USER, content="Write a story about {input}")
    ]
)


dataset = create_dataset(
    name=f"story-topics-{suffix}",
    content= [{"input": "Cryptography"}, {"input": "Middle earth"}],
)

results = run_experiment(
	"travel-experiment",
	dataset=dataset,
	prompt_template=prompt_template,
	prompt_settings={
		"model_alias": "GPT-4o",
	},
    project=project,
	metrics=["Sentence Density"],
)
```

and you'll get:

```
Traceback (most recent call last):
  File "/Users/andriisoldatenko/work/rungalileo/galileo-python/downloads/run_experiment3.py", line 40, in <module>
    results = run_experiment(
  File "/Users/andriisoldatenko/work/rungalileo/galileo-python/src/galileo/experiments.py", line 256, in run_experiment
    scorer_settings = Experiments.create_run_scorer_settings(project_obj.id, experiment_obj.id, metrics)
  File "/Users/andriisoldatenko/work/rungalileo/galileo-python/src/galileo/experiments.py", line 87, in create_run_scorer_settings
    raise ValueError(f"Non-existent metric is specified `{' '.join(metrics)}`")
ValueError: Non-existent metric is specified `Sentence Density`

Process finished with exit code 1
```