### PR TITLE
feat: Session management

### DIFF
--- a/src/galileo/constants/routes.py
+++ b/src/galileo/constants/routes.py
@@ -20,3 +20,5 @@ class Routes(str, Enum):
     spans_search = "/v2/projects/{project_id}/spans/search"
     spans_available_columns = "/v2/projects/{project_id}/spans/available_columns"
     span = "/v2/projects/{project_id}/spans/{span_id}"
+
+    sessions = "/v2/projects/{project_id}/sessions"

--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -858,6 +858,16 @@ class GalileoDecorator:
         _span_stack_context.set([])
         _trace_context.set(None)
 
+    def start_session(
+        self, name: str, previous_session_id: Optional[str] = None, external_id: Optional[str] = None
+    ) -> None:
+        self.get_logger_instance().start_session(
+            name=name, previous_session_id=previous_session_id, external_id=external_id
+        )
+
+    def clear_session(self) -> None:
+        self.get_logger_instance().clear_session()
+
 
 galileo_context = GalileoDecorator()
 log = galileo_context.log

--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -861,11 +861,22 @@ class GalileoDecorator:
     def start_session(
         self, name: str, previous_session_id: Optional[str] = None, external_id: Optional[str] = None
     ) -> None:
+        """
+        Start a session in the active context logger instance.
+
+        Args:
+            name: The name of the session.
+            previous_session_id: The id of the previous session. Defaults to None.
+            external_id: The external id of the session. Defaults to None.
+        """
         self.get_logger_instance().start_session(
             name=name, previous_session_id=previous_session_id, external_id=external_id
         )
 
     def clear_session(self) -> None:
+        """
+        Clear the session in the active context logger instance.
+        """
         self.get_logger_instance().clear_session()
 
 

--- a/src/galileo/logger.py
+++ b/src/galileo/logger.py
@@ -12,7 +12,7 @@ from galileo.api_client import GalileoApiClient
 from galileo.constants import DEFAULT_LOG_STREAM_NAME, DEFAULT_PROJECT_NAME
 from galileo.log_streams import LogStreams
 from galileo.projects import Projects
-from galileo.schema.trace import TracesIngestRequest
+from galileo.schema.trace import SessionCreateRequest, TracesIngestRequest
 from galileo.utils.catch_log import DecorateAllMethods
 from galileo.utils.core_api_client import GalileoCoreApiClient
 from galileo.utils.nop_logger import nop_async, nop_sync
@@ -104,6 +104,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
     project_id: Optional[str] = None
     log_stream_id: Optional[str] = None
     experiment_id: Optional[str] = None
+    session_id: Optional[str] = None
 
     _logger = logging.getLogger("galileo.logger")
 
@@ -543,7 +544,9 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
 
         self._logger.info("Flushing %d traces...", len(self.traces))
 
-        traces_ingest_request = TracesIngestRequest(traces=self.traces, experiment_id=self.experiment_id)
+        traces_ingest_request = TracesIngestRequest(
+            traces=self.traces, experiment_id=self.experiment_id, session_id=self._session_id
+        )
         self._client.ingest_traces_sync(traces_ingest_request)
         logged_traces = self.traces
 
@@ -574,7 +577,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
 
         self._logger.info("Flushing %d traces...", len(self.traces))
 
-        traces_ingest_request = TracesIngestRequest(traces=self.traces)
+        traces_ingest_request = TracesIngestRequest(traces=self.traces, session_id=self._session_id)
         await self._client.ingest_traces(traces_ingest_request)
         logged_traces = self.traces
 
@@ -593,3 +596,21 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
         atexit.unregister(self.terminate)
         self._logger.info("Attempting to flush on interpreter exit...")
         self.flush()
+
+    def start_session(
+        self, name: str, previous_session_id: Optional[str] = None, external_id: Optional[str] = None
+    ) -> None:
+        self._logger.info("Starting a new session...")
+
+        session = self._client.create_session_sync(
+            SessionCreateRequest(name=name, previous_session_id=previous_session_id, external_id=external_id)
+        )
+
+        self._logger.info("Session started with ID: %s", session.id)
+
+        self._session_id = session.id
+
+    def clear_session(self) -> None:
+        self._logger.info("Clearing the current session from the logger...")
+        self._session_id = None
+        self._logger.info("Current session cleared.")

--- a/src/galileo/logger.py
+++ b/src/galileo/logger.py
@@ -545,7 +545,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
         self._logger.info("Flushing %d traces...", len(self.traces))
 
         traces_ingest_request = TracesIngestRequest(
-            traces=self.traces, experiment_id=self.experiment_id, session_id=self._session_id
+            traces=self.traces, experiment_id=self.experiment_id, session_id=self.session_id
         )
         self._client.ingest_traces_sync(traces_ingest_request)
         logged_traces = self.traces
@@ -577,7 +577,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
 
         self._logger.info("Flushing %d traces...", len(self.traces))
 
