### PR TITLE
fix: Fixing the OpenAI wrapper when it's used in an active trace

### DIFF
--- a/src/galileo/openai.py
+++ b/src/galileo/openai.py
@@ -430,9 +430,6 @@ def _is_streaming_response(response):
 def _wrap(
     open_ai_resource: OpenAiModuleDefinition, initialize: Callable, wrapped: Callable, args: dict, kwargs: dict
 ) -> Any:
-    # Retrieve the decorator context
-    decorator_context_trace = galileo_context.get_current_trace()
-
     start_time = _get_timestamp()
     arg_extractor = OpenAiArgsExtractor(*args, **kwargs)
 
@@ -441,7 +438,7 @@ def _wrap(
     galileo_logger: GalileoLogger = initialize()
 
     should_complete_trace = False
-    if decorator_context_trace:
+    if galileo_logger.current_parent():
         pass
     else:
         # If we don't have an active trace, start a new trace


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/28964/openai-wrapper-can-t-append-llm-node-to-existing-trace

This will allow users to create a single trace with multiple LLM spans generated by our OpenAI client wrapper (without using the `log` decorator):

```
client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))

logger = galileo_context.get_logger_instance()
logger.start_trace("test trace")

client.chat.completions.create(messages=[{"role": "user", "content": "Say this is a test"}], model="gpt-4o-mini")
client.chat.completions.create(
    messages=[{"role": "user", "content": "Say this is a second test"}], model="gpt-4o-mini"
)

logger.conclude(output="trace completed")
logger.flush()
```