### PR TITLE
fix: Correctly associate datasets when logging experiments

### DIFF
--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -46,8 +46,11 @@ class ExperimentCreateRequest:
 
 
 class Experiments(BaseClientModel):
-    def create(self, project_id: str, name: str) -> ExperimentResponse:
+    def create(self, project_id: str, name: str, dataset_obj: Dataset | None = None) -> ExperimentResponse:
         body = ExperimentCreateRequest(name=name, task_type=EXPERIMENT_TASK_TYPE)
+        if dataset_obj is not None:
+            dataset = {"dataset_id": dataset_obj.dataset.id, "version_index": dataset_obj.dataset.current_version_index}
+            body.additional_properties["dataset"] = dataset
 
         experiment = create_experiment_projects_project_id_experiments_post.sync(
             project_id=project_id,
@@ -298,7 +301,7 @@ def run_experiment(
         #       .replace('Z', '');
         experiment_name = f"{existing_experiment.name} {now:%Y-%m-%d} at {now:%H:%M:%S}.{now.microsecond // 1000:03d}"
 
-    experiment_obj = Experiments().create(project_obj.id, experiment_name)
+    experiment_obj = Experiments().create(project_obj.id, experiment_name, dataset_obj)
 
     # Set up metrics if provided
     scorer_settings: Optional[list[ScorerConfig]] = None

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -273,7 +273,7 @@ class TestExperiments:
         mock_get_project.assert_called_once_with(name="awesome-new-project")
         mock_get_experiment.assert_called_once_with(project().id, "test_experiment")
         mock_create_experiment.assert_called_once_with(
-            project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000"
+            project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000", mock_get_dataset.return_value
         )
         mock_get_dataset.assert_called_once_with(id="00000000-0000-0000-0000-000000000000", name=None)
         mock_get_dataset_instance.get_content.assert_called()
@@ -402,7 +402,7 @@ class TestExperiments:
         assert f"/project/{project().id}/experiments/{experiment_response().id}" in result["link"]
         mock_get_project.assert_called_with(name="awesome-new-project")
         mock_get_experiment.assert_called_once_with("00000000-0000-0000-0000-000000000000", "test_experiment")
-        mock_create_experiment.assert_called_once_with("00000000-0000-0000-0000-000000000000", ANY)
+        mock_create_experiment.assert_called_once_with("00000000-0000-0000-0000-000000000000", ANY, mock_get_dataset.return_value)
 
         mock_get_dataset.assert_called_once_with(id="00000000-0000-4000-8000-000000000000", name=None)
         mock_get_dataset_instance.get_content.assert_called()
@@ -478,7 +478,7 @@ class TestExperiments:
         mock_get_project.assert_called_once_with(name="awesome-new-project")
         mock_get_experiment.assert_called_once_with(project().id, "test_experiment")
         mock_create_experiment.assert_called_once_with(
-            project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000"
+            project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000", mock_get_dataset.return_value
         )
         mock_get_dataset.assert_called_once_with(id="00000000-0000-0000-0000-000000000000", name=None)
         mock_get_dataset_instance.get_content.assert_called()
@@ -522,7 +522,7 @@ class TestExperiments:
         mock_get_project.assert_called_once_with(name="awesome-new-project")
         mock_get_experiment.assert_called_once_with(project().id, "test_experiment")
         mock_create_experiment.assert_called_once_with(
-            project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000"
+            project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000", mock_get_dataset.return_value
         )
 
         mock_get_dataset.assert_called_once_with(id="00000000-0000-0000-0000-000000000000", name=None)
@@ -582,7 +582,7 @@ class TestExperiments:
 
         mock_get_project.assert_called_with(name="awesome-new-project")
         mock_get_experiment.assert_called_once_with("00000000-0000-0000-0000-000000000000", "test_experiment")
-        mock_create_experiment.assert_called_once_with("00000000-0000-0000-0000-000000000000", ANY)
+        mock_create_experiment.assert_called_once_with("00000000-0000-0000-0000-000000000000", ANY, mock_get_dataset.return_value)
 
         mock_get_dataset.assert_called_once_with(id="00000000-0000-0000-0000-000000000000", name=None)
         mock_get_dataset_instance.get_content.assert_called()


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/35595/experiments-a-b-comparison-not-working