### PR TITLE
fix: creating empty dataset

### DIFF
--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -287,7 +287,10 @@ class Datasets(BaseClientModel):
             If the request takes longer than Client.timeout.
 
         """
-
+        if isinstance(content, (list, dict)) and len(content) == 0:
+            # we want to avoid errors: Invalid CSV data: CSV parse error:
+            # Empty CSV file or block: cannot infer number of columns
+            content = [{}]
         file_path, dataset_format = parse_dataset(content)
         file = File(
             payload=file_path.open("rb"),


### PR DESCRIPTION
This PR resolves issues with [creating empty datasets for example:](https://app.shortcut.com/galileo/story/28509/create-dataset-python-sdk-creating-empty-dataset-not-working)

🟢  OK
```
dataset = create_dataset(
   name = "countries",
   content=[],
)
```
🟢  OK

```
dataset = create_dataset(
   name = "countries",
   content={},
)
```

🔴 FAIL `ValueError`

```
dataset = create_dataset(
   name = "countries",
   content=None,
)
```