### PR TITLE
fix: Make langchain callbacks produce data closer to our schema's intentions

### DIFF
--- a/src/galileo/__init__.py
+++ b/src/galileo/__init__.py
@@ -2,44 +2,6 @@
 
 # flake8: noqa: F401
 # ruff: noqa: F401
-from typing import Any, Dict
-from pydantic import ValidationError
-from json import dumps
-
-import galileo_core.schemas.logging.llm
-import galileo_core.schemas.logging.span
-
-
-def _convert_dict_to_message(
-    value: Dict[str, Any], default_role: galileo_core.schemas.logging.llm.MessageRole = galileo_core.schemas.logging.llm.MessageRole.user
-) -> galileo_core.schemas.logging.llm.Message:
-    """
-    Converts a dict into a Message object.
-    Will dump the dict to a json string if it unable to be deserialized into a Message object.
-
-    Args:
-        value (Dict[str, Any]): The dict to convert.
-        default_role (Optional[MessageRole], optional): The role to use if the dict does not contain a role. Defaults to MessageRole.user.
-
-    Returns:
-        Message: The converted Message object.
-    """
-    print(f"Converting dict to message: {value}")
-    try:
-        ret = galileo_core.schemas.logging.llm.Message.model_validate(value)
-        # print(f"success, returning {ret}")
-        return ret
-    except ValidationError as e:
-        print(f"message validation error, value: {value}")
-        raise e
-    # try:
-    #     return galileo_core.schemas.logging.llm.Message.model_validate(value)
-    # except ValidationError:
-    #     return galileo_core.schemas.logging.llm.Message(content=dumps(value), role=default_role)
-
-galileo_core.schemas.logging.span.LlmSpan._convert_dict_to_message = _convert_dict_to_message
-
-
 from galileo.decorator import GalileoDecorator, galileo_context, log
 from galileo.logger import GalileoLogger
 from galileo.schema.message import Message

--- a/src/galileo/__init__.py
+++ b/src/galileo/__init__.py
@@ -2,6 +2,7 @@
 
 # flake8: noqa: F401
 # ruff: noqa: F401
+
 from galileo.decorator import GalileoDecorator, galileo_context, log
 from galileo.logger import GalileoLogger
 from galileo.schema.message import Message

--- a/src/galileo/__init__.py
+++ b/src/galileo/__init__.py
@@ -2,6 +2,43 @@
 
 # flake8: noqa: F401
 # ruff: noqa: F401
+from typing import Any, Dict
+from pydantic import ValidationError
+from json import dumps
+
+import galileo_core.schemas.logging.llm
+import galileo_core.schemas.logging.span
+
+
+def _convert_dict_to_message(
+    value: Dict[str, Any], default_role: galileo_core.schemas.logging.llm.MessageRole = galileo_core.schemas.logging.llm.MessageRole.user
+) -> galileo_core.schemas.logging.llm.Message:
+    """
+    Converts a dict into a Message object.
+    Will dump the dict to a json string if it unable to be deserialized into a Message object.
+
+    Args:
+        value (Dict[str, Any]): The dict to convert.
+        default_role (Optional[MessageRole], optional): The role to use if the dict does not contain a role. Defaults to MessageRole.user.
+
+    Returns:
+        Message: The converted Message object.
+    """
+    print(f"Converting dict to message: {value}")
+    try:
+        ret = galileo_core.schemas.logging.llm.Message.model_validate(value)
+        # print(f"success, returning {ret}")
+        return ret
+    except ValidationError as e:
+        print(f"message validation error, value: {value}")
+        raise e
+    # try:
+    #     return galileo_core.schemas.logging.llm.Message.model_validate(value)
+    # except ValidationError:
+    #     return galileo_core.schemas.logging.llm.Message(content=dumps(value), role=default_role)
+
+galileo_core.schemas.logging.span.LlmSpan._convert_dict_to_message = _convert_dict_to_message
+
 
 from galileo.decorator import GalileoDecorator, galileo_context, log
 from galileo.logger import GalileoLogger

--- a/src/galileo/handlers/langchain/async_handler.py
+++ b/src/galileo/handlers/langchain/async_handler.py
@@ -474,7 +474,11 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
             return obj
         if hasattr(obj, "update") and isinstance(obj.update, dict) and "messages" in obj.update:
             update_messages = obj.update["messages"]
-            if isinstance(update_messages, list) and len(update_messages) > 0 and isinstance(update_messages[-1], ToolMessage):
+            if (
+                isinstance(update_messages, list)
+                and len(update_messages) > 0
+                and isinstance(update_messages[-1], ToolMessage)
+            ):
                 return update_messages[-1]
         return None
 

