### PR TITLE
fix: Fix functionality to add new rows to dataset

### DIFF
--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -17,12 +17,11 @@ from galileo.resources.api.datasets import (
 )
 from galileo.resources.models import ListDatasetVersionParams, ListDatasetVersionResponse
 from galileo.resources.models.body_upload_dataset_datasets_post import BodyUploadDatasetDatasetsPost
+from galileo.resources.models.dataset_append_row import DatasetAppendRow
 from galileo.resources.models.dataset_content import DatasetContent
 from galileo.resources.models.dataset_db import DatasetDB
 from galileo.resources.models.dataset_name_filter import DatasetNameFilter
 from galileo.resources.models.dataset_name_filter_operator import DatasetNameFilterOperator
-from galileo.resources.models.dataset_update_row import DatasetUpdateRow
-from galileo.resources.models.dataset_update_row_values import DatasetUpdateRowValues
 from galileo.resources.models.dataset_updated_at_sort import DatasetUpdatedAtSort
 from galileo.resources.models.http_validation_error import HTTPValidationError
 from galileo.resources.models.list_dataset_params import ListDatasetParams
@@ -96,14 +95,13 @@ class Dataset(BaseClientModel, DecorateAllMethods):
             If the request takes longer than Client.timeout.
 
         """
-        for row in row_data:
-            row_values = DatasetUpdateRow(values=DatasetUpdateRowValues.from_dict(row))
-            request = UpdateDatasetContentRequest(edits=[row_values])
-            response = update_dataset_content_datasets_dataset_id_content_patch.sync(
-                client=self.client, dataset_id=self.dataset.id, body=request
-            )
-            if isinstance(response, HTTPValidationError):
-                raise response
+        append_rows: list[DatasetAppendRow] = [DatasetAppendRow(values=row) for row in row_data]
+        request = UpdateDatasetContentRequest(edits=append_rows)
+        response = update_dataset_content_datasets_dataset_id_content_patch.sync(
+            client=self.client, dataset_id=self.dataset.id, body=request
+        )
+        if isinstance(response, HTTPValidationError):
+            raise response
 
         # Refresh the content
         self.get_content()

--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -74,7 +74,7 @@ class Dataset(BaseClientModel, DecorateAllMethods):
 
         return content
 
-    def _get_etag(self) -> str | None:
+    def _get_etag(self) -> Optional[str]:
         """
         ETag is returned in response headers of API endpoints of the format /datasets.*contents.*
 

--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -101,7 +101,7 @@ class Dataset(BaseClientModel, DecorateAllMethods):
             client=self.client, dataset_id=self.dataset.id, body=request
         )
         if isinstance(response, HTTPValidationError):
-            raise response
+            raise DatasetAPIException("Request to add new rows to dataset failed.")
 
         # Refresh the content
         self.get_content()


### PR DESCRIPTION
### Shortcut

[sc-28511](https://app.shortcut.com/galileo/story/28511/add-rows-to-dataset-through-python-sdk-not-working) : Add rows to dataset through python sdk not working.

### Description

We were using `DatasetUpdateRow` which targets updating a specific row instead of adding new rows to the dataset. We should be using `DatasetAppendRow` to achieve the same which this PR adds. 

### Testing

We also add test to verify we are using the right dataset entity for adding new rows.