### PR TITLE
fix: langchain on_chain_start with_kwargs name and serialised is none

### DIFF
--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -262,7 +262,7 @@ class GalileoCallback(BaseCallbackHandler):
     ) -> Any:
         """Langchain callback when a chain starts."""
         node_type = "chain"
-        node_name = self._get_node_name(node_type, serialized)
+        node_name = self._get_node_name(node_type, serialized) if serialized else kwargs.get("name", "Chain")
 
         # If the `name` is `LangGraph` or `Agent`, set the node type to `agent`.
         if node_name in ["LangGraph", "Agent"]:


### PR DESCRIPTION
This PR fixes https://app.shortcut.com/galileo/story/31460/langgraph-tracing-metrics-don-t-work-properly

after https://github.com/rungalileo/galileo-python/pull/118/files

After this PR:

![image](https://github.com/user-attachments/assets/f25ac268-5fcb-4660-8784-1c03d9b00e5d)

Before this PR:

![image](https://github.com/user-attachments/assets/058d0894-1174-4985-b1c3-851ccc49b20c)
