### PR TITLE
chore: Add the default templates for openapi-autogen endpoint resources

### DIFF
--- a/codegen_templates/endpoint_macros.py.jinja
+++ b/codegen_templates/endpoint_macros.py.jinja
@@ -1,0 +1,186 @@
+{% from "property_templates/helpers.jinja" import guarded_statement %}
+{% from "helpers.jinja" import safe_docstring %}
+
+{% macro header_params(endpoint) %}
+{% if endpoint.header_parameters or endpoint.bodies | length > 0 %}
+headers: dict[str, Any] = {}
+{% if endpoint.header_parameters %}
+    {% for parameter in endpoint.header_parameters %}
+        {% import "property_templates/" + parameter.template as param_template %}
+        {% if param_template.transform_header %}
+            {% set expression = param_template.transform_header(parameter.python_name) %}
+        {% else %}
+            {% set expression = parameter.python_name %}
+        {% endif %}
+        {% set statement = 'headers["' +  parameter.name + '"]' + " = " + expression %}
+{{ guarded_statement(parameter, parameter.python_name, statement) }}
+    {% endfor %}
+{% endif %}
+{% endif %}
+{% endmacro %}
+
+{% macro cookie_params(endpoint) %}
+{% if endpoint.cookie_parameters %}
+cookies = {}
+    {% for parameter in endpoint.cookie_parameters %}
+        {% if parameter.required %}
+cookies["{{ parameter.name}}"] = {{ parameter.python_name }}
+        {% else %}
+if {{ parameter.python_name }} is not UNSET:
+    cookies["{{ parameter.name}}"] = {{ parameter.python_name }}
+        {% endif %}
+
+    {% endfor %}
+{% endif %}
+{% endmacro %}
+
+
+{% macro query_params(endpoint) %}
+{% if endpoint.query_parameters %}
+params: dict[str, Any] = {}
+
+{% for property in endpoint.query_parameters %}
+    {% set destination = property.python_name %}
+    {% import "property_templates/" + property.template as prop_template %}
+    {% if prop_template.transform %}
+        {% set destination = "json_" + property.python_name %}
+{{ prop_template.transform(property, property.python_name, destination) }}
+    {% endif %}
+    {%- if not property.json_is_dict %}
+params["{{ property.name }}"] = {{ destination }}
+    {% else %}
+{{ guarded_statement(property, destination, "params.update(" + destination + ")") }}
+    {% endif %}
+
+{% endfor %}
+
+params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+{% endif %}
+{% endmacro %}
+
+{% macro body_to_kwarg(body) %}
+{% if body.body_type == "data" %}
+_kwargs["data"] = body.to_dict()
+{% elif body.body_type == "files"%}
+{{ multipart_body(body) }}
+{% elif body.body_type == "json" %}
+{{ json_body(body) }}
+{% elif body.body_type == "content" %}
+_kwargs["content"] = body.payload
+{% endif %}
+{% endmacro %}
+
+{% macro json_body(body) %}
+{% set property = body.prop %}
+{% import "property_templates/" + property.template as prop_template %}
+{% if prop_template.transform %}
+{{ prop_template.transform(property, property.python_name, "_kwargs[\"json\"]") }}
+{% else %}
+_kwargs["json"] = {{ property.python_name }}
+{% endif %}
+{% endmacro %}
+
+{% macro multipart_body(body) %}
+{% set property = body.prop %}
+{% import "property_templates/" + property.template as prop_template %}
+{% if prop_template.transform_multipart_body %}
+{{ prop_template.transform_multipart_body(property) }}
+{% endif %}
+{% endmacro %}
+
+{# The all the kwargs passed into an endpoint (and variants thereof)) #}
+{% macro arguments(endpoint, include_client=True) %}
+{# path parameters #}
+{% for parameter in endpoint.path_parameters %}
+{{ parameter.to_string() }},
+{% endfor %}
+{% if include_client or ((endpoint.list_all_parameters() | length) > (endpoint.path_parameters | length)) %}
+*,
+{% endif %}
+{# Proper client based on whether or not the endpoint requires authentication #}
+{% if include_client %}
+{% if endpoint.requires_security %}
+client: AuthenticatedClient,
+{% else %}
+client: Union[AuthenticatedClient, Client],
+{% endif %}
+{% endif %}
+{# Any allowed bodies #}
+{% if endpoint.bodies | length == 1 %}
+body: {{ endpoint.bodies[0].prop.get_type_string() }},
+{% elif endpoint.bodies | length > 1 %}
+body: Union[
+    {% for body in endpoint.bodies %}
+    {{ body.prop.get_type_string() }},
+    {% endfor %}
+],
+{% endif %}
+{# query parameters #}
+{% for parameter in endpoint.query_parameters %}
+{{ parameter.to_string() }},
+{% endfor %}
+{% for parameter in endpoint.header_parameters %}
+{{ parameter.to_string() }},
+{% endfor %}
+{# cookie parameters #}
+{% for parameter in endpoint.cookie_parameters %}
+{{ parameter.to_string() }},
+{% endfor %}
+{% endmacro %}
+
+{# Just lists all kwargs to endpoints as name=name for passing to other functions #}
+{% macro kwargs(endpoint, include_client=True) %}
+{% for parameter in endpoint.path_parameters %}
+{{ parameter.python_name }}={{ parameter.python_name }},
+{% endfor %}
+{% if include_client %}
+client=client,
+{% endif %}
+{% if endpoint.bodies | length > 0 %}
+body=body,
+{% endif %}
+{% for parameter in endpoint.query_parameters %}
+{{ parameter.python_name }}={{ parameter.python_name }},
+{% endfor %}
+{% for parameter in endpoint.header_parameters %}
+{{ parameter.python_name }}={{ parameter.python_name }},
+{% endfor %}
+{% for parameter in endpoint.cookie_parameters %}
+{{ parameter.python_name }}={{ parameter.python_name }},
+{% endfor %}
+{% endmacro %}
+
+{% macro docstring_content(endpoint, return_string, is_detailed) %}
+{% if endpoint.summary %}{{ endpoint.summary | wordwrap(100)}}
+
+{% endif -%}
+{%- if endpoint.description %} {{ endpoint.description | wordwrap(100) }}
+
+{% endif %}
+{% if not endpoint.summary and not endpoint.description %}
+{# Leave extra space so that Args or Returns isn't at the top #}
+
+{% endif %}
+{% set all_parameters = endpoint.list_all_parameters() %}
+{% if all_parameters %}
+Args:
+    {% for parameter in all_parameters %}
+    {{ parameter.to_docstring() | wordwrap(90) | indent(8) }}
+    {% endfor %}
+
+{% endif %}
+Raises:
+    errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+    httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+Returns:
+{% if is_detailed %}
+    Response[{{ return_string }}]
+{% else %}
+    {{ return_string }}
+{% endif %}
+{% endmacro %}
+
+{% macro docstring(endpoint, return_string, is_detailed) %}
+{{ safe_docstring(docstring_content(endpoint, return_string, is_detailed)) }}
+{% endmacro %}

--- a/codegen_templates/endpoint_module.py.jinja
+++ b/codegen_templates/endpoint_module.py.jinja
@@ -1,0 +1,149 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+{% for relative in endpoint.relative_imports | sort %}
+{{ relative }}
+{% endfor %}
+
+{% from "endpoint_macros.py.jinja" import header_params, cookie_params, query_params,
+    arguments, client, kwargs, parse_response, docstring, body_to_kwarg %}
+
+{% set return_string = endpoint.response_type() %}
+{% set parsed_responses = (endpoint.responses | length > 0) and return_string != "Any" %}
+
+def _get_kwargs(
+    {{ arguments(endpoint, include_client=False) | indent(4) }}
+) -> dict[str, Any]:
+    {{ header_params(endpoint) | indent(4) }}
+
+    {{ cookie_params(endpoint) | indent(4) }}
+
+    {{ query_params(endpoint) | indent(4) }}
+
+    _kwargs: dict[str, Any] = {
+        "method": "{{ endpoint.method }}",
+        {% if endpoint.path_parameters %}
+        "url": "{{ endpoint.path }}".format(
+        {%- for parameter in endpoint.path_parameters -%}
+        {{parameter.python_name}}={{parameter.python_name}},
+        {%- endfor -%}
+        ),
+        {% else %}
+        "url": "{{ endpoint.path }}",
+        {% endif %}
+        {% if endpoint.query_parameters %}
+        "params": params,
+        {% endif %}
+        {% if endpoint.cookie_parameters %}
+        "cookies": cookies,
+        {% endif %}
+    }
+
+{% if endpoint.bodies | length > 1 %}
+{% for body in endpoint.bodies %}
+    if isinstance(body, {{body.prop.get_type_string() }}):
+        {{ body_to_kwarg(body) | indent(8) }}
+        headers["Content-Type"] = "{{ body.content_type }}"
+{% endfor %}
+{% elif endpoint.bodies | length == 1 %}
+{% set body = endpoint.bodies[0] %}
+    {{ body_to_kwarg(body) | indent(4) }}
+    {% if body.content_type != "multipart/form-data" %}{# Need httpx to set the boundary automatically #}
+    headers["Content-Type"] = "{{ body.content_type }}"
+    {% endif %}
+{% endif %}
+
+{% if endpoint.header_parameters or endpoint.bodies | length > 0 %}
+    _kwargs["headers"] = headers
+{% endif %}
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[{{ return_string }}]:
+    {% for response in endpoint.responses %}
+    if response.status_code == {{ response.status_code.value }}:
+        {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
+        {% if prop_template.construct %}
+        {{ prop_template.construct(response.prop, response.source.attribute) | indent(8) }}
+        {% elif response.source.return_type == response.prop.get_type_string()  %}
+        {{ response.prop.python_name }} = {{ response.source.attribute }}
+        {% else %}
+        {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source.attribute }})
+        {% endif %}
+        return {{ response.prop.python_name }}
+        {% else %}
+        return None
+        {% endif %}
+    {% endfor %}
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[{{ return_string }}]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint, include_client=False) }}
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+{% if parsed_responses %}
+def sync(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Optional[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+
+    return sync_detailed(
+        {{ kwargs(endpoint) }}
+    ).parsed
+{% endif %}
+
+async def asyncio_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint, include_client=False) }}
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+{% if parsed_responses %}
+async def asyncio(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Optional[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+
+    return (await asyncio_detailed(
+        {{ kwargs(endpoint) }}
+    )).parsed
+{% endif %}

--- a/codegen_templates/property_templates/model_property.py.jinja
+++ b/codegen_templates/property_templates/model_property.py.jinja
@@ -1,0 +1,37 @@
+{% macro construct_function(property, source) %}
+{{ property.class_info.name }}.from_dict({{ source }})
+{% endmacro %}
+
+{% from "property_templates/property_macros.py.jinja" import construct_template %}
+
+{% macro construct(property, source) %}
+{{ construct_template(construct_function, property, source) }}
+{% endmacro %}
+
+{% macro check_type_for_construct(property, source) %}isinstance({{ source }}, dict){% endmacro %}
+
+{% macro transform(property, source, destination, declare_type=True) %}
+{% set transformed = source + ".to_dict()" %}
+{% set type_string = property.get_type_string(json=True) %}
+{% if property.required %}
+{{ destination }} = {{ transformed }}
+{%- else %}
+{{ destination }}{% if declare_type %}: {{ type_string }}{% endif %} = UNSET
+if not isinstance({{ source }}, Unset):
+    {{ destination }} = {{ transformed }}
+{%- endif %}
+{% endmacro %}
+
+{% macro transform_multipart_body(property) %}
+{% set transformed = property.python_name + ".to_multipart()" %}
+{% if property.required %}
+_kwargs["files"] = {{ transformed }}
+{%- else %}
+if not isinstance({{ property.python_name }}, Unset):
+    _kwargs["files"] = {{ transformed }}
+{%- endif %}
+{% endmacro %}
+
+{% macro multipart(property, source, name) %}
+files.append(({{ name }}, (None, json.dumps( {{source}}.to_dict()).encode(), "application/json")))
+{% endmacro %}


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/34869/galileo-python-migrate-all-api-interactions-to-use-config-and-api-client-from-galileo-core#activity-36213

**description:** This adds the default openapi-autogen [templates](https://github.com/openapi-generators/openapi-python-client/tree/main/openapi_python_client/templates) needed for the api resources. This is just to allow for a proper diff against [254](https://github.com/rungalileo/galileo-python/pull/254) which has the template changes.