### PR TITLE
fix: Use `Message` and `MessageRole` models from `galileo-core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,17 +248,17 @@ datasets = list_datasets()
 Run an experiment with a prompt template:
 
 ```python
+from galileo import Message, MessageRole
 from galileo.datasets import get_dataset
 from galileo.experiments import run_experiment
 from galileo.prompts import create_prompt_template
-from galileo.resources.models import MessageRole, Message
 
 prompt = create_prompt_template(
     name="my-prompt",
     project="new-project",
     messages=[
-        Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"),
-        Message(role=MessageRole.USER, content="why is sky blue?")
+        Message(role=MessageRole.system, content="you are a helpful assistant"),
+        Message(role=MessageRole.user, content="why is sky blue?")
     ]
 )
 

--- a/src/galileo/__init__.py
+++ b/src/galileo/__init__.py
@@ -6,9 +6,9 @@
 from galileo.decorator import GalileoDecorator, galileo_context, log
 from galileo.logger import GalileoLogger
 from galileo.schema.message import Message
-from galileo.schema.message_role import MessageRole
 from galileo_core.helpers.api_key import create_api_key, delete_api_key, list_api_keys
 from galileo_core.helpers.dependencies import is_dependency_available
+from galileo_core.schemas.logging.llm import MessageRole, ToolCall, ToolCallFunction
 from galileo_core.schemas.shared.traces.types import LlmSpan, RetrieverSpan, ToolSpan, Trace, WorkflowSpan
 from galileo_core.schemas.shared.workflows.node_type import NodeType
 from galileo_core.schemas.shared.workflows.step import (

--- a/src/galileo/__init__.py
+++ b/src/galileo/__init__.py
@@ -5,6 +5,8 @@
 
 from galileo.decorator import GalileoDecorator, galileo_context, log
 from galileo.logger import GalileoLogger
+from galileo.schema.message import Message
+from galileo.schema.message_role import MessageRole
 from galileo_core.helpers.api_key import create_api_key, delete_api_key, list_api_keys
 from galileo_core.helpers.dependencies import is_dependency_available
 from galileo_core.schemas.shared.traces.types import LlmSpan, RetrieverSpan, ToolSpan, Trace, WorkflowSpan

--- a/src/galileo/prompts.py
+++ b/src/galileo/prompts.py
@@ -2,6 +2,7 @@ import builtins
 import logging
 from typing import Optional, Union
 
+from galileo import Message
 from galileo.base import BaseClientModel
 from galileo.projects import Projects
 from galileo.resources.api.prompts import (
@@ -13,7 +14,6 @@ from galileo.resources.models import (
     BasePromptTemplateResponse,
     CreatePromptTemplateWithVersionRequestBody,
     HTTPValidationError,
-    Message,
 )
 from galileo.utils.exceptions import APIException
 
@@ -112,7 +112,7 @@ class PromptTemplates(BaseClientModel):
         return PromptTemplate(prompt_template=response.parsed)
 
 
-def create_prompt_template(name: str, project: str, messages: Union[list["Message"], str]) -> Optional[PromptTemplate]:
+def create_prompt_template(name: str, project: str, messages: Union[list[Message], str]) -> Optional[PromptTemplate]:
     return PromptTemplates().create(name=name, project_name=project, template=messages)
 
 

--- a/src/galileo/schema/message.py
+++ b/src/galileo/schema/message.py
@@ -1,0 +1,26 @@
+# ruff: noqa: F401
+from typing import Any
+
+from galileo_core.schemas.logging.llm import Message as CoreMessage
+
+# These classes should not be removed. They are used to rebuild the new `Message` model
+# we are defining below.
+from galileo_core.schemas.logging.llm import ToolCall, ToolCallFunction
+
+
+class Message(CoreMessage):
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump(exclude_none=True)
+
+    def __eq__(self, value: CoreMessage) -> bool:
+        return (
+            self.content == value.content
+            and self.role == value.role
+            and self.tool_calls == value.tool_calls
+            and self.tool_call_id == value.tool_call_id
+        )
+
+
+# Without rebuilding the model, Message class we create here would not know and validate
+# constituent classes defined in core which build up message.
+Message.model_rebuild()

--- a/src/galileo/schema/message_role.py
+++ b/src/galileo/schema/message_role.py
@@ -1,0 +1,3 @@
+from galileo_core.schemas.logging.llm import MessageRole as CoreMessageRole
+
+MessageRole = CoreMessageRole

--- a/src/galileo/schema/message_role.py
+++ b/src/galileo/schema/message_role.py
@@ -1,3 +1,0 @@
-from galileo_core.schemas.logging.llm import MessageRole as CoreMessageRole
-
-MessageRole = CoreMessageRole

--- a/tests/schemas/test_message.py
+++ b/tests/schemas/test_message.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+import pytest
+
+from galileo import Message, MessageRole, ToolCall, ToolCallFunction
+
+
+@pytest.mark.parametrize(
+    "message, expected_to_dict",
+    [
+        (
+            Message(role=MessageRole.system, content="You are a helpful agent"),
+            {"content": "You are a helpful agent", "role": MessageRole.system},
+        ),
+        (
+            Message(role=MessageRole.system, content="You are a helpful agent enabling friction free flow"),
+            {"content": "You are a helpful agent enabling friction free flow", "role": MessageRole.system},
+        ),
+        (
+            Message(role=MessageRole.user, content="Why is the sky blue?"),
+            {"content": "Why is the sky blue?", "role": MessageRole.user},
+        ),
+        (
+            Message(role=MessageRole.user, content="Is sun getting colder?"),
+            {"content": "Is sun getting colder?", "role": MessageRole.user},
+        ),
+        (
+            Message(
+                role=MessageRole.user,
+                content="Who are you?",
+                tool_call_id="my_helpful_tool_1",
+                tool_calls=[
+                    ToolCall(id="my_helpful_tool_1", function=ToolCallFunction(name="fun_a", arguments="arg1 arg2")),
+                    ToolCall(id="my_helpful_tool_2", function=ToolCallFunction(name="fun_b", arguments="arg3")),
+                ],
+            ),
+            {
+                "content": "Who are you?",
+                "role": MessageRole.user,
+                "tool_call_id": "my_helpful_tool_1",
+                "tool_calls": [
+                    {"function": {"arguments": "arg1 arg2", "name": "fun_a"}, "id": "my_helpful_tool_1"},
+                    {"function": {"arguments": "arg3", "name": "fun_b"}, "id": "my_helpful_tool_2"},
+                ],
+            },
+        ),
+    ],
+)
+def test_to_dict(message: Message, expected_to_dict: dict[str, Any]) -> None:
+    assert message.to_dict() == expected_to_dict
+
+
+def test_eq() -> None:
+    m1 = Message(
+        role=MessageRole.user,
+        content="Who are you?",
+        tool_call_id="my_helpful_tool_1",
+        tool_calls=[
+            ToolCall(id="my_helpful_tool_1", function=ToolCallFunction(name="fun_a", arguments="arg1 arg2")),
+            ToolCall(id="my_helpful_tool_2", function=ToolCallFunction(name="fun_b", arguments="arg3")),
+        ],
+    )
+    m2 = Message(
+        role=MessageRole.user,
+        content="Who are you?",
+        tool_call_id="my_helpful_tool_1",
+        tool_calls=[
+            ToolCall(id="my_helpful_tool_1", function=ToolCallFunction(name="fun_a", arguments="arg1 arg2")),
+            ToolCall(id="my_helpful_tool_2", function=ToolCallFunction(name="fun_b", arguments="arg3")),
+        ],
+    )
+    assert m1 == m2

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -2,8 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from galileo import galileo_context, log
-from galileo_core.schemas.logging.llm import Message, MessageRole
+from galileo import Message, MessageRole, galileo_context, log
 from galileo_core.schemas.logging.span import LlmSpan, RetrieverSpan, ToolSpan, WorkflowSpan
 from galileo_core.schemas.shared.document import Document
 from tests.testutils.setup import setup_mock_core_api_client, setup_mock_logstreams_client, setup_mock_projects_client

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -6,10 +6,10 @@ from langchain_core.agents import AgentFinish
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, HumanMessage
 
+from galileo import Message, MessageRole
 from galileo.handlers.langchain import GalileoCallback
 from galileo.handlers.langchain.handler import _root_node
 from galileo.logger import GalileoLogger
-from galileo_core.schemas.logging.llm import Message, MessageRole
 from galileo_core.schemas.shared.document import Document as GalileoDocument
 from tests.testutils.setup import setup_mock_core_api_client, setup_mock_logstreams_client, setup_mock_projects_client
 

--- a/tests/test_langchain_async.py
+++ b/tests/test_langchain_async.py
@@ -7,9 +7,9 @@ from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, HumanMessage
 from pytest import mark
 
+from galileo import Message, MessageRole
 from galileo.handlers.langchain import GalileoAsyncCallback
 from galileo.logger import GalileoLogger
-from galileo_core.schemas.logging.llm import Message, MessageRole
 from galileo_core.schemas.shared.document import Document as GalileoDocument
 from tests.testutils.setup import setup_mock_core_api_client, setup_mock_logstreams_client, setup_mock_projects_client
 

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -6,9 +6,8 @@ from httpx import Response
 from openai import Stream
 from openai.types.chat import ChatCompletionChunk
 
-from galileo import galileo_context, log
+from galileo import Message, MessageRole, galileo_context, log
 from galileo.openai import OpenAIGalileo, openai
-from galileo_core.schemas.logging.llm import Message, MessageRole
 from galileo_core.schemas.logging.span import LlmSpan, WorkflowSpan
 from tests.testutils.setup import setup_mock_core_api_client, setup_mock_logstreams_client, setup_mock_projects_client
 from tests.testutils.streaming import EventStream

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,8 +4,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from galileo import Message, MessageRole
 from galileo.prompts import PromptTemplateAPIException, create_prompt_template
-from galileo.resources.models import BasePromptTemplateResponse, Message, MessageRole, ProjectDB
+from galileo.resources.models import BasePromptTemplateResponse, ProjectDB
 from galileo.resources.types import Response
 
 
@@ -69,8 +70,8 @@ def test_create_prompt(create_prompt_template_mock: Mock, get_projects_projects_
         name="andrii-good-prompt",
         project="andrii-new-project",
         messages=[
-            Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"),
-            Message(role=MessageRole.USER, content="why is sky blue?"),
+            Message(role=MessageRole.system, content="you are a helpful assistant"),
+            Message(role=MessageRole.user, content="why is sky blue?"),
         ],
     )
 
@@ -94,8 +95,8 @@ def test_create_prompt_bad_request(create_prompt_template_mock: Mock, get_projec
             name="andrii-good-prompt",
             project="andrii-new-project",
             messages=[
-                Message(role=MessageRole.SYSTEM, content="you are a helpful assistant"),
-                Message(role=MessageRole.USER, content="why is sky blue?"),
+                Message(role=MessageRole.system, content="you are a helpful assistant"),
+                Message(role=MessageRole.user, content="why is sky blue?"),
             ],
         )
     create_prompt_template_mock.sync_detailed.assert_called_once()


### PR DESCRIPTION
### Summary

Following PR does the following according to the detailed discussion which happened [here](https://galileoteamworkspace.slack.com/archives/C087G0X1JG2/p1744123147608439)

1. Adds wrapper classes for `Message` and `MessageRole` within python SDK which internally inherits from `galileo_core`. This is done to ensure name, functionality normalization across the board [27505](https://app.shortcut.com/galileo/story/27505/g2-0-python-sdk-standardize-the-messagerole-models)
2. Exposes the new class (along with its component classes) right at the package level so that they can be imported as `from galileo import Message, MessageRole, ToolCall, ToolCallFunction`. This is done to ensure `galileo_core` remains encapsulated and also to prevent confusion of importing from different packages/sources.
3. Adds `to_dict` method to `Message` class as the generated client makes call to `to_dict` method.

### Testing

Installed the package in edit mode via `pip install -e src/galileo-python` and ensured 
1. `MessageRole` enum works and uses lower cased members
2. `Message` role class can be instantiated and `to_dict` method is supported and works as expected. Also added a UT for the same.