-        traces_ingest_request = TracesIngestRequest(traces=self.traces, session_id=self._session_id)
+        traces_ingest_request = TracesIngestRequest(traces=self.traces, session_id=self.session_id)
         await self._client.ingest_traces(traces_ingest_request)
         logged_traces = self.traces
 
@@ -606,11 +606,11 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             SessionCreateRequest(name=name, previous_session_id=previous_session_id, external_id=external_id)
         )
 
-        self._logger.info("Session started with ID: %s", session.id)
+        self._logger.info("Session started with ID: %s", session["id"])
 
-        self._session_id = session.id
+        self.session_id = str(session["id"])
 
     def clear_session(self) -> None:
         self._logger.info("Clearing the current session from the logger...")
-        self._session_id = None
+        self.session_id = None
         self._logger.info("Current session cleared.")

--- a/src/galileo/schema/trace.py
+++ b/src/galileo/schema/trace.py
@@ -12,6 +12,7 @@ class BaseLogStreamOrExperimentModel(BaseModel):
 
 class TracesIngestRequest(BaseLogStreamOrExperimentModel):
     traces: list[Trace] = Field(..., description="List of traces to log.", min_length=1)
+    session_id: Optional[UUID4] = Field(default=None, description="Session id associated with the traces.")
 
 
 class TracesIngestResponse(BaseLogStreamOrExperimentModel):
@@ -19,3 +20,19 @@ class TracesIngestResponse(BaseLogStreamOrExperimentModel):
     project_name: str = Field(description="Project name associated with the traces.")
     traces_count: int = Field(description="total number of traces ingested")
     records_count: int = Field(description="total number of records (traces & spans) ingested")
+
+
+class SessionCreateRequest(BaseLogStreamOrExperimentModel):
+    name: str = Field(..., description="Name of the session.")
+    previous_session_id: Optional[UUID4] = Field(default=None, description="Previous session id.")
+    external_id: Optional[str] = Field(default=None, description="External id of the session.")
+
+
+class SessionCreateResponse(BaseLogStreamOrExperimentModel):
+    id: UUID4 = Field(description="Id of the session.")
+    name: str = Field(description="Name of the session.")
+    previous_session_id: Optional[UUID4] = Field(default=None, description="Previous session id.")
+    external_id: Optional[str] = Field(default=None, description="External id of the session.")
+    project_id: UUID4 = Field(description="Project id associated with the session.")
+    project_name: str = Field(description="Project name associated with the session.")
+    log_stream_id: Optional[UUID4] = Field(default=None, description="Log stream id associated with the session.")

--- a/src/galileo/utils/core_api_client.py
+++ b/src/galileo/utils/core_api_client.py
@@ -8,7 +8,7 @@ from httpx import Client, Timeout
 
 from galileo.api_client import GalileoApiClient
 from galileo.constants.routes import Routes
-from galileo.schema.trace import TracesIngestRequest
+from galileo.schema.trace import SessionCreateRequest, SessionCreateResponse, TracesIngestRequest
 from galileo.utils.request import HttpHeaders, make_request
 from galileo_core.constants.request_method import RequestMethod
 from galileo_core.helpers.api_client import ApiClient as CoreApiClient
@@ -147,6 +147,30 @@ class GalileoCoreApiClient:
 
         return self._make_request(
             RequestMethod.POST, endpoint=Routes.traces.format(project_id=self.project_id), json=json
+        )
+
+    def create_session_sync(self, session_create_request: SessionCreateRequest) -> SessionCreateResponse:
+        if self.experiment_id:
+            session_create_request.experiment_id = UUID(self.experiment_id)
+        elif self.log_stream_id:
+            session_create_request.log_stream_id = UUID(self.log_stream_id)
+
+        json = session_create_request.model_dump(mode="json")
+
+        return self._make_request(
+            RequestMethod.POST, endpoint=Routes.sessions.format(project_id=self.project_id), json=json
+        )
+
+    async def create_session(self, session_create_request: SessionCreateRequest) -> SessionCreateResponse:
+        if self.experiment_id:
+            session_create_request.experiment_id = UUID(self.experiment_id)
+        elif self.log_stream_id:
+            session_create_request.log_stream_id = UUID(self.log_stream_id)
+
+        json = session_create_request.model_dump(mode="json")
+
+        return await self._make_async_request(
+            RequestMethod.POST, endpoint=Routes.sessions.format(project_id=self.project_id), json=json
         )
 
     # TODO: Move this method to galileo_core.helpers.api_client

--- a/src/galileo/utils/core_api_client.py
+++ b/src/galileo/utils/core_api_client.py
@@ -8,7 +8,7 @@ from httpx import Client, Timeout
 
 from galileo.api_client import GalileoApiClient
 from galileo.constants.routes import Routes
-from galileo.schema.trace import SessionCreateRequest, SessionCreateResponse, TracesIngestRequest
+from galileo.schema.trace import SessionCreateRequest, TracesIngestRequest
 from galileo.utils.request import HttpHeaders, make_request
 from galileo_core.constants.request_method import RequestMethod
 from galileo_core.helpers.api_client import ApiClient as CoreApiClient