--- a/src/galileo/handlers/langchain/async_handler.py
+++ b/src/galileo/handlers/langchain/async_handler.py
@@ -473,15 +473,15 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
         """
         Look for a ToolMessage in the output passed to langchain's on_tool_end callback.
         If found, return the ToolMessage. Otherwise, return None.
-        
+
         Can return a ToolMessage in two cases:
         1. The output is already a ToolMessage.
         2. The output is a Command object with a ToolMessage in its update list.
-        
+
         As of this writing, Command and ToolMessage are the only Langchain/Langgraph
         classes inheriting from ToolOutputMixin. And Langchain is supposed to convert
         any tool output **not** inheriting from ToolOutputMixin to a ToolMessage.
-        
+
         So this should cover all cases. Either:
 
         - the output is a Command (converted to ToolMessage here),

--- a/src/galileo/handlers/langchain/async_handler.py
+++ b/src/galileo/handlers/langchain/async_handler.py
@@ -14,7 +14,7 @@ from galileo.utils.serialization import EventSerializer, convert_to_string_dict,
 _logger = logging.getLogger(__name__)
 
 try:
-    from langchain_core.agents import AgentAction, AgentFinish
+    from langchain_core.agents import AgentFinish
     from langchain_core.callbacks.base import AsyncCallbackHandler
     from langchain_core.documents import Document
     from langchain_core.messages import BaseMessage, ToolMessage
@@ -23,7 +23,6 @@ except ImportError:
     _logger.warning("Failed to import langchain, using stubs")
     AsyncCallbackHandler = object
     Document = object
-    AgentAction = object
     BaseMessage = object
     LLMResult = object
     AgentFinish = object

--- a/src/galileo/handlers/langchain/async_handler.py
+++ b/src/galileo/handlers/langchain/async_handler.py
@@ -470,6 +470,23 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
 
     @staticmethod
     def _find_tool_message(obj: Any) -> Optional[ToolMessage]:
+        """
+        Look for a ToolMessage in the output passed to langchain's on_tool_end callback.
+        If found, return the ToolMessage. Otherwise, return None.
+        
+        Can return a ToolMessage in two cases:
+        1. The output is already a ToolMessage.
+        2. The output is a Command object with a ToolMessage in its update list.
+        
+        As of this writing, Command and ToolMessage are the only Langchain/Langgraph
+        classes inheriting from ToolOutputMixin. And Langchain is supposed to convert
+        any tool output **not** inheriting from ToolOutputMixin to a ToolMessage.
+        
+        So this should cover all cases. Either:
+
+        - the output is a Command (converted to ToolMessage here),
+        - or Langchain will force it to be a ToolMessage before passing it to us.
+        """
         if isinstance(obj, ToolMessage):
             return obj
         if hasattr(obj, "update") and isinstance(obj.update, dict) and "messages" in obj.update:

--- a/src/galileo/handlers/langchain/async_handler.py
+++ b/src/galileo/handlers/langchain/async_handler.py
@@ -392,8 +392,6 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
         **kwargs: Any,
     ) -> Any:
         """Langchain callback when a chat model starts."""
-        # print(f"on_chat_model_start serialized: {type(serialized)}, {serialized}")
-        # print(f"on_chat_model_start messages: {type(messages)}, {messages}")
         node_type = "chat"
         node_name = GalileoCallback._get_node_name(node_type, serialized)
         invocation_params = kwargs.get("invocation_params", {})
@@ -403,14 +401,8 @@ class GalileoAsyncCallback(AsyncCallbackHandler):
 
         # Serialize messages safely
         try:
-            for batch in messages:
-                for message in batch:
-                    print(type(message))
-            # flattened_messages = [message.model_dump() for batch in messages for message in batch]
             flattened_messages = [message for batch in messages for message in batch]
-            prepped_messages = flattened_messages
-            _logger.info(f"Messages before serialization: {prepped_messages}")
-            serialized_messages = json.loads(json.dumps(prepped_messages, cls=EventSerializer))
+            serialized_messages = json.loads(json.dumps(flattened_messages, cls=EventSerializer))
         except Exception as e:
             _logger.warning(f"Failed to serialize chat messages: {e}")
             serialized_messages = str(messages)

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -487,6 +487,23 @@ class GalileoCallback(BaseCallbackHandler):
 
     @staticmethod
     def _find_tool_message(obj: Any) -> Optional[ToolMessage]:
+        """
+        Look for a ToolMessage in the output passed to langchain's on_tool_end callback.
+        If found, return the ToolMessage. Otherwise, return None.
+        
+        Can return a ToolMessage in two cases:
+        1. The output is already a ToolMessage.
+        2. The output is a Command object with a ToolMessage in its update list.
+        
+        As of this writing, Command and ToolMessage are the only Langchain/Langgraph
+        classes inheriting from ToolOutputMixin. And Langchain is supposed to convert
+        any tool output **not** inheriting from ToolOutputMixin to a ToolMessage.
+        
+        So this should cover all cases. Either:
+
+        - the output is a Command (converted to ToolMessage here),
+        - or Langchain will force it to be a ToolMessage before passing it to us.
+        """
         if isinstance(obj, ToolMessage):
             return obj
         if hasattr(obj, "update") and isinstance(obj.update, dict) and "messages" in obj.update:

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -189,6 +189,7 @@ class GalileoCallback(BaseCallbackHandler):
                 tags=tags,
                 created_at=created_at,
                 step_number=step_number,
+                tool_call_id=node.span_params.get("tool_call_id"),
             )
         else:
             _logger.warning(f"Unknown node type: {node.node_type}")

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -419,11 +419,14 @@ class GalileoCallback(BaseCallbackHandler):
 
         # Serialize messages safely
         try:
-            flattened_messages = [message.model_dump() for batch in messages for message in batch]
+            # flattened_messages = [message.model_dump() for batch in messages for message in batch]
+            flattened_messages = [message for batch in messages for message in batch]
+            _logger.info(f"Messages before serialization: {flattened_messages}")
             serialized_messages = json.loads(json.dumps(flattened_messages, cls=EventSerializer))
         except Exception as e:
             _logger.warning(f"Failed to serialize chat messages: {e}")
             serialized_messages = str(messages)
+        _logger.info(f"Messages after serialization: {serialized_messages}")
 
         self._start_node(
             node_type,
@@ -446,7 +449,8 @@ class GalileoCallback(BaseCallbackHandler):
         token_usage = response.llm_output.get("token_usage", {}) if response.llm_output else {}
 
         try:
-            flattened_messages = [message.model_dump() for batch in response.generations for message in batch]
+            # flattened_messages = [message.model_dump() for batch in response.generations for message in batch]
+            flattened_messages = [message for batch in response.generations for message in batch]
             output = json.loads(json.dumps(flattened_messages[0], cls=EventSerializer))
         except Exception as e:
             _logger.warning(f"Failed to serialize LLM output: {e}")

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -313,10 +313,10 @@ class GalileoCallback(BaseCallbackHandler):
             elif node_class_reference and isinstance(node_class_reference, list):
                 return node_class_reference[-1]
             elif isinstance(kwargs, dict):
-                if (kwargs_name := kwargs.get("name")):
+                if kwargs_name := kwargs.get("name"):
                     return kwargs_name
                 if "metadata" in kwargs and isinstance(kwargs["metadata"], dict):
-                    if (metadata_name := kwargs["metadata"].get("name")):
+                    if metadata_name := kwargs["metadata"].get("name"):
                         return metadata_name
             return node_type.capitalize()
         except Exception as e:

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -14,20 +14,19 @@ from galileo.utils.serialization import EventSerializer, convert_to_string_dict,
 _logger = logging.getLogger(__name__)
 
 try:
-    from langchain_core.agents import AgentAction, AgentFinish
+    from langchain_core.agents import AgentFinish
     from langchain_core.callbacks.base import BaseCallbackHandler
     from langchain_core.documents import Document
-    from langchain_core.messages import BaseMessage
+    from langchain_core.messages import BaseMessage, ToolMessage
     from langchain_core.outputs import LLMResult
 except ImportError:
     _logger.warning("Failed to import langchain, using stubs")
     BaseCallbackHandler = object
     Document = object
-    AgentAction = object
     BaseMessage = object
     LLMResult = object
     AgentFinish = object
-
+    ToolMessage = object
 
 _root_node: contextvars.ContextVar[Optional[Node]] = contextvars.ContextVar("langchain_root_node", default=None)
 
@@ -419,14 +418,11 @@ class GalileoCallback(BaseCallbackHandler):
 
         # Serialize messages safely
         try:
-            # flattened_messages = [message.model_dump() for batch in messages for message in batch]
             flattened_messages = [message for batch in messages for message in batch]
-            _logger.info(f"Messages before serialization: {flattened_messages}")
             serialized_messages = json.loads(json.dumps(flattened_messages, cls=EventSerializer))
         except Exception as e:
             _logger.warning(f"Failed to serialize chat messages: {e}")
             serialized_messages = str(messages)
-        _logger.info(f"Messages after serialization: {serialized_messages}")
 
         self._start_node(
             node_type,
@@ -449,7 +445,6 @@ class GalileoCallback(BaseCallbackHandler):
         token_usage = response.llm_output.get("token_usage", {}) if response.llm_output else {}
 
         try:
-            # flattened_messages = [message.model_dump() for batch in response.generations for message in batch]
             flattened_messages = [message for batch in response.generations for message in batch]
             output = json.loads(json.dumps(flattened_messages[0], cls=EventSerializer))
         except Exception as e:
@@ -478,6 +473,8 @@ class GalileoCallback(BaseCallbackHandler):
         """Langchain callback when a tool node starts."""
         node_type = "tool"
         node_name = self._get_node_name(node_type, serialized)
+        if "inputs" in kwargs and isinstance(kwargs["inputs"], dict):
+            input_str = json.dumps(kwargs["inputs"], cls=EventSerializer)
         self._start_node(
             node_type,
             parent_run_id,
@@ -488,15 +485,25 @@ class GalileoCallback(BaseCallbackHandler):
             metadata={k: str(v) for k, v in metadata.items()} if metadata else None,
         )
 
+    @staticmethod
+    def _find_tool_message(obj: Any) -> Optional[ToolMessage]:
+        if isinstance(obj, ToolMessage):
+            return obj
+        if hasattr(obj, "update") and isinstance(obj.update, dict) and "messages" in obj.update:
+            update_messages = obj.update["messages"]
+            if isinstance(update_messages, list) and len(update_messages) > 0 and isinstance(update_messages[-1], ToolMessage):
+                return update_messages[-1]
+        return None
+
     def on_tool_end(self, output: Any, *, run_id: UUID, parent_run_id: Optional[UUID] = None, **kwargs: Any) -> Any:
         """Langchain callback when a tool node ends."""
-        if isinstance(output, dict) and "content" in output:
-            output = serialize_to_str(output["content"])
-        elif hasattr(output, "content"):
-            output = serialize_to_str(output.content)
+        end_node_kwargs = {}
+        if (tool_message := self._find_tool_message(output)) is not None:
+            end_node_kwargs["output"] = json.dumps(tool_message.content, cls=EventSerializer)
+            end_node_kwargs["tool_call_id"] = tool_message.tool_call_id
         else:
-            output = serialize_to_str(output)
-        self._end_node(run_id, output=output)
+            end_node_kwargs["output"] = json.dumps(output, cls=EventSerializer)
+        self._end_node(run_id, **end_node_kwargs)
 
     def on_retriever_start(
         self,

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -491,7 +491,11 @@ class GalileoCallback(BaseCallbackHandler):
             return obj
         if hasattr(obj, "update") and isinstance(obj.update, dict) and "messages" in obj.update:
             update_messages = obj.update["messages"]
-            if isinstance(update_messages, list) and len(update_messages) > 0 and isinstance(update_messages[-1], ToolMessage):
+            if (
+                isinstance(update_messages, list)
+                and len(update_messages) > 0
+                and isinstance(update_messages[-1], ToolMessage)
+            ):
                 return update_messages[-1]
         return None
 

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -295,7 +295,11 @@ class GalileoCallback(BaseCallbackHandler):
             self._commit()
 
     @staticmethod
-    def _get_node_name(node_type: LANGCHAIN_NODE_TYPE, serialized: Optional[dict[str, Any]] = None) -> str:
+    def _get_node_name(
+        node_type: LANGCHAIN_NODE_TYPE,
+        serialized: Optional[dict[str, Any]] = None,
+        kwargs: Optional[dict[str, Any]] = None,
+    ) -> str:
         try:
             node_name = None
             node_class_reference = None
@@ -308,6 +312,12 @@ class GalileoCallback(BaseCallbackHandler):
                 return node_name
             elif node_class_reference and isinstance(node_class_reference, list):
                 return node_class_reference[-1]
+            elif isinstance(kwargs, dict):
+                if (kwargs_name := kwargs.get("name")) is not None:
+                    return kwargs_name
+                if "metadata" in kwargs and isinstance(kwargs["metadata"], dict):
+                    if (metadata_name := kwargs["metadata"].get("name")) is not None:
+                        return metadata_name
             else:
                 return node_type.capitalize()
         except Exception as e:
@@ -330,7 +340,7 @@ class GalileoCallback(BaseCallbackHandler):
             return
 
         node_type = "chain"
-        node_name = self._get_node_name(node_type, serialized) if serialized else kwargs.get("name", "Chain")
+        node_name = self._get_node_name(node_type, serialized, kwargs)
 
         # If the `name` is `LangGraph` or `Agent`, set the node type to `agent`.
         if node_name in ["LangGraph", "Agent"]:
@@ -368,7 +378,7 @@ class GalileoCallback(BaseCallbackHandler):
         Note: This callback is only used for non-chat models.
         """
         node_type = "llm"
