### PR TITLE
fix: JSON datasets are not being passed into runner functions correctly

### DIFF
--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -1,3 +1,4 @@
+import json
 import mimetypes
 from typing import Any, Optional, Union, overload
 
@@ -466,4 +467,17 @@ def convert_dataset_content_to_records(dataset_content: DatasetContent):
     rows = dataset_content.rows
     if not rows:
         return []
-    return [row.additional_properties["values_dict"] for row in rows]
+
+    result = []
+    for row in rows:
+        row_values = row.additional_properties["values_dict"]
+        if "input" in row_values:
+            if isinstance(row_values["input"], str):
+                try:
+                    result.append(json.loads(row_values["input"]))
+                except json.decoder.JSONDecodeError:
+                    result.append(row_values["input"])
+        else:
+            result.append(row_values)
+
+    return result

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -257,3 +257,16 @@ def test_convert_dataset_content_to_records_str(value, expected):
     content = DatasetContent(column_names=column_names, rows=[row])
     result = convert_dataset_content_to_records(content)
     assert result == expected
+
+
+def test_convert_dataset_content_to_records_no_rows():
+    column_names = ["input", "output", "metadata"]
+    content = DatasetContent(column_names=column_names, rows=[])
+    assert convert_dataset_content_to_records(content) == []
+
+
+def test_convert_dataset_content_to_records_empty_values_dict():
+    row = DatasetRow(index=0, values=[])
+    row.additional_properties = {"values_dict": {}}
+    content = DatasetContent(column_names=[], rows=[row])
+    assert convert_dataset_content_to_records(content) == [{}]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,8 +3,13 @@ from unittest.mock import ANY, Mock, patch
 
 import pytest
 
-from galileo.datasets import DatasetAPIException, create_dataset, get_dataset_version, get_dataset_version_history, \
-    convert_dataset_content_to_records
+from galileo.datasets import (
+    DatasetAPIException,
+    convert_dataset_content_to_records,
+    create_dataset,
+    get_dataset_version,
+    get_dataset_version_history,
+)
 from galileo.resources.models import (
     DatasetContent,
     DatasetDB,
@@ -238,19 +243,16 @@ def test_get_dataset_version_history_wo_dataset_name_or_dataset_id():
 @pytest.mark.parametrize(
     "value, expected",
     [
-        ('{"input": "Which continent is Spain in?", "expected": "Europe"}', [{'expected': 'Europe', 'input': 'Which continent is Spain in?'}]),
-        ('string', ['string']),
-    ]
+        (
+            '{"input": "Which continent is Spain in?", "expected": "Europe"}',
+            [{"expected": "Europe", "input": "Which continent is Spain in?"}],
+        ),
+        ("string", ["string"]),
+    ],
 )
 def test_convert_dataset_content_to_records_str(value, expected):
     row = DatasetRow(index=0, values=[value])
-    row.additional_properties = {
-        "values_dict": {
-            "input": value,
-            "output": None,
-            "metadata": None,
-        }
-    }
+    row.additional_properties = {"values_dict": {"input": value, "output": None, "metadata": None}}
     column_names = ["input", "output", "metadata"]
     content = DatasetContent(column_names=column_names, rows=[row])
     result = convert_dataset_content_to_records(content)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,7 +3,8 @@ from unittest.mock import ANY, Mock, patch
 
 import pytest
 
-from galileo.datasets import DatasetAPIException, create_dataset, get_dataset_version, get_dataset_version_history
+from galileo.datasets import DatasetAPIException, create_dataset, get_dataset_version, get_dataset_version_history, \
+    convert_dataset_content_to_records
 from galileo.resources.models import (
     DatasetContent,
     DatasetDB,
@@ -232,3 +233,25 @@ def test_get_dataset_version_history_wo_dataset_name_or_dataset_id():
     with pytest.raises(ValueError) as exc_info:
         get_dataset_version_history()
     assert "Either dataset_name or dataset_id must be provided." in str(exc_info.value), str(exc_info)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ('{"input": "Which continent is Spain in?", "expected": "Europe"}', [{'expected': 'Europe', 'input': 'Which continent is Spain in?'}]),
+        ('string', ['string']),
+    ]
+)
+def test_convert_dataset_content_to_records_str(value, expected):
+    row = DatasetRow(index=0, values=[value])
+    row.additional_properties = {
+        "values_dict": {
+            "input": value,
+            "output": None,
+            "metadata": None,
+        }
+    }
+    column_names = ["input", "output", "metadata"]
+    content = DatasetContent(column_names=column_names, rows=[row])
+    result = convert_dataset_content_to_records(content)
+    assert result == expected


### PR DESCRIPTION
This PR solves https://app.shortcut.com/galileo/story/26791/g2-0-python-and-ts-sdks-json-datasets-are-not-being-passed-into-runner-functions-correctly

## How to test:

Create JSON like dataset
```
test_data = [
    {
        "question": "Which continent is Spain in?",
        "expected": "Europe",
    },
    {
        "question": "Which continent is Japan in?",
        "expected": "Asia",
    },
]
dataset = create_dataset(
    "storyteller-dataset1",
    test_data,
)
```

Run an experiment with local runner and this dataset:
```
def runner(input):
    return openai.chat.completions.create(
        model="gpt-4o",
        messages=[
            {"role": "user", "content": f"Say hello: {input['question']}"}
        ],
    ).choices[0].message.content


run_experiment(
    "test experiment runner10",
    project="andrii-new-project",
    dataset=get_dataset(name="storyteller-dataset1"),
    function=runner,
    metrics=['output_tone'],
)
```