@@ -149,7 +149,7 @@ class GalileoCoreApiClient:
             RequestMethod.POST, endpoint=Routes.traces.format(project_id=self.project_id), json=json
         )
 
-    def create_session_sync(self, session_create_request: SessionCreateRequest) -> SessionCreateResponse:
+    def create_session_sync(self, session_create_request: SessionCreateRequest) -> dict[str, str]:
         if self.experiment_id:
             session_create_request.experiment_id = UUID(self.experiment_id)
         elif self.log_stream_id:
@@ -157,11 +157,13 @@ class GalileoCoreApiClient:
 
         json = session_create_request.model_dump(mode="json")
 
-        return self._make_request(
+        response = self._make_request(
             RequestMethod.POST, endpoint=Routes.sessions.format(project_id=self.project_id), json=json
         )
 
-    async def create_session(self, session_create_request: SessionCreateRequest) -> SessionCreateResponse:
+        return response
+
+    async def create_session(self, session_create_request: SessionCreateRequest) -> dict[str, str]:
         if self.experiment_id:
             session_create_request.experiment_id = UUID(self.experiment_id)
         elif self.log_stream_id:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock, patch
+from uuid import UUID
 
 import pytest
 
@@ -518,3 +519,63 @@ def test_decorator_we_should_create_trace_but_reraise_exception(
 
     assert len(payload.traces) == 1
     assert len(payload.traces[0].spans) == 1
+
+
+@patch("galileo.logger.LogStreams")
+@patch("galileo.logger.Projects")
+@patch("galileo.logger.GalileoCoreApiClient")
+def test_decorator_start_session(
+    mock_core_api_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
+) -> None:
+    mock_core_api_instance = setup_mock_core_api_client(mock_core_api_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+
+    @log()
+    def foo():
+        return "response"
+
+    foo()
+    galileo_context.start_session(
+        name="test-session", previous_session_id="6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9e", external_id="test"
+    )
+
+    logger = galileo_context.get_logger_instance()
+    assert logger.session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
+
+    galileo_context.flush()
+
+    payload = mock_core_api_instance.ingest_traces_sync.call_args[0][0]
+
+    assert payload.session_id == UUID("6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c")
+
+
+@patch("galileo.logger.LogStreams")
+@patch("galileo.logger.Projects")
+@patch("galileo.logger.GalileoCoreApiClient")
+def test_decorator_clear_session(
+    mock_core_api_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
+) -> None:
+    mock_core_api_instance = setup_mock_core_api_client(mock_core_api_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+
+    @log()
+    def foo():
+        return "response"
+
+    foo()
+    galileo_context.start_session(name="test-session")
+
+    logger = galileo_context.get_logger_instance()
+    assert logger.session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
+
+    galileo_context.clear_session()
+
+    assert logger.session_id is None
+
+    galileo_context.flush()
+
+    payload = mock_core_api_instance.ingest_traces_sync.call_args[0][0]
+
+    assert payload.session_id is None

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -799,3 +799,26 @@ def test_get_last_output_last_child_no_output() -> None:
 
     trace.spans = [tool_span]
     assert GalileoLogger._get_last_output(trace) is None
+
+
+@patch("galileo.logger.LogStreams")
+@patch("galileo.logger.Projects")
+@patch("galileo.logger.GalileoCoreApiClient")
+def test_session_create(mock_core_api_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock) -> None:
+    mock_core_api_instance = setup_mock_core_api_client(mock_core_api_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+
+    datetime.datetime.now()
+    logger = GalileoLogger(project="my_project", log_stream="my_log_stream")
+    logger.start_session(
+        name="test-session", previous_session_id="6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9e", external_id="test"
+    )
+
+    payload = mock_core_api_instance.create_session_sync.call_args[0][0]
+
+    assert payload.name == "test-session"
+    assert payload.previous_session_id == UUID("6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9e")
+    assert payload.external_id == "test"
+
+    assert logger.session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"

--- a/tests/testutils/setup.py
+++ b/tests/testutils/setup.py
@@ -91,4 +91,15 @@ def setup_mock_core_api_client(mock_core_api_client: Mock):
     mock_instance.get_log_stream_by_name = AsyncMock(return_value={"id": UUID("6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9b")})
     mock_instance.ingest_traces_sync = AsyncMock(return_value={})
     mock_instance.ingest_traces = AsyncMock(return_value={})
+    mock_instance.create_session_sync = Mock(
+        return_value={
+            "id": UUID("6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"),
+            "name": "test",
+            "previous_session_id": UUID("6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9e"),
+            "external_id": "test",
+            "project_id": UUID("6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9a"),
+            "project_name": "test project",
+            "log_stream_id": UUID("6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9d"),
+        }
+    )
     return mock_instance


### PR DESCRIPTION
Adding session management to the GalileoLogger

```
logger.start_session(name="test-session", previous_session_id="6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9e", external_id="myAppId123")

...

logger.clear_session()
```

https://app.shortcut.com/galileo/story/29394/sdk-add-session-compatibility-to-the-galileologger-python