### PR TITLE
fix: Updating the Langchain handler retriever, tool, async chain callbacks

### DIFF
--- a/src/galileo/handlers/langchain/async_handler.py
+++ b/src/galileo/handlers/langchain/async_handler.py
@@ -260,7 +260,10 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
         self, outputs: dict[str, Any], *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any
     ) -> Any:
         """Langchain callback when a chain ends."""
-        await self._end_node(run_id, output=serialize_to_str(outputs))
+        # The input is sent via kwargs in on_chain_end in async streaming mode
+        if "inputs" in kwargs:
+            kwargs["input"] = serialize_to_str(kwargs["inputs"])
+        await self._end_node(run_id, output=serialize_to_str(outputs), **kwargs)
 
     async def on_agent_finish(self, finish: AgentFinish, *, run_id: UUID, **kwargs: Any) -> Any:
         """Langchain callback when an agent finishes."""

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -394,24 +394,36 @@ class GalileoCallback(BaseCallbackHandler):
             metadata={k: str(v) for k, v in metadata.items()} if metadata else None,
         )
 
-    def on_tool_end(self, output: str, *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any) -> Any:
+    def on_tool_end(self, output: Any, *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any) -> Any:
         """Langchain callback when a tool node ends."""
-        self._end_node(run_id, output=serialize_to_str(output))
+        if isinstance(output, dict) and "content" in output:
+            output = serialize_to_str(output["content"])
+        elif hasattr(output, "content"):
+            output = serialize_to_str(output.content)
+        else:
+            output = serialize_to_str(output)
+        self._end_node(run_id, output=output)
 
     def on_retriever_start(
-        self, query: str, *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any
+        self,
+        serialized: dict[str, Any],
+        query: str,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
     ) -> Any:
         """Langchain callback when a retriever node starts."""
         self._start_node("retriever", parent_run_id, run_id, name="Retriever", input=serialize_to_str(query))
 
     def on_retriever_end(
-        self, response: list[Document], *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any
+        self, documents: list[Document], *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any
     ) -> Any:
         """Langchain callback when a retriever node ends."""
         try:
-            serialized_response = json.loads(json.dumps(response, cls=EventSerializer))
+            serialized_response = json.loads(json.dumps(documents, cls=EventSerializer))
         except Exception as e:
             _logger.warning(f"Failed to serialize retriever output: {e}")
-            serialized_response = str(response)
+            serialized_response = str(documents)
 
         self._end_node(run_id, output=serialized_response)

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -300,7 +300,7 @@ class TestGalileoCallback:
             }
         ]
 
-    def test_on_tool_start_end(self, callback: GalileoCallback):
+    def test_on_tool_start_end_with_string_output(self, callback: GalileoCallback):
         """Test tool start and end callbacks"""
         parent_id = uuid.uuid4()
         run_id = uuid.uuid4()
@@ -317,10 +317,116 @@ class TestGalileoCallback:
         assert callback._nodes[str(run_id)].node_type == "tool"
         assert callback._nodes[str(run_id)].span_params["input"] == "2+2"
 
-        # End tool
+        # End tool with a string output
         callback.on_tool_end(output="4", run_id=run_id, parent_run_id=parent_id)
 
         assert callback._nodes[str(run_id)].span_params["output"] == "4"
+
+    def test_on_tool_start_end_with_object_output(self, callback: GalileoCallback):
+        """Test tool start and end callbacks"""
+        parent_id = uuid.uuid4()
+        run_id = uuid.uuid4()
+
+        # Create parent chain
+        callback.on_chain_start(serialized={}, inputs={"query": "test"}, run_id=parent_id)
+
+        # Start tool
+        callback.on_tool_start(
+            serialized={"name": "calculator"}, input_str="2+2", run_id=run_id, parent_run_id=parent_id
+        )
+
+        assert str(run_id) in callback._nodes
+        assert callback._nodes[str(run_id)].node_type == "tool"
+        assert callback._nodes[str(run_id)].span_params["input"] == "2+2"
+
+        class ToolResponseWithContent:
+            def __init__(self, content, tool_call_id, status, role):
+                self.content = content
+                self.tool_call_id = tool_call_id
+                self.status = status
+                self.role = role
+
+        # End tool with an object output with a content field
+        callback.on_tool_end(
+            output=ToolResponseWithContent(content="tool response", tool_call_id="1", status="success", role="tool"),
+            run_id=run_id,
+            parent_run_id=parent_id,
+        )
+
+        assert str(run_id) in callback._nodes
+        assert callback._nodes[str(run_id)].node_type == "tool"
+        assert callback._nodes[str(run_id)].span_params["input"] == "2+2"
+        assert callback._nodes[str(run_id)].span_params["output"] == "tool response"
+
+        # Start tool
+        callback.on_tool_start(
+            serialized={"name": "calculator"}, input_str="2+2", run_id=run_id, parent_run_id=parent_id
+        )
+
+        class ToolResponseWithoutContent:
+            def __init__(self, tool_call_id, status, role):
+                self.tool_call_id = tool_call_id
+                self.status = status
+                self.role = role
+
+        # End tool with an object output without a content field
+        callback.on_tool_end(
+            output=ToolResponseWithoutContent(tool_call_id="1", status="success", role="tool"),
+            run_id=run_id,
+            parent_run_id=parent_id,
+        )
+
+        assert str(run_id) in callback._nodes
+        assert callback._nodes[str(run_id)].node_type == "tool"
+        assert callback._nodes[str(run_id)].span_params["input"] == "2+2"
+        assert (
+            callback._nodes[str(run_id)].span_params["output"]
+            == '{"tool_call_id": "1", "status": "success", "role": "tool"}'
+        )
+
+    def test_on_tool_start_end_with_dict_output(self, callback: GalileoCallback):
+        """Test tool start and end callbacks"""
+        parent_id = uuid.uuid4()
+        run_id = uuid.uuid4()
+
+        # Create parent chain
+        callback.on_chain_start(serialized={}, inputs={"query": "test"}, run_id=parent_id)
+
+        # Start tool
+        callback.on_tool_start(
+            serialized={"name": "calculator"}, input_str="2+2", run_id=run_id, parent_run_id=parent_id
+        )
+
+        assert str(run_id) in callback._nodes
+        assert callback._nodes[str(run_id)].node_type == "tool"
+        assert callback._nodes[str(run_id)].span_params["input"] == "2+2"
+
+        # End tool with a dict output with a content field
+        callback.on_tool_end(
+            output={"content": "tool response", "tool_call_id": "1", "status": "success", "role": "tool"},
+            run_id=run_id,
+            parent_run_id=parent_id,
+        )
+
+        assert str(run_id) in callback._nodes
+        assert callback._nodes[str(run_id)].node_type == "tool"
+        assert callback._nodes[str(run_id)].span_params["input"] == "2+2"
+        assert callback._nodes[str(run_id)].span_params["output"] == "tool response"
+
+        # Start tool
+        callback.on_tool_start(
+            serialized={"name": "calculator"}, input_str="2+2", run_id=run_id, parent_run_id=parent_id
+        )
+
+        # End tool with an object output without a content field
+        callback.on_tool_end(
+            output={"tool_call_id": "1", "status": "success", "role": "tool"}, run_id=run_id, parent_run_id=parent_id
+        )
+
+        assert (
+            callback._nodes[str(run_id)].span_params["output"]
+            == '{"tool_call_id": "1", "status": "success", "role": "tool"}'
+        )
 
     def test_on_retriever_start_end(self, callback: GalileoCallback):
         """Test retriever start and end callbacks"""