-        node_name = self._get_node_name(node_type, serialized)
+        node_name = self._get_node_name(node_type, serialized, kwargs)
         invocation_params = kwargs.get("invocation_params", {})
         model = invocation_params.get("model_name", "")
         temperature = invocation_params.get("temperature", 0.0)
@@ -411,7 +421,7 @@ class GalileoCallback(BaseCallbackHandler):
     ) -> Any:
         """Langchain callback when a chat model starts."""
         node_type = "chat"
-        node_name = self._get_node_name(node_type, serialized)
+        node_name = self._get_node_name(node_type, serialized, kwargs)
         invocation_params = kwargs.get("invocation_params", {})
         model = invocation_params.get("model", invocation_params.get("_type", "undefined-type"))
         temperature = invocation_params.get("temperature", 0.0)
@@ -473,7 +483,7 @@ class GalileoCallback(BaseCallbackHandler):
     ) -> Any:
         """Langchain callback when a tool node starts."""
         node_type = "tool"
-        node_name = self._get_node_name(node_type, serialized)
+        node_name = self._get_node_name(node_type, serialized, kwargs)
         if "inputs" in kwargs and isinstance(kwargs["inputs"], dict):
             input_str = json.dumps(kwargs["inputs"], cls=EventSerializer)
         self._start_node(
@@ -547,7 +557,7 @@ class GalileoCallback(BaseCallbackHandler):
     ) -> Any:
         """Langchain callback when a retriever node starts."""
         node_type = "retriever"
