### PR TITLE
fix: Reverting a change from a previous context manager fix

### DIFF
--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -50,13 +50,11 @@ import logging
 from collections.abc import AsyncGenerator, Generator
 from contextvars import ContextVar
 from functools import wraps
-from os import getenv
 from types import TracebackType
 from typing import Any, Callable, Literal, Optional, TypeVar, Union, cast, overload
 
 from typing_extensions import ParamSpec
 
-from galileo.constants import DEFAULT_LOG_STREAM_NAME, DEFAULT_PROJECT_NAME
 from galileo.logger import GalileoLogger
 from galileo.schema.datasets import DatasetRecord
 from galileo.schema.metrics import LocalMetricConfig
@@ -103,11 +101,6 @@ class GalileoDecorator:
     1. A function decorator via the `log` method
     2. A context manager via the `__call__` method
     """
-
-    def __init__(self):
-        # Get default values from environment variables
-        self.project_from_env = getenv("GALILEO_PROJECT", DEFAULT_PROJECT_NAME)
-        self.log_stream_from_env = getenv("GALILEO_LOG_STREAM", DEFAULT_LOG_STREAM_NAME)
 
     def __enter__(self) -> "GalileoDecorator":
         """
@@ -173,13 +166,13 @@ class GalileoDecorator:
         _trace_stack.get().append(_trace_context.get())
         _span_stack_stack.get().append(_span_stack_context.get().copy())
 
-        # Reset context values
+        # Reset trace context values
         _span_stack_context.set([])
         _trace_context.set(None)
 
-        # Set context values to environment defaults
-        _project_context.set(self.project_from_env)
-        _log_stream_context.set(self.log_stream_from_env)
+        # Set request context values to defaults
+        _project_context.set(None)
+        _log_stream_context.set(None)
         _experiment_id_context.set(None)
 
         # Override with explicitly provided values

--- a/tests/test_galileo_context.py
+++ b/tests/test_galileo_context.py
@@ -88,18 +88,18 @@ def test_context_update_with_defaults(
         # Second level context with only project updated; log_stream should be default
         with galileo_context(project="project2"):
             assert _project_context.get() == "project2"
-            assert _log_stream_context.get() == "test-log-stream"  # use env default
+            assert _log_stream_context.get() is None  # use env default
             assert _experiment_id_context.get() is None
 
             # Third level context with no params: should use defaults
             with galileo_context():
-                assert _project_context.get() == "test-project"
-                assert _log_stream_context.get() == "test-log-stream"
+                assert _project_context.get() is None
+                assert _log_stream_context.get() is None
                 assert _experiment_id_context.get() is None
 
             # After exiting third level, should restore second level context with default log_stream
             assert _project_context.get() == "project2"
-            assert _log_stream_context.get() == "test-log-stream"
+            assert _log_stream_context.get() is None
             assert _experiment_id_context.get() is None
 
         # After exiting second level, should be back to first level


### PR DESCRIPTION
The previous change (https://github.com/rungalileo/galileo-python/pull/126) was causing the project and log stream to get set to "default" in the decorator, and these values were being passed to the GalileoLogger init method. Project and Log Stream defaults should be set by GalileoLogger.