@@ -331,7 +437,7 @@ class TestGalileoCallback:
         callback.on_chain_start(serialized={}, inputs={"query": "test"}, run_id=parent_id)
 
         # Start retriever
-        callback.on_retriever_start(query="AI development", run_id=run_id, parent_run_id=parent_id)
+        callback.on_retriever_start(serialized={}, query="AI development", run_id=run_id, parent_run_id=parent_id)
 
         assert str(run_id) in callback._nodes
         assert callback._nodes[str(run_id)].node_type == "retriever"
@@ -339,7 +445,7 @@ class TestGalileoCallback:
 
         # End retriever
         document = Document(page_content="AI is advancing rapidly", metadata={"source": "textbook"})
-        callback.on_retriever_end(response=[document], run_id=run_id, parent_run_id=parent_id)
+        callback.on_retriever_end(documents=[document], run_id=run_id, parent_run_id=parent_id)
 
         assert isinstance(callback._nodes[str(run_id)].span_params["output"], list)
         assert len(callback._nodes[str(run_id)].span_params["output"]) == 1
@@ -358,11 +464,13 @@ class TestGalileoCallback:
         )
 
         # Start retriever
-        callback.on_retriever_start(query="latest AI research", run_id=retriever_id, parent_run_id=chain_id)
+        callback.on_retriever_start(
+            serialized={}, query="latest AI research", run_id=retriever_id, parent_run_id=chain_id
+        )
 
         # End retriever
         document = Document(page_content="Recent advances in large language models...", metadata={"source": "paper"})
-        callback.on_retriever_end(response=[document], run_id=retriever_id, parent_run_id=chain_id)
+        callback.on_retriever_end(documents=[document], run_id=retriever_id, parent_run_id=chain_id)
 
         # Start LLM
         callback.on_llm_start(
@@ -467,11 +575,11 @@ class TestGalileoCallback:
         callback.on_chain_start(serialized={}, inputs={"query": "test"}, run_id=run_id)
 
         retriever_id = uuid.uuid4()
-        callback.on_retriever_start(query="test query", run_id=retriever_id, parent_run_id=run_id)
+        callback.on_retriever_start(serialized={}, query="test query", run_id=retriever_id, parent_run_id=run_id)
 
         # This should be handled gracefully
         with patch("json.dumps", side_effect=TypeError("Cannot serialize")):
-            callback.on_retriever_end(response=[unserializable], run_id=retriever_id, parent_run_id=run_id)
+            callback.on_retriever_end(documents=[unserializable], run_id=retriever_id, parent_run_id=run_id)
 
         # Node should still exist and output should be a string
         assert str(retriever_id) in callback._nodes


### PR DESCRIPTION
Few fixes:
1. `on_retriever_start` wasn't working correctly bc it was missing a positional argument (`serialized`).
2. `on_tool_end` was serializing unnecessary Langchain metadata as the output when we only care about the `content` (if it exists in the object). This was originally suggested by a user (@ChrisTague1) in the following PR: https://github.com/rungalileo/galileo-python/pull/90 . Since the tool output is typed as Any and Langchain doesn't have proper documentation for what to expect, I'm doing some type checking and handling.
3. In async streaming scenarios, `on_chain_start `actually sends an empty string as the input and then sends the full input in `on_chain_end`. Updating the async handler to reflect this.