### PR TITLE
feat: Add a Langchain tool for Protect

### DIFF
--- a/src/galileo/handlers/langchain/tool.py
+++ b/src/galileo/handlers/langchain/tool.py
@@ -1,0 +1,83 @@
+from collections.abc import Sequence
+from typing import Optional
+
+from langchain_core.runnables.base import Runnable
+from langchain_core.tools import BaseTool
+from pydantic import UUID4, BaseModel, ConfigDict, Field
+
+from galileo.constants.protect import TIMEOUT
+from galileo.protect import invoke
+from galileo_core.schemas.protect.execution_status import ExecutionStatus
+from galileo_core.schemas.protect.payload import Payload as CorePayload
+from galileo_core.schemas.protect.response import Response
+from galileo_core.schemas.protect.ruleset import Ruleset
+
+
+class ProtectToolInputSchema(BaseModel):
+    input: Optional[str] = None
+    output: Optional[str] = None
+
+
+class ProtectTool(BaseTool):
+    name: str = "GalileoProtect"
+    description: str = (
+        "Protect your LLM applications from harmful content using Galileo Protect. "
+        "This tool is a wrapper around Galileo's Protect API, can be used to scan text "
+        "for harmful content, and can be used to trigger actions based on the results."
+        "The tool can be used synchronously or asynchronously, on the input text or output text,"
+        "and can be configured with a set of rulesets to evaluate on."
+    )
+    args_schema: type[BaseModel] = ProtectToolInputSchema
+
+    prioritized_rulesets: Optional[Sequence[Ruleset]] = None
+    project_id: Optional[UUID4] = None
+    project_name: Optional[str] = None
+    stage_name: Optional[str] = None
+    stage_id: Optional[UUID4] = None
+    stage_version: Optional[int] = None
+    timeout: float = TIMEOUT
+
+    def _run(self, input: Optional[str] = None, output: Optional[str] = None) -> str:
+        """
+        Apply the tool synchronously.
+
+        We serialize the response to JSON because that's what `langchain_core` expects
+        for tools.
+        """
+        api_payload = CorePayload(input=input, output=output)
+        api_response = invoke(
+            payload=api_payload,
+            prioritized_rulesets=self.prioritized_rulesets,
+            project_name=self.project_name,
+            project_id=self.project_id,
+            stage_name=self.stage_name,
+            stage_id=self.stage_id,
+            stage_version=self.stage_version,
+            timeout=self.timeout,
+        )
+        return api_response.model_dump_json()
+
+
+class ProtectParser(BaseModel):
+    chain: Runnable = Field(..., description="The chain to trigger if the Protect invocation is not triggered.")
+    ignore_trigger: bool = Field(
+        default=False,
+        description="Ignore the status of the Protect invocation and always trigger the rest of the chain.",
+    )
+    echo_output: bool = Field(default=False, description="Echo the output of the Protect invocation.")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def parser(self, response_raw_json: str) -> str:
+        try:
+            response = Response.model_validate_json(response_raw_json)
+        except Exception:
+            return self.chain.invoke(response_raw_json)
+        text = response.text
+
+        if self.echo_output:
+            print(f"> Raw response: {text}")
+        if response.status == ExecutionStatus.triggered and not self.ignore_trigger:
+            return text
+        else:
+            return self.chain.invoke(text)

--- a/tests/test_protect_parser.py
+++ b/tests/test_protect_parser.py
@@ -1,0 +1,85 @@
+from json import dumps
+from typing import Any, Optional
+from unittest.mock import patch
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.llms import LLM
+from pytest import CaptureFixture, mark
+
+from galileo.handlers.langchain.tool import ProtectParser
+
+A_TRACE_METADATA_DICT = {
+    "trace_metadata": {
+        "id": "57f7ec49-8e44-42cb-8825-4a971e44b252",
+        "received_at": 1717538501568372000,
+        "response_at": 1717538501568372000,
+        "execution_time": 0.46,
+    }
+}
+
+
+class ProtectLLM(LLM):
+    @property
+    def _llm_type(self) -> str:
+        return "protect"
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        return prompt
+
+
+@mark.parametrize(
+    ["output", "ignore_trigger", "expected_return", "expected_call_count"],
+    [
+        [dumps({"text": "foo", "status": "NOT_TRIGGERED", **A_TRACE_METADATA_DICT}), False, "foo", 1],
+        [dumps({"text": "foo", "status": "NOT_TRIGGERED", **A_TRACE_METADATA_DICT}), True, "foo", 1],
+        [dumps({"text": "timeout", "status": "TIMEOUT", **A_TRACE_METADATA_DICT}), False, "timeout", 1],
+        [dumps({"text": "timeout", "status": "TIMEOUT", **A_TRACE_METADATA_DICT}), True, "timeout", 1],
+        [
+            dumps({"text": "not_triggered", "status": "NOT_TRIGGERED", **A_TRACE_METADATA_DICT}),
+            False,
+            "not_triggered",
+            1,
+        ],
+        [
+            dumps({"text": "not_triggered", "status": "NOT_TRIGGERED", **A_TRACE_METADATA_DICT}),
+            True,
+            "not_triggered",
+            1,
+        ],
+        [
+            dumps({"text": "triggering text", "status": "TRIGGERED", **A_TRACE_METADATA_DICT}),
+            False,
+            "triggering text",
+            0,
+        ],
+        [
+            dumps({"text": "triggering text", "status": "TRIGGERED", **A_TRACE_METADATA_DICT}),
+            True,
+            "triggering text",
+            1,
+        ],
+    ],
+)
+def test_parser(output: str, ignore_trigger: bool, expected_return: str, expected_call_count: int) -> None:
+    # Verify that the ProtectParser invokes the ProtectLLM only if the status is not "TRIGGERED"
+    # and ignore_trigger is False.
+    parser = ProtectParser(chain=ProtectLLM(), ignore_trigger=ignore_trigger)
+    with patch.object(ProtectLLM, "invoke", wraps=parser.chain.invoke) as mock_fn:
+        return_value = parser.parser(output)
+        assert return_value == expected_return
+        assert mock_fn.call_count == expected_call_count
+
+
+@mark.parametrize(["echo_output", "expected_output"], [[True, "> Raw response: foo\n"], [False, ""]])
+def test_echo(echo_output: bool, expected_output: str, capsys: CaptureFixture) -> None:
+    """Verify that the ProtectParser echoes the output if echo_output is True."""
+    parser = ProtectParser(chain=ProtectLLM(), echo_output=echo_output)
+    parser.parser(dumps({"text": "foo", "status": "NOT_TRIGGERED", **A_TRACE_METADATA_DICT}))
+    captured = capsys.readouterr()
+    assert captured.out == expected_output


### PR DESCRIPTION
**Shortcut**: https://app.shortcut.com/galileo/story/30923/add-the-protect-tool-to-the-2-0-python-sdk

Just a separate PR to make the review easier that adds a custom Langchain tool for Protect calls that allows Protect data to appear under Traces in the UI.

Added support for `stage_version` which wasn't in the Protect 1.0 SDK

(I'll merge this into my other PR manually)