### PR TITLE
fix: removing failiing delete call that's not needed

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -55,8 +55,7 @@ jobs:
       - name: Update SDK docs
         run: |
           rm -rf ./docs-official/sdk-api/python/reference
-          rm ./galileo-python/.generated_docs/reference/**/sidebar.json
-          rm ./galileo-python/.generated_docs/reference/**/__init__.mdx
+          rm -f ./galileo-python/.generated_docs/reference/**/sidebar.json
           cp -r ./galileo-python/.generated_docs/reference ./docs-official/sdk-api/python/
 
       # Commit the changes to the branch, and push


### PR DESCRIPTION
Running this action in GH fails as the `__init__.mdx` files are now removed by a clean up step. Removing this delete.