### PR TITLE
fix: Making sure that created_at is set during node creation for Langchain

### DIFF
--- a/src/galileo/handlers/langchain/async_handler.py
+++ b/src/galileo/handlers/langchain/async_handler.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import UUID
 
@@ -109,6 +110,7 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
         name = node.span_params.get("name")
         metadata = node.span_params.get("metadata")
         tags = node.span_params.get("tags")
+        created_at = node.span_params.get("created_at")
 
         # Convert metadata to a dict[str, str]
         if metadata is not None:
@@ -123,6 +125,7 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
                 duration_ns=node.span_params.get("duration_ns"),
                 metadata=metadata,
                 tags=tags,
+                created_at=created_at,
             )
             is_workflow_span = True
         elif node.node_type in ("llm", "chat"):
@@ -140,6 +143,7 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
                 num_output_tokens=node.span_params.get("num_output_tokens"),
                 total_tokens=node.span_params.get("total_tokens"),
                 time_to_first_token_ns=node.span_params.get("time_to_first_token_ns"),
+                created_at=created_at,
             )
         elif node.node_type == "retriever":
             self._galileo_logger.add_retriever_span(
@@ -149,6 +153,7 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
                 duration_ns=node.span_params.get("duration_ns"),
                 metadata=metadata,
                 tags=tags,
+                created_at=created_at,
             )
         elif node.node_type == "tool":
             self._galileo_logger.add_tool_span(
@@ -158,6 +163,7 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
                 duration_ns=node.span_params.get("duration_ns"),
                 metadata=metadata,
                 tags=tags,
+                created_at=created_at,
             )
         else:
             _logger.warning(f"Unknown node type: {node.node_type}")
@@ -208,8 +214,12 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
         # Create new node
         node = Node(node_type=node_type, span_params=kwargs, run_id=run_id, parent_run_id=parent_run_id)
 
+        # start_time is used to calculate duration_ns
         if "start_time" not in node.span_params:
             node.span_params["start_time"] = time.perf_counter_ns()
+
+        if "created_at" not in node.span_params:
+            node.span_params["created_at"] = datetime.now(tz=timezone.utc)
 
         self._nodes[node_id] = node
 

--- a/tests/test_langchain_async.py
+++ b/tests/test_langchain_async.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from unittest.mock import MagicMock, Mock, patch
 
@@ -667,3 +668,60 @@ class TestGalileoAsyncCallback:
         assert traces[0].spans[0].spans[0].type == "retriever"
         assert traces[0].spans[0].spans[0].input == "test query"
         assert traces[0].spans[0].spans[0].output == [GalileoDocument(content="test document", metadata={})]
+
+    @mark.asyncio
+    async def test_node_created_at(self, callback: GalileoAsyncCallback, galileo_logger: GalileoLogger):
+        parent_id = uuid.uuid4()
+        llm_run_id = uuid.uuid4()
+        retriever_run_id = uuid.uuid4()
+
+        # Create parent chain
+        await callback.on_chain_start(serialized={}, inputs={"query": "test"}, run_id=parent_id)
+
+        # Start retriever
+        await callback.on_retriever_start(
+            serialized={}, query="AI development", run_id=retriever_run_id, parent_run_id=parent_id
+        )
+
+        # End retriever
+        document = Document(page_content="AI is advancing rapidly", metadata={"source": "textbook"})
+        await callback.on_retriever_end(documents=[document], run_id=retriever_run_id, parent_run_id=parent_id)
+
+        delay_ms = 500
+
+        await asyncio.sleep(delay_ms / 1000)
+
+        await callback.on_llm_start(
+            serialized={},
+            prompts=["Tell me about AI"],
+            run_id=llm_run_id,
+            parent_run_id=parent_id,
+            invocation_params={"model_name": "gpt-4", "temperature": 0.7},
+        )
+
+        # Add a token to test token timing
+        await callback.on_llm_new_token("AI", run_id=llm_run_id)
+
+        # End LLM
+        llm_response = MagicMock()
+        llm_response.generations = [[MagicMock()]]
+        llm_response.llm_output = {"token_usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}}
+
+        # Mock dict method on the generation
+        llm_response.generations[0][0].dict.return_value = {"text": "AI is a technology..."}
+
+        await callback.on_llm_end(response=llm_response, run_id=llm_run_id, parent_run_id=parent_id)
+
+        # End chain
+        await callback.on_chain_end(outputs='{"result": "test answer"}', run_id=parent_id)
+
+        traces = galileo_logger.traces
+        assert len(traces) == 1
+        assert len(traces[0].spans) == 1
+        assert len(traces[0].spans[0].spans) == 2
+
+        retriever_span = traces[0].spans[0].spans[0]
+        llm_span = traces[0].spans[0].spans[1]
+
+        time_diff_ms = (llm_span.created_at - retriever_span.created_at).total_seconds() * 1000
+        assert time_diff_ms >= delay_ms


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/32021/langgraph-provide-the-timestamp-at-which-each-span-starts-getting-executed