-        node_name = self._get_node_name(node_type, serialized)
+        node_name = self._get_node_name(node_type, serialized, kwargs)
         self._start_node(
             node_type,
             parent_run_id,

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -313,13 +313,12 @@ class GalileoCallback(BaseCallbackHandler):
             elif node_class_reference and isinstance(node_class_reference, list):
                 return node_class_reference[-1]
             elif isinstance(kwargs, dict):
-                if (kwargs_name := kwargs.get("name")) is not None:
+                if (kwargs_name := kwargs.get("name")):
                     return kwargs_name
                 if "metadata" in kwargs and isinstance(kwargs["metadata"], dict):
-                    if (metadata_name := kwargs["metadata"].get("name")) is not None:
+                    if (metadata_name := kwargs["metadata"].get("name")):
                         return metadata_name
-            else:
-                return node_type.capitalize()
+            return node_type.capitalize()
         except Exception as e:
             _logger.error(f"Failed to get node name: {e}")
             return node_type.capitalize()

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -491,15 +491,15 @@ class GalileoCallback(BaseCallbackHandler):
         """
         Look for a ToolMessage in the output passed to langchain's on_tool_end callback.
         If found, return the ToolMessage. Otherwise, return None.
-        
+
         Can return a ToolMessage in two cases:
         1. The output is already a ToolMessage.
         2. The output is a Command object with a ToolMessage in its update list.
-        
+
         As of this writing, Command and ToolMessage are the only Langchain/Langgraph
         classes inheriting from ToolOutputMixin. And Langchain is supposed to convert
         any tool output **not** inheriting from ToolOutputMixin to a ToolMessage.
-        
+
         So this should cover all cases. Either:
 
         - the output is a Command (converted to ToolMessage here),

--- a/src/galileo/handlers/langchain/handler.py
+++ b/src/galileo/handlers/langchain/handler.py
@@ -521,10 +521,17 @@ class GalileoCallback(BaseCallbackHandler):
         """Langchain callback when a tool node ends."""
         end_node_kwargs = {}
         if (tool_message := self._find_tool_message(output)) is not None:
-            end_node_kwargs["output"] = json.dumps(tool_message.content, cls=EventSerializer)
+            end_node_kwargs["output"] = tool_message.content
             end_node_kwargs["tool_call_id"] = tool_message.tool_call_id
         else:
-            end_node_kwargs["output"] = json.dumps(output, cls=EventSerializer)
+            end_node_kwargs["output"] = output
+        # This will pass-through strings like 'blah' without encoding them
+        # into '"blah"', but will turn everything else into a JSON string.
+        end_node_kwargs["output"] = (
+            end_node_kwargs["output"]
+            if isinstance(end_node_kwargs["output"], str)
+            else json.dumps(end_node_kwargs["output"], cls=EventSerializer)
+        )
         self._end_node(run_id, **end_node_kwargs)
 
     def on_retriever_start(

--- a/src/galileo/utils/serialization.py
+++ b/src/galileo/utils/serialization.py
@@ -44,10 +44,7 @@ def serialize_datetime(v: dt.datetime) -> str:
 
 
 def map_langchain_role(role: str) -> str:
-    role_map = {
-        "ai": "assistant",
-        "human": "user",
-    }
+    role_map = {"ai": "assistant", "human": "user"}
     return role_map.get(role, role)
 
 
@@ -90,9 +87,8 @@ class EventSerializer(JSONEncoder):
                 return str(obj)
 
             if is_langchain_available:
-                from langchain_core.load.serializable import Serializable
-
                 from langchain_core.agents import AgentAction, AgentFinish
+                from langchain_core.load.serializable import Serializable
                 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage
                 from langchain_core.outputs import ChatGeneration, LLMResult
                 from langchain_core.prompt_values import ChatPromptValue

--- a/src/galileo/utils/serialization.py
+++ b/src/galileo/utils/serialization.py
@@ -96,17 +96,8 @@ class EventSerializer(JSONEncoder):
                 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage
                 from langchain_core.outputs import ChatGeneration, LLMResult
                 from langchain_core.prompt_values import ChatPromptValue
-                from langgraph.types import Command
 
-                if isinstance(obj, Command):
-                    print(f"Command: {obj}")
-                    if isinstance(obj.update, dict) and "messages" in obj.update:
-                        update_messages = obj.update["messages"]
-                        if isinstance(update_messages, list) and len(update_messages) > 0 and isinstance(update_messages[-1], ToolMessage):
-                            update_messages[-1].tool_call_id = obj.id
-                        obj.update["messages"] = update_messages
-                    return self.default(obj.model_dump(mode="json", exclude_none=True, exclude_unset=True, exclude_defaults=True))
-                elif isinstance(obj, (AgentFinish, AgentAction, ChatPromptValue)):
+                if isinstance(obj, (AgentFinish, AgentAction, ChatPromptValue)):
                     print(f"AgentFinish, AgentAction, ChatPromptValue: {obj}")
                     return self.default(obj.messages)
                 elif isinstance(obj, ChatGeneration):

--- a/src/galileo/utils/serialization.py
+++ b/src/galileo/utils/serialization.py
@@ -146,25 +146,20 @@ class EventSerializer(JSONEncoder):
                 return list(obj)
 
             if isinstance(obj, dict):
-                # print(f"dict: {type(obj)}")
                 return {self.default(k): self.default(v) for k, v in obj.items()}
 
             if isinstance(obj, list):
-                # print(f"list: {type(obj)}")
                 return [self.default(item) for item in obj]
 
             # Important: this needs to be always checked after str and bytes types
             # Useful for serializing protobuf messages
             if isinstance(obj, Sequence):
-                # print(f"Sequence: {type(obj)}")
                 return [self.default(item) for item in obj]
 
             if hasattr(obj, "__slots__") and len(obj.__slots__) > 0:
-                # print(f"__slots__: {type(obj)}")
                 return self.default({slot: getattr(obj, slot, None) for slot in obj.__slots__})
 
             elif hasattr(obj, "__dict__"):
-                # print(f"__dict__: {type(obj)}")
                 obj_id = id(obj)
 
                 if obj_id in self.seen:
@@ -181,8 +176,7 @@ class EventSerializer(JSONEncoder):
                 # Return object type rather than JSONEncoder.default(obj) which simply raises a TypeError
                 return f"<{type(obj).__name__}>"
 
-        except Exception as e:
-            print(f"Serialization failed for object of type {type(obj).__name__}: {e}")
+        except Exception:
             _logger.warning(f"Serialization failed for object of type {type(obj).__name__}")
             return f'"<not serializable object of type: {type(obj).__name__}>"'
 

--- a/src/galileo/utils/serialization.py
+++ b/src/galileo/utils/serialization.py
@@ -92,6 +92,7 @@ class EventSerializer(JSONEncoder):
                 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage
                 from langchain_core.outputs import ChatGeneration, LLMResult
                 from langchain_core.prompt_values import ChatPromptValue
+                from langchain_core.documents import Document as LangchainDocument
 
                 if isinstance(obj, (AgentFinish, AgentAction, ChatPromptValue)):
                     return self.default(obj.messages)
@@ -117,6 +118,9 @@ class EventSerializer(JSONEncoder):
                     dumped = obj.model_dump(include={"content", "type"})
                     dumped["role"] = map_langchain_role(dumped.pop("type"))
                     return self.default(dumped)
+
+                if isinstance(obj, LangchainDocument):
+                    return self.default(obj.model_dump(include={"page_content", "metadata"}))
 
                 if isinstance(obj, Serializable):
                     ret = obj.to_json()

--- a/src/galileo/utils/serialization.py
+++ b/src/galileo/utils/serialization.py
@@ -102,25 +102,25 @@ class EventSerializer(JSONEncoder):
                     return self.default(obj.generations[0])
                 elif isinstance(obj, (AIMessageChunk, AIMessage)):
                     # Map the `type` to `role`.
-                    dumped = obj.model_dump(include={"content", "type", "additional_kwargs"})
+                    dumped = obj.model_dump(mode="json", include={"content", "type", "additional_kwargs"})
                     dumped["role"] = map_langchain_role(dumped.pop("type"))
                     additional_kwargs = dumped.pop("additional_kwargs", {})
                     if "tool_calls" in additional_kwargs:
                         dumped["tool_calls"] = additional_kwargs.pop("tool_calls")
-                    return self.default(dumped)
+                    return dumped
                 elif isinstance(obj, ToolMessage):
                     # Map the `type` to `role`.
-                    dumped = obj.model_dump(include={"content", "type", "status", "tool_call_id"})
+                    dumped = obj.model_dump(mode="json", include={"content", "type", "status", "tool_call_id"})
                     dumped["role"] = map_langchain_role(dumped.pop("type"))
-                    return self.default(dumped)
+                    return dumped
                 elif isinstance(obj, BaseMessage):
                     # Map the `type` to `role`.
-                    dumped = obj.model_dump(include={"content", "type"})
+                    dumped = obj.model_dump(mode="json", include={"content", "type"})
                     dumped["role"] = map_langchain_role(dumped.pop("type"))
-                    return self.default(dumped)
+                    return dumped
 
                 if isinstance(obj, LangchainDocument):
-                    return self.default(obj.model_dump(include={"page_content", "metadata"}))
+                    return self.default(obj.model_dump(mode="json", include={"page_content", "metadata"}))
 
                 if isinstance(obj, Serializable):
                     ret = obj.to_json()

--- a/src/galileo/utils/serialization.py
+++ b/src/galileo/utils/serialization.py
@@ -98,17 +98,13 @@ class EventSerializer(JSONEncoder):
                 from langchain_core.prompt_values import ChatPromptValue
 
                 if isinstance(obj, (AgentFinish, AgentAction, ChatPromptValue)):
-                    print(f"AgentFinish, AgentAction, ChatPromptValue: {obj}")
                     return self.default(obj.messages)
                 elif isinstance(obj, ChatGeneration):
-                    print(f"ChatGeneration: {type(obj)}")
                     return self.default(obj.message)
                 elif isinstance(obj, LLMResult):
-                    print(f"LLMResult: {type(obj)}")
                     return self.default(obj.generations[0])
                 elif isinstance(obj, (AIMessageChunk, AIMessage)):
                     # Map the `type` to `role`.
-                    print(f"AIMessageChunk, AIMessage: {type(obj)}")
                     dumped = obj.model_dump(include={"content", "type", "additional_kwargs"})
                     dumped["role"] = map_langchain_role(dumped.pop("type"))
                     additional_kwargs = dumped.pop("additional_kwargs", {})
@@ -117,30 +113,23 @@ class EventSerializer(JSONEncoder):
                     return self.default(dumped)
                 elif isinstance(obj, ToolMessage):
                     # Map the `type` to `role`.
-                    print(f"ToolMessage: {obj}")
                     dumped = obj.model_dump(include={"content", "type", "status", "tool_call_id"})
                     dumped["role"] = map_langchain_role(dumped.pop("type"))
-                    print(f"ToolMessage dumped: {dumped}")
                     return self.default(dumped)
                 elif isinstance(obj, BaseMessage):
                     # Map the `type` to `role`.
-                    print(f"BaseMessage: {type(obj)}")
                     dumped = obj.model_dump(include={"content", "type"})
                     dumped["role"] = map_langchain_role(dumped.pop("type"))
                     return self.default(dumped)
 
                 if isinstance(obj, Serializable):
-                    print(f"Serializable: {type(obj)}")
                     ret = obj.to_json()
-                    print(f"Serializable to_json: {ret}")
                     return ret
 
             if is_dataclass(obj):
-                print(f"Dataclass: {obj}")
                 return {self.default(k): self.default(v) for k, v in obj.__dict__.items()}
 
             if isinstance(obj, BaseModel):
-                print(f"BaseModel: {type(obj)}")
                 return self.default(
                     obj.model_dump(mode="json", exclude_none=True, exclude_unset=True, exclude_defaults=True)
                 )

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from langchain_core.agents import AgentFinish
 from langchain_core.documents import Document
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
 
 from galileo import Message, MessageRole
 from galileo.handlers.langchain import GalileoCallback
@@ -150,7 +151,7 @@ class TestGalileoCallback:
         assert callback._nodes[str(run_id)].node_type == "agent"
         assert (
             callback._nodes[str(run_id)].span_params["input"]
-            == '{"messages": [{"content": "What does Lilian Weng say about the types of agent memory?", "role": "user"}}]}'
+            == '{"messages": [{"content": "What does Lilian Weng say about the types of agent memory?", "role": "user"}]}'
         )
 
         # End chain
@@ -218,12 +219,10 @@ class TestGalileoCallback:
         callback.on_llm_new_token("AI", run_id=run_id)
 
         # End LLM
-        llm_response = MagicMock()
-        llm_response.generations = [[MagicMock()]]
-        llm_response.llm_output = {"token_usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}}
-
-        # Mock dict method on the generation
-        llm_response.generations[0][0].dict.return_value = {"text": "AI is a technology..."}
+        llm_response = LLMResult(
+            generations=[[ChatGeneration(message=AIMessage(content="AI is a technology..."))]],
+            llm_output={"token_usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}},
+        )
 
         callback.on_llm_end(response=llm_response, run_id=run_id, parent_run_id=parent_id)
 
@@ -530,10 +529,16 @@ class TestGalileoCallback:
         )
 
         # End LLM
-        llm_response = MagicMock()
-        llm_response.generations = [[MagicMock()]]
-        llm_response.llm_output = {"token_usage": {"total_tokens": 100}}
-        llm_response.generations[0][0].model_dump.return_value = {"text": "LLMs have seen significant progress..."}
+        llm_response = LLMResult(
+            generations=[
+                [
+                    ChatGeneration(
+                        message=AIMessage(content="LLMs have seen significant progress..."),
+                        generation_info={"token_usage": {"total_tokens": 100}},
+                    )
+                ]
+            ]
+        )
 
         callback.on_llm_end(response=llm_response, run_id=llm_id, parent_run_id=chain_id)
 
@@ -547,7 +552,11 @@ class TestGalileoCallback:
         )
 
         # End tool
-        callback.on_tool_end(output="Verification complete: accurate statement", run_id=tool_id, parent_run_id=chain_id)
+        callback.on_tool_end(
+            output=ToolMessage(content="Verification complete: accurate statement", tool_call_id="1"),
+            run_id=tool_id,
+            parent_run_id=chain_id,
+        )
 
         # End chain
         callback.on_chain_end(
@@ -583,7 +592,7 @@ class TestGalileoCallback:
             )
         ]
         assert traces[0].spans[0].spans[1].output == Message(
-            content='{"text": "LLMs have seen significant progress..."}',
+            content="LLMs have seen significant progress...",
             role=MessageRole.assistant,
             tool_call_id=None,
             tool_calls=None,
@@ -739,12 +748,10 @@ class TestGalileoCallback:
         callback.on_llm_new_token("AI", run_id=llm_run_id)
 
         # End LLM
-        llm_response = MagicMock()
-        llm_response.generations = [[MagicMock()]]
-        llm_response.llm_output = {"token_usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}}
-
-        # Mock dict method on the generation
-        llm_response.generations[0][0].dict.return_value = {"text": "AI is a technology..."}
+        llm_response = LLMResult(
+            generations=[[ChatGeneration(message=AIMessage(content="AI is a technology..."))]],
+            llm_output={"token_usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}},
+        )
 
         callback.on_llm_end(response=llm_response, run_id=llm_run_id, parent_run_id=parent_id)
 

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -150,7 +150,7 @@ class TestGalileoCallback:
         assert callback._nodes[str(run_id)].node_type == "agent"
         assert (
             callback._nodes[str(run_id)].span_params["input"]
-            == '{"messages": [{"content": "What does Lilian Weng say about the types of agent memory?"}]}'
+            == '{"messages": [{"content": "What does Lilian Weng say about the types of agent memory?", "role": "user"}}]}'
         )
 
         # End chain
@@ -163,7 +163,7 @@ class TestGalileoCallback:
         assert traces[0].spans[0].type == "agent"
         assert (
             traces[0].spans[0].input
-            == '{"messages": [{"content": "What does Lilian Weng say about the types of agent memory?"}]}'
+            == '{"messages": [{"content": "What does Lilian Weng say about the types of agent memory?", "role": "user"}]}'
         )
         assert traces[0].spans[0].output == '{"result": "test answer"}'
         assert traces[0].spans[0].step_number is None
@@ -399,7 +399,9 @@ class TestGalileoCallback:
         assert str(run_id) in callback._nodes
         assert callback._nodes[str(run_id)].node_type == "tool"
         assert callback._nodes[str(run_id)].span_params["input"] == "2+2"
-        assert callback._nodes[str(run_id)].span_params["output"] == "tool response"
+        assert callback._nodes[str(run_id)].span_params["output"] == (
+            '{"content": "tool response", "tool_call_id": "1", "status": "success", "role": "tool"}'
+        )
 
         # Start tool
         callback.on_tool_start(
@@ -454,7 +456,9 @@ class TestGalileoCallback:
         assert str(run_id) in callback._nodes
         assert callback._nodes[str(run_id)].node_type == "tool"
         assert callback._nodes[str(run_id)].span_params["input"] == "2+2"
-        assert callback._nodes[str(run_id)].span_params["output"] == "tool response"
+        assert callback._nodes[str(run_id)].span_params["output"] == (
+            '{"content": "tool response", "tool_call_id": "1", "status": "success", "role": "tool"}'
+        )
 
         # Start tool
         callback.on_tool_start(

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from langchain_core.agents import AgentFinish
 from langchain_core.documents import Document
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 
 from galileo import Message, MessageRole

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -501,6 +501,37 @@ class TestGalileoCallback:
         assert isinstance(callback._nodes[str(run_id)].span_params["output"], list)
         assert len(callback._nodes[str(run_id)].span_params["output"]) == 1
 
+    def test_extracting_chain_names_from_metadata(self, callback: GalileoCallback, galileo_logger: GalileoLogger):
+        """Test extracting chain names from metadata kwarg, with two nested chains"""
+        chain_id = uuid.uuid4()
+        chain_id2 = uuid.uuid4()
+
+        callback.on_chain_start(
+            serialized={}, inputs={"query": "test"}, run_id=chain_id, metadata={"name": "Test Chain"}
+        )
+
+        callback.on_chain_start(
+            serialized={},
+            inputs={"query": "test"},
+            run_id=chain_id2,
+            parent_run_id=chain_id,
+            metadata={"name": "Test Chain 2"},
+        )
+
+        callback.on_chain_end(outputs={"result": "test"}, run_id=chain_id)
+
+        callback.on_chain_end(outputs={"result": "test"}, run_id=chain_id2)
+
+        traces = galileo_logger.traces
+
+        assert len(traces) == 1
+
+        assert len(traces[0].spans) == 1
+        assert traces[0].spans[0].name == "Test Chain"
+
+        assert len(traces[0].spans[0].spans) == 1
+        assert traces[0].spans[0].spans[0].name == "Test Chain 2"
+
     def test_complex_execution_flow(self, callback: GalileoCallback, galileo_logger: GalileoLogger):
         """Test a complex execution flow with multiple component types"""
         # Create UUIDs for different components

--- a/tests/test_langchain_async.py
+++ b/tests/test_langchain_async.py
@@ -267,7 +267,7 @@ class TestGalileoAsyncCallback:
         assert input_data[2]["content"] == "AI is a technology..."
         assert input_data[0]["role"] == "system"
         assert input_data[1]["role"] == "user"
-        assert input_data[2]["role"] == "ai"
+        assert input_data[2]["role"] == "assistant"
 
     @mark.asyncio
     async def test_on_chat_model_start_end_with_tools(

--- a/tests/test_langchain_async.py
+++ b/tests/test_langchain_async.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from langchain_core.agents import AgentFinish
 from langchain_core.documents import Document
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 from pytest import mark
 
@@ -240,9 +240,10 @@ class TestGalileoAsyncCallback:
         await callback.on_chain_start(serialized={}, inputs={"query": "test"}, run_id=parent_id)
 
         # Start chat model
+        system_message = SystemMessage(content="You are a helpful assistant.")
         human_message = HumanMessage(content="Tell me about AI")
         ai_message = AIMessage(content="AI is a technology...")
-        messages = [[human_message, ai_message]]
+        messages = [[system_message, human_message, ai_message]]
 
         await callback.on_chat_model_start(
             serialized={},
@@ -260,9 +261,13 @@ class TestGalileoAsyncCallback:
         # Check that message serialization worked
         input_data = callback._nodes[str(run_id)].span_params["input"]
         assert isinstance(input_data, list)
-        assert len(input_data) == 2  # Two messages
-        assert input_data[0]["content"] == "Tell me about AI"
-        assert input_data[1]["content"] == "AI is a technology..."
+        assert len(input_data) == 3  # Two messages
+        assert input_data[0]["content"] == "You are a helpful assistant."
+        assert input_data[1]["content"] == "Tell me about AI"
+        assert input_data[2]["content"] == "AI is a technology..."
+        assert input_data[0]["role"] == "system"
+        assert input_data[1]["role"] == "user"
+        assert input_data[2]["role"] == "ai"
 
     @mark.asyncio
     async def test_on_chat_model_start_end_with_tools(


### PR DESCRIPTION
I was looking over some recent logstreams created with Langchain/Langgraph today, and noticed that a lot of them contained "raw Langchain" data in span inputs and/or outputs.

E.g. LLM messages that have `"content"` as a dict with its own inner "content" key, plus a dict called "additional_kwargs," and all of that stuff.  And we often weren't setting our own schema's `tool_call_id` either on tool nodes or on the LLM output messages that called the tools.

----

This PR updates our langchain callbacks to fix at least some of the problems I observed.

I tested this against the [langgraph-fsi-agent](https://github.com/rungalileo/sdk-examples/tree/main/python/agent/langgraph-fsi-agent) example from our SDK examples repo, and I can confirm it works in that case, although I can't guarantee it works everywhere.  It does change the SDK's behavior, so users might be confused at least for a little while even if it's ultimately a good change.

I'll document what changed in comments.  Note that we have two callback classes, the sync one and the async one, which are largely identical; I tried to keep both in sync, let me know if you see any differences.

---

EDIT: also made a change that fetches more informative names for chain nodes, see [slack discussion](https://galileoteamworkspace.slack.com/archives/C087G0X1JG2/p1753317258496139?thread_ts=1753316118.299229&cid=C087G0X1JG2)