### PR TITLE
fix: Fixed langchain handler to include parent info in agent node names

### DIFF
--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -258,6 +258,8 @@ class GalileoCallback(BaseCallbackHandler):
         if parent_run_id:
             parent = self._nodes.get(parent_node_id)
             if parent:
+                if node.node_type == "agent":
+                    node.span_params["name"] = parent.span_params["name"] + ":" + node.span_params["name"]
                 parent.children.append(node_id)
             else:
                 _logger.debug(f"Parent node {parent_node_id} not found for {node_id}")
@@ -323,6 +325,10 @@ class GalileoCallback(BaseCallbackHandler):
         **kwargs: Any,
     ) -> Any:
         """Langchain callback when a chain starts."""
+        # If the node is tagged with `hidden`, don't log it.
+        if tags and "langsmith:hidden" in tags:
+            return
+
         node_type = "chain"
         node_name = self._get_node_name(node_type, serialized) if serialized else kwargs.get("name", "Chain")
 
@@ -332,10 +338,6 @@ class GalileoCallback(BaseCallbackHandler):
             node_name = "Agent"
 
         kwargs["name"] = node_name
-
-        # If the node is tagged with `hidden`, don't log it.
-        if tags and "langsmith:hidden" in tags:
-            return
 
         self._start_node(node_type, parent_run_id, run_id, input=serialize_to_str(inputs), tags=tags, **kwargs)
 

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -851,3 +851,33 @@ class TestGalileoCallback:
             root_span = traces[0].spans[0]
             assert root_span.type == expected_type
             assert root_span.step_number == step_number
+
+    def test_on_nested_agent_chains(self, callback: GalileoCallback, galileo_logger: GalileoLogger):
+        """Test nested agent chain handling and name change"""
+        outer_run_id = uuid.uuid4()
+        inner_run_id = uuid.uuid4()
+
+        # Start outer agent chain, then inner agent chain
+        callback.on_chain_start(serialized={"name": "OuterChain"}, inputs={"input": "outer input"}, run_id=outer_run_id)
+        callback.on_chain_start(
+            serialized={"name": "LangGraph"},
+            inputs={"input": "inner input"},
+            run_id=inner_run_id,
+            parent_run_id=outer_run_id,
+        )
+
+        # End inner agent chain, then outer agent chain
+        inner_finish = AgentFinish(return_values={"output": "inner result"}, log="inner log")
+        callback.on_agent_finish(finish=inner_finish, run_id=inner_run_id)
+        callback.on_chain_end(outputs={"output": "outer result"}, run_id=outer_run_id)
+
+        traces = galileo_logger.traces
+        assert len(traces) == 1
+        assert len(traces[0].spans) == 1
+        outer_span = traces[0].spans[0]
+        assert outer_span.type == "workflow"
+        assert outer_span.name == "OuterChain"
+        assert len(outer_span.spans) == 1
+        inner_span = outer_span.spans[0]
+        assert inner_span.type == "agent"
+        assert inner_span.name == "OuterChain:Agent"


### PR DESCRIPTION
<img width="1272" alt="Screenshot 2025-07-03 at 1 54 25 PM" src="https://github.com/user-attachments/assets/987eb785-ad53-4e09-b269-0054d8d52174" />

With this change - the Aggregated Graph view distinguishes the two agents separately