### PR TITLE
feat: Regenerate the api resources to use the Core client

### DIFF
--- a/src/galileo/resources/api/auth/login_api_key_login_api_key_post.py
+++ b/src/galileo/resources/api/auth/login_api_key_login_api_key_post.py
@@ -22,7 +22,7 @@ def _get_kwargs(*, body: ApiKeyLoginRequest) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/auth/login_api_key_login_api_key_post.py
+++ b/src/galileo/resources/api/auth/login_api_key_login_api_key_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.api_key_login_request import ApiKeyLoginRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.token import Token
@@ -14,7 +16,7 @@ from ...types import Response
 def _get_kwargs(*, body: ApiKeyLoginRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/login/api_key"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/login/api_key"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -24,9 +26,7 @@ def _get_kwargs(*, body: ApiKeyLoginRequest) -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, Token]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, Token]]:
     if response.status_code == 200:
         response_200 = Token.from_dict(response.json())
 
@@ -41,9 +41,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, Token]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, Token]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -52,9 +50,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    *, client: Union[AuthenticatedClient, Client], body: ApiKeyLoginRequest
-) -> Response[Union[HTTPValidationError, Token]]:
+def sync_detailed(*, client: ApiClient, body: ApiKeyLoginRequest) -> Response[Union[HTTPValidationError, Token]]:
     """Login Api Key
 
     Args:
@@ -70,14 +66,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    *, client: Union[AuthenticatedClient, Client], body: ApiKeyLoginRequest
-) -> Optional[Union[HTTPValidationError, Token]]:
+def sync(*, client: ApiClient, body: ApiKeyLoginRequest) -> Optional[Union[HTTPValidationError, Token]]:
     """Login Api Key
 
     Args:
@@ -95,7 +89,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *, client: Union[AuthenticatedClient, Client], body: ApiKeyLoginRequest
+    *, client: ApiClient, body: ApiKeyLoginRequest
 ) -> Response[Union[HTTPValidationError, Token]]:
     """Login Api Key
 
@@ -112,14 +106,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    *, client: Union[AuthenticatedClient, Client], body: ApiKeyLoginRequest
-) -> Optional[Union[HTTPValidationError, Token]]:
+async def asyncio(*, client: ApiClient, body: ApiKeyLoginRequest) -> Optional[Union[HTTPValidationError, Token]]:
     """Login Api Key
 
     Args:

--- a/src/galileo/resources/api/auth/login_email_login_post.py
+++ b/src/galileo/resources/api/auth/login_email_login_post.py
@@ -22,7 +22,7 @@ def _get_kwargs(*, body: BodyLoginEmailLoginPost) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/auth/login_email_login_post.py
+++ b/src/galileo/resources/api/auth/login_email_login_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.body_login_email_login_post import BodyLoginEmailLoginPost
 from ...models.http_validation_error import HTTPValidationError
 from ...models.token import Token
@@ -14,7 +16,7 @@ from ...types import Response
 def _get_kwargs(*, body: BodyLoginEmailLoginPost) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/login"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/login"}
 
     _kwargs["data"] = body.to_dict()
 
@@ -24,9 +26,7 @@ def _get_kwargs(*, body: BodyLoginEmailLoginPost) -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, Token]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, Token]]:
     if response.status_code == 200:
         response_200 = Token.from_dict(response.json())
 
@@ -41,9 +41,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, Token]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, Token]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -52,9 +50,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    *, client: Union[AuthenticatedClient, Client], body: BodyLoginEmailLoginPost
-) -> Response[Union[HTTPValidationError, Token]]:
+def sync_detailed(*, client: ApiClient, body: BodyLoginEmailLoginPost) -> Response[Union[HTTPValidationError, Token]]:
     """Login Email
 
     Args:
@@ -70,14 +66,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    *, client: Union[AuthenticatedClient, Client], body: BodyLoginEmailLoginPost
-) -> Optional[Union[HTTPValidationError, Token]]:
+def sync(*, client: ApiClient, body: BodyLoginEmailLoginPost) -> Optional[Union[HTTPValidationError, Token]]:
     """Login Email
 
     Args:
@@ -95,7 +89,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *, client: Union[AuthenticatedClient, Client], body: BodyLoginEmailLoginPost
+    *, client: ApiClient, body: BodyLoginEmailLoginPost
 ) -> Response[Union[HTTPValidationError, Token]]:
     """Login Email
 
@@ -112,14 +106,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    *, client: Union[AuthenticatedClient, Client], body: BodyLoginEmailLoginPost
-) -> Optional[Union[HTTPValidationError, Token]]:
+async def asyncio(*, client: ApiClient, body: BodyLoginEmailLoginPost) -> Optional[Union[HTTPValidationError, Token]]:
     """Login Email
 
     Args:

--- a/src/galileo/resources/api/data/create_code_scorer_version_scorers_scorer_id_version_code_post.py
+++ b/src/galileo/resources/api/data/create_code_scorer_version_scorers_scorer_id_version_code_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(scorer_id: str, *, body: BodyCreateCodeScorerVersionScorersScore
 
     _kwargs["files"] = body.to_multipart()
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/data/create_code_scorer_version_scorers_scorer_id_version_code_post.py
+++ b/src/galileo/resources/api/data/create_code_scorer_version_scorers_scorer_id_version_code_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_scorer_version_response import BaseScorerVersionResponse
 from ...models.body_create_code_scorer_version_scorers_scorer_id_version_code_post import (
     BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost,
@@ -16,7 +18,11 @@ from ...types import Response
 def _get_kwargs(scorer_id: str, *, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/scorers/{scorer_id}/version/code"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}/version/code",
+    }
 
     _kwargs["files"] = body.to_multipart()
 
@@ -25,7 +31,7 @@ def _get_kwargs(scorer_id: str, *, body: BodyCreateCodeScorerVersionScorersScore
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BaseScorerVersionResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost
+    scorer_id: str, *, client: ApiClient, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Code Scorer Version
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str, *, client: AuthenticatedClient, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost
+    scorer_id: str, *, client: ApiClient, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Code Scorer Version
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost
+    scorer_id: str, *, client: ApiClient, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Code Scorer Version
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str, *, client: AuthenticatedClient, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost
+    scorer_id: str, *, client: ApiClient, body: BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Code Scorer Version
 

--- a/src/galileo/resources/api/data/create_llm_scorer_version_scorers_scorer_id_version_llm_post.py
+++ b/src/galileo/resources/api/data/create_llm_scorer_version_scorers_scorer_id_version_llm_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(scorer_id: str, *, body: CreateLLMScorerVersionRequest) -> dict[
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/data/create_llm_scorer_version_scorers_scorer_id_version_llm_post.py
+++ b/src/galileo/resources/api/data/create_llm_scorer_version_scorers_scorer_id_version_llm_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_scorer_version_response import BaseScorerVersionResponse
 from ...models.create_llm_scorer_version_request import CreateLLMScorerVersionRequest
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(scorer_id: str, *, body: CreateLLMScorerVersionRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/scorers/{scorer_id}/version/llm"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}/version/llm",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(scorer_id: str, *, body: CreateLLMScorerVersionRequest) -> dict[
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BaseScorerVersionResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, body: CreateLLMScorerVersionRequest
+    scorer_id: str, *, client: ApiClient, body: CreateLLMScorerVersionRequest
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Llm Scorer Version
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str, *, client: AuthenticatedClient, body: CreateLLMScorerVersionRequest
+    scorer_id: str, *, client: ApiClient, body: CreateLLMScorerVersionRequest
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Llm Scorer Version
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, body: CreateLLMScorerVersionRequest
+    scorer_id: str, *, client: ApiClient, body: CreateLLMScorerVersionRequest
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Llm Scorer Version
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str, *, client: AuthenticatedClient, body: CreateLLMScorerVersionRequest
+    scorer_id: str, *, client: ApiClient, body: CreateLLMScorerVersionRequest
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Llm Scorer Version
 

--- a/src/galileo/resources/api/data/create_preset_scorer_version_scorers_scorer_id_version_preset_post.py
+++ b/src/galileo/resources/api/data/create_preset_scorer_version_scorers_scorer_id_version_preset_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(scorer_id: str, *, body: CreateScorerVersionRequest) -> dict[str
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/data/create_preset_scorer_version_scorers_scorer_id_version_preset_post.py
+++ b/src/galileo/resources/api/data/create_preset_scorer_version_scorers_scorer_id_version_preset_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_scorer_version_response import BaseScorerVersionResponse
 from ...models.create_scorer_version_request import CreateScorerVersionRequest
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(scorer_id: str, *, body: CreateScorerVersionRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/scorers/{scorer_id}/version/preset"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}/version/preset",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(scorer_id: str, *, body: CreateScorerVersionRequest) -> dict[str
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BaseScorerVersionResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, body: CreateScorerVersionRequest
+    scorer_id: str, *, client: ApiClient, body: CreateScorerVersionRequest
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Preset Scorer Version
 
@@ -73,13 +79,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str, *, client: AuthenticatedClient, body: CreateScorerVersionRequest
+    scorer_id: str, *, client: ApiClient, body: CreateScorerVersionRequest
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Preset Scorer Version
 
@@ -101,7 +107,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, body: CreateScorerVersionRequest
+    scorer_id: str, *, client: ApiClient, body: CreateScorerVersionRequest
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Preset Scorer Version
 
@@ -121,13 +127,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str, *, client: AuthenticatedClient, body: CreateScorerVersionRequest
+    scorer_id: str, *, client: ApiClient, body: CreateScorerVersionRequest
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Create Preset Scorer Version
 

--- a/src/galileo/resources/api/data/create_scorers_post.py
+++ b/src/galileo/resources/api/data/create_scorers_post.py
@@ -22,7 +22,7 @@ def _get_kwargs(*, body: CreateScorerRequest) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/data/create_scorers_post.py
+++ b/src/galileo/resources/api/data/create_scorers_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.create_scorer_request import CreateScorerRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.scorer_response import ScorerResponse
@@ -14,7 +16,7 @@ from ...types import Response
 def _get_kwargs(*, body: CreateScorerRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/scorers"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/scorers"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +27,7 @@ def _get_kwargs(*, body: CreateScorerRequest) -> dict[str, Any]:
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     if response.status_code == 200:
         response_200 = ScorerResponse.from_dict(response.json())
@@ -42,7 +44,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +55,7 @@ def _build_response(
 
 
 def sync_detailed(
-    *, client: AuthenticatedClient, body: CreateScorerRequest
+    *, client: ApiClient, body: CreateScorerRequest
 ) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     """Create
 
@@ -70,14 +72,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    *, client: AuthenticatedClient, body: CreateScorerRequest
-) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
+def sync(*, client: ApiClient, body: CreateScorerRequest) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     """Create
 
     Args:
@@ -95,7 +95,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, body: CreateScorerRequest
+    *, client: ApiClient, body: CreateScorerRequest
 ) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     """Create
 
@@ -112,13 +112,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    *, client: AuthenticatedClient, body: CreateScorerRequest
+    *, client: ApiClient, body: CreateScorerRequest
 ) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     """Create
 

--- a/src/galileo/resources/api/data/delete_scorer_scorers_scorer_id_delete.py
+++ b/src/galileo/resources/api/data/delete_scorer_scorers_scorer_id_delete.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.delete_scorer_response import DeleteScorerResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(scorer_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/scorers/{scorer_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[DeleteScorerResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DeleteScorerResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[DeleteScorerResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -44,9 +50,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    scorer_id: str, *, client: AuthenticatedClient
-) -> Response[Union[DeleteScorerResponse, HTTPValidationError]]:
+def sync_detailed(scorer_id: str, *, client: ApiClient) -> Response[Union[DeleteScorerResponse, HTTPValidationError]]:
     """Delete Scorer
 
     Args:
@@ -62,12 +66,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(scorer_id: str, *, client: AuthenticatedClient) -> Optional[Union[DeleteScorerResponse, HTTPValidationError]]:
+def sync(scorer_id: str, *, client: ApiClient) -> Optional[Union[DeleteScorerResponse, HTTPValidationError]]:
     """Delete Scorer
 
     Args:
@@ -85,7 +89,7 @@ def sync(scorer_id: str, *, client: AuthenticatedClient) -> Optional[Union[Delet
 
 
 async def asyncio_detailed(
-    scorer_id: str, *, client: AuthenticatedClient
+    scorer_id: str, *, client: ApiClient
 ) -> Response[Union[DeleteScorerResponse, HTTPValidationError]]:
     """Delete Scorer
 
@@ -102,14 +106,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    scorer_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[DeleteScorerResponse, HTTPValidationError]]:
+async def asyncio(scorer_id: str, *, client: ApiClient) -> Optional[Union[DeleteScorerResponse, HTTPValidationError]]:
     """Delete Scorer
 
     Args:

--- a/src/galileo/resources/api/data/get_scorer_scorers_scorer_id_get.py
+++ b/src/galileo/resources/api/data/get_scorer_scorers_scorer_id_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.scorer_response import ScorerResponse
 from ...types import Response
 
 
 def _get_kwargs(scorer_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/scorers/{scorer_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     if response.status_code == 200:
         response_200 = ScorerResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -44,9 +50,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    scorer_id: str, *, client: AuthenticatedClient
-) -> Response[Union[HTTPValidationError, ScorerResponse]]:
+def sync_detailed(scorer_id: str, *, client: ApiClient) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     """Get Scorer
 
     Args:
@@ -62,12 +66,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(scorer_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
+def sync(scorer_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     """Get Scorer
 
     Args:
@@ -85,7 +89,7 @@ def sync(scorer_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPV
 
 
 async def asyncio_detailed(
-    scorer_id: str, *, client: AuthenticatedClient
+    scorer_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     """Get Scorer
 
@@ -102,14 +106,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    scorer_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
+async def asyncio(scorer_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     """Get Scorer
 
     Args:

--- a/src/galileo/resources/api/data/get_scorer_version_code_scorers_scorer_id_version_code_get.py
+++ b/src/galileo/resources/api/data/get_scorer_version_code_scorers_scorer_id_version_code_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response, Unset
 
@@ -21,14 +23,17 @@ def _get_kwargs(scorer_id: str, *, version: Union[None, Unset, int] = UNSET) -> 
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/scorers/{scorer_id}/version/code", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}/version/code",
+        "params": params,
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -42,9 +47,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -54,7 +57,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, version: Union[None, Unset, int] = UNSET
+    scorer_id: str, *, client: ApiClient, version: Union[None, Unset, int] = UNSET
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Get Scorer Version Code
 
@@ -72,13 +75,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, version=version)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str, *, client: AuthenticatedClient, version: Union[None, Unset, int] = UNSET
+    scorer_id: str, *, client: ApiClient, version: Union[None, Unset, int] = UNSET
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Get Scorer Version Code
 
@@ -98,7 +101,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, version: Union[None, Unset, int] = UNSET
+    scorer_id: str, *, client: ApiClient, version: Union[None, Unset, int] = UNSET
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Get Scorer Version Code
 
@@ -116,13 +119,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, version=version)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str, *, client: AuthenticatedClient, version: Union[None, Unset, int] = UNSET
+    scorer_id: str, *, client: ApiClient, version: Union[None, Unset, int] = UNSET
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Get Scorer Version Code
 

--- a/src/galileo/resources/api/data/get_scorer_version_or_latest_scorers_scorer_id_version_get.py
+++ b/src/galileo/resources/api/data/get_scorer_version_or_latest_scorers_scorer_id_version_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_scorer_version_response import BaseScorerVersionResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response, Unset
@@ -17,13 +19,18 @@ def _get_kwargs(scorer_id: str, *, version: Union[Unset, int] = UNSET) -> dict[s
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/scorers/{scorer_id}/version", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}/version",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BaseScorerVersionResponse.from_dict(response.json())
@@ -40,7 +47,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -51,7 +58,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, version: Union[Unset, int] = UNSET
+    scorer_id: str, *, client: ApiClient, version: Union[Unset, int] = UNSET
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Get Scorer Version Or Latest
 
@@ -69,13 +76,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, version=version)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str, *, client: AuthenticatedClient, version: Union[Unset, int] = UNSET
+    scorer_id: str, *, client: ApiClient, version: Union[Unset, int] = UNSET
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Get Scorer Version Or Latest
 
@@ -95,7 +102,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, version: Union[Unset, int] = UNSET
+    scorer_id: str, *, client: ApiClient, version: Union[Unset, int] = UNSET
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Get Scorer Version Or Latest
 
@@ -113,13 +120,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, version=version)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str, *, client: AuthenticatedClient, version: Union[Unset, int] = UNSET
+    scorer_id: str, *, client: ApiClient, version: Union[Unset, int] = UNSET
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Get Scorer Version Or Latest
 

--- a/src/galileo/resources/api/data/list_all_versions_for_scorer_scorers_scorer_id_versions_get.py
+++ b/src/galileo/resources/api/data/list_all_versions_for_scorer_scorers_scorer_id_versions_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_scorer_versions_response import ListScorerVersionsResponse
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/scorers/{scorer_id}/versions", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}/versions",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListScorerVersionsResponse]]:
     if response.status_code == 200:
         response_200 = ListScorerVersionsResponse.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListScorerVersionsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    scorer_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListScorerVersionsResponse]]:
     """List All Versions For Scorer
 
@@ -78,17 +81,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    scorer_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListScorerVersionsResponse]]:
     """List All Versions For Scorer
 
@@ -109,11 +108,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    scorer_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListScorerVersionsResponse]]:
     """List All Versions For Scorer
 
@@ -132,17 +127,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    scorer_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListScorerVersionsResponse]]:
     """List All Versions For Scorer
 

--- a/src/galileo/resources/api/data/list_projects_for_scorer_route_scorers_scorer_id_projects_get.py
+++ b/src/galileo/resources/api/data/list_projects_for_scorer_route_scorers_scorer_id_projects_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.get_projects_paginated_response_v2 import GetProjectsPaginatedResponseV2
 from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/scorers/{scorer_id}/projects", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}/projects",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[GetProjectsPaginatedResponseV2, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = GetProjectsPaginatedResponseV2.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[GetProjectsPaginatedResponseV2, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    scorer_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[GetProjectsPaginatedResponseV2, HTTPValidationError]]:
     """List Projects For Scorer Route
 
@@ -80,17 +83,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    scorer_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[GetProjectsPaginatedResponseV2, HTTPValidationError]]:
     """List Projects For Scorer Route
 
@@ -113,11 +112,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    scorer_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[GetProjectsPaginatedResponseV2, HTTPValidationError]]:
     """List Projects For Scorer Route
 
@@ -138,17 +133,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    scorer_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[GetProjectsPaginatedResponseV2, HTTPValidationError]]:
     """List Projects For Scorer Route
 

--- a/src/galileo/resources/api/data/list_projects_for_scorer_version_route_scorers_versions_scorer_version_id_projects_get.py
+++ b/src/galileo/resources/api/data/list_projects_for_scorer_version_route_scorers_versions_scorer_version_id_projects_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.get_projects_paginated_response_v2 import GetProjectsPaginatedResponseV2
 from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response, Unset
@@ -24,8 +26,9 @@ def _get_kwargs(
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
-        "method": "get",
-        "url": f"/scorers/versions/{scorer_version_id}/projects",
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/scorers/versions/{scorer_version_id}/projects",
         "params": params,
     }
 
@@ -33,7 +36,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[GetProjectsPaginatedResponseV2, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = GetProjectsPaginatedResponseV2.from_dict(response.json())
@@ -50,7 +53,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[GetProjectsPaginatedResponseV2, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -63,7 +66,7 @@ def _build_response(
 def sync_detailed(
     scorer_version_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     scorer_id: str,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -90,7 +93,7 @@ def sync_detailed(
         scorer_version_id=scorer_version_id, scorer_id=scorer_id, starting_token=starting_token, limit=limit
     )
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -98,7 +101,7 @@ def sync_detailed(
 def sync(
     scorer_version_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     scorer_id: str,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -133,7 +136,7 @@ def sync(
 async def asyncio_detailed(
     scorer_version_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     scorer_id: str,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -160,7 +163,7 @@ async def asyncio_detailed(
         scorer_version_id=scorer_version_id, scorer_id=scorer_id, starting_token=starting_token, limit=limit
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -168,7 +171,7 @@ async def asyncio_detailed(
 async def asyncio(
     scorer_version_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     scorer_id: str,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/data/list_scorers_with_filters_scorers_list_post.py
+++ b/src/galileo/resources/api/data/list_scorers_with_filters_scorers_list_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_scorers_request import ListScorersRequest
 from ...models.list_scorers_response import ListScorersResponse
@@ -24,7 +26,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/scorers/list", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": "/scorers/list",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -35,7 +42,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListScorersResponse]]:
     if response.status_code == 200:
         response_200 = ListScorersResponse.from_dict(response.json())
@@ -52,7 +59,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListScorersResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -64,7 +71,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListScorersRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -86,14 +93,14 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListScorersRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -118,7 +125,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListScorersRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -140,14 +147,14 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListScorersRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/data/list_scorers_with_filters_scorers_list_post.py
+++ b/src/galileo/resources/api/data/list_scorers_with_filters_scorers_list_post.py
@@ -37,7 +37,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/data/list_tags_scorers_tags_get.py
+++ b/src/galileo/resources/api/data/list_tags_scorers_tags_get.py
@@ -1,20 +1,22 @@
 from http import HTTPStatus
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, cast
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...types import Response
 
 
 def _get_kwargs() -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": "/scorers/tags"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.GET, "return_raw_response": True, "path": "/scorers/tags"}
 
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list[str]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[list[str]]:
     if response.status_code == 200:
         response_200 = cast(list[str], response.json())
 
@@ -25,7 +27,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
         return None
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list[str]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[list[str]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -34,7 +36,7 @@ def _build_response(*, client: Union[AuthenticatedClient, Client], response: htt
     )
 
 
-def sync_detailed(*, client: AuthenticatedClient) -> Response[list[str]]:
+def sync_detailed(*, client: ApiClient) -> Response[list[str]]:
     """List Tags
 
     Raises:
@@ -47,12 +49,12 @@ def sync_detailed(*, client: AuthenticatedClient) -> Response[list[str]]:
 
     kwargs = _get_kwargs()
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(*, client: AuthenticatedClient) -> Optional[list[str]]:
+def sync(*, client: ApiClient) -> Optional[list[str]]:
     """List Tags
 
     Raises:
@@ -66,7 +68,7 @@ def sync(*, client: AuthenticatedClient) -> Optional[list[str]]:
     return sync_detailed(client=client).parsed
 
 
-async def asyncio_detailed(*, client: AuthenticatedClient) -> Response[list[str]]:
+async def asyncio_detailed(*, client: ApiClient) -> Response[list[str]]:
     """List Tags
 
     Raises:
@@ -79,12 +81,12 @@ async def asyncio_detailed(*, client: AuthenticatedClient) -> Response[list[str]
 
     kwargs = _get_kwargs()
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(*, client: AuthenticatedClient) -> Optional[list[str]]:
+async def asyncio(*, client: ApiClient) -> Optional[list[str]]:
     """List Tags
 
     Raises:

--- a/src/galileo/resources/api/data/restore_scorer_version_scorers_scorer_id_versions_version_number_restore_post.py
+++ b/src/galileo/resources/api/data/restore_scorer_version_scorers_scorer_id_versions_version_number_restore_post.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_scorer_version_response import BaseScorerVersionResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(scorer_id: str, version_number: int) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/scorers/{scorer_id}/versions/{version_number}/restore"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}/versions/{version_number}/restore",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BaseScorerVersionResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str, version_number: int, *, client: AuthenticatedClient
+    scorer_id: str, version_number: int, *, client: ApiClient
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Restore Scorer Version
 
@@ -65,13 +71,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, version_number=version_number)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str, version_number: int, *, client: AuthenticatedClient
+    scorer_id: str, version_number: int, *, client: ApiClient
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Restore Scorer Version
 
@@ -93,7 +99,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str, version_number: int, *, client: AuthenticatedClient
+    scorer_id: str, version_number: int, *, client: ApiClient
 ) -> Response[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Restore Scorer Version
 
@@ -113,13 +119,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, version_number=version_number)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str, version_number: int, *, client: AuthenticatedClient
+    scorer_id: str, version_number: int, *, client: ApiClient
 ) -> Optional[Union[BaseScorerVersionResponse, HTTPValidationError]]:
     """Restore Scorer Version
 

--- a/src/galileo/resources/api/data/update_scorers_scorer_id_patch.py
+++ b/src/galileo/resources/api/data/update_scorers_scorer_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.scorer_response import ScorerResponse
 from ...models.update_scorer_request import UpdateScorerRequest
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(scorer_id: str, *, body: UpdateScorerRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/scorers/{scorer_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/scorers/{scorer_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(scorer_id: str, *, body: UpdateScorerRequest) -> dict[str, Any]:
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     if response.status_code == 200:
         response_200 = ScorerResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, body: UpdateScorerRequest
+    scorer_id: str, *, client: ApiClient, body: UpdateScorerRequest
 ) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     """Update
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    scorer_id: str, *, client: AuthenticatedClient, body: UpdateScorerRequest
+    scorer_id: str, *, client: ApiClient, body: UpdateScorerRequest
 ) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     """Update
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    scorer_id: str, *, client: AuthenticatedClient, body: UpdateScorerRequest
+    scorer_id: str, *, client: ApiClient, body: UpdateScorerRequest
 ) -> Response[Union[HTTPValidationError, ScorerResponse]]:
     """Update
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(scorer_id=scorer_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    scorer_id: str, *, client: AuthenticatedClient, body: UpdateScorerRequest
+    scorer_id: str, *, client: ApiClient, body: UpdateScorerRequest
 ) -> Optional[Union[HTTPValidationError, ScorerResponse]]:
     """Update
 

--- a/src/galileo/resources/api/data/update_scorers_scorer_id_patch.py
+++ b/src/galileo/resources/api/data/update_scorers_scorer_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(scorer_id: str, *, body: UpdateScorerRequest) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/create_dataset_datasets_post.py
+++ b/src/galileo/resources/api/datasets/create_dataset_datasets_post.py
@@ -43,7 +43,7 @@ def _get_kwargs(
 
     _kwargs["files"] = body.to_multipart()
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/create_dataset_datasets_post.py
+++ b/src/galileo/resources/api/datasets/create_dataset_datasets_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.body_create_dataset_datasets_post import BodyCreateDatasetDatasetsPost
 from ...models.dataset_db import DatasetDB
 from ...models.dataset_format import DatasetFormat
@@ -32,7 +34,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/datasets", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": "/datasets",
+        "params": params,
+    }
 
     _kwargs["files"] = body.to_multipart()
 
@@ -40,9 +47,7 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DatasetDB, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[DatasetDB, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DatasetDB.from_dict(response.json())
 
@@ -57,9 +62,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[DatasetDB, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[DatasetDB, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -70,7 +73,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyCreateDatasetDatasetsPost,
     format_: Union[Unset, DatasetFormat] = UNSET,
     hidden: Union[Unset, bool] = False,
@@ -94,14 +97,14 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body, format_=format_, hidden=hidden)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyCreateDatasetDatasetsPost,
     format_: Union[Unset, DatasetFormat] = UNSET,
     hidden: Union[Unset, bool] = False,
@@ -128,7 +131,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyCreateDatasetDatasetsPost,
     format_: Union[Unset, DatasetFormat] = UNSET,
     hidden: Union[Unset, bool] = False,
@@ -152,14 +155,14 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body, format_=format_, hidden=hidden)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyCreateDatasetDatasetsPost,
     format_: Union[Unset, DatasetFormat] = UNSET,
     hidden: Union[Unset, bool] = False,

--- a/src/galileo/resources/api/datasets/create_group_dataset_collaborators_datasets_dataset_id_groups_post.py
+++ b/src/galileo/resources/api/datasets/create_group_dataset_collaborators_datasets_dataset_id_groups_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.group_collaborator import GroupCollaborator
 from ...models.group_collaborator_create import GroupCollaboratorCreate
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(dataset_id: str, *, body: list["GroupCollaboratorCreate"]) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/datasets/{dataset_id}/groups"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/groups",
+    }
 
     _kwargs["json"] = []
     for body_item_data in body:
@@ -28,7 +34,7 @@ def _get_kwargs(dataset_id: str, *, body: list["GroupCollaboratorCreate"]) -> di
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -50,7 +56,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -61,7 +67,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str, *, client: AuthenticatedClient, body: list["GroupCollaboratorCreate"]
+    dataset_id: str, *, client: ApiClient, body: list["GroupCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     """Create Group Dataset Collaborators
 
@@ -81,13 +87,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str, *, client: AuthenticatedClient, body: list["GroupCollaboratorCreate"]
+    dataset_id: str, *, client: ApiClient, body: list["GroupCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     """Create Group Dataset Collaborators
 
@@ -109,7 +115,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str, *, client: AuthenticatedClient, body: list["GroupCollaboratorCreate"]
+    dataset_id: str, *, client: ApiClient, body: list["GroupCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     """Create Group Dataset Collaborators
 
@@ -129,13 +135,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str, *, client: AuthenticatedClient, body: list["GroupCollaboratorCreate"]
+    dataset_id: str, *, client: ApiClient, body: list["GroupCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     """Create Group Dataset Collaborators
 

--- a/src/galileo/resources/api/datasets/create_group_dataset_collaborators_datasets_dataset_id_groups_post.py
+++ b/src/galileo/resources/api/datasets/create_group_dataset_collaborators_datasets_dataset_id_groups_post.py
@@ -29,7 +29,7 @@ def _get_kwargs(dataset_id: str, *, body: list["GroupCollaboratorCreate"]) -> di
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/create_user_dataset_collaborators_datasets_dataset_id_users_post.py
+++ b/src/galileo/resources/api/datasets/create_user_dataset_collaborators_datasets_dataset_id_users_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.user_collaborator import UserCollaborator
 from ...models.user_collaborator_create import UserCollaboratorCreate
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(dataset_id: str, *, body: list["UserCollaboratorCreate"]) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/datasets/{dataset_id}/users"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/users",
+    }
 
     _kwargs["json"] = []
     for body_item_data in body:
@@ -28,7 +34,7 @@ def _get_kwargs(dataset_id: str, *, body: list["UserCollaboratorCreate"]) -> dic
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -50,7 +56,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -61,7 +67,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    dataset_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Dataset Collaborators
 
@@ -79,13 +85,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    dataset_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Dataset Collaborators
 
@@ -105,7 +111,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    dataset_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Dataset Collaborators
 
@@ -123,13 +129,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    dataset_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Dataset Collaborators
 

--- a/src/galileo/resources/api/datasets/create_user_dataset_collaborators_datasets_dataset_id_users_post.py
+++ b/src/galileo/resources/api/datasets/create_user_dataset_collaborators_datasets_dataset_id_users_post.py
@@ -29,7 +29,7 @@ def _get_kwargs(dataset_id: str, *, body: list["UserCollaboratorCreate"]) -> dic
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/delete_dataset_datasets_dataset_id_delete.py
+++ b/src/galileo/resources/api/datasets/delete_dataset_datasets_dataset_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(dataset_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/datasets/{dataset_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,7 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(dataset_id: str, *, client: AuthenticatedClient) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(dataset_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Dataset
 
     Args:
@@ -58,12 +60,12 @@ def sync_detailed(dataset_id: str, *, client: AuthenticatedClient) -> Response[U
 
     kwargs = _get_kwargs(dataset_id=dataset_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(dataset_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Dataset
 
     Args:
@@ -80,9 +82,7 @@ def sync(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any,
     return sync_detailed(dataset_id=dataset_id, client=client).parsed
 
 
-async def asyncio_detailed(
-    dataset_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+async def asyncio_detailed(dataset_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Dataset
 
     Args:
@@ -98,12 +98,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(dataset_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Dataset
 
     Args:

--- a/src/galileo/resources/api/datasets/delete_group_dataset_collaborator_datasets_dataset_id_groups_group_id_delete.py
+++ b/src/galileo/resources/api/datasets/delete_group_dataset_collaborator_datasets_dataset_id_groups_group_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(dataset_id: str, group_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/datasets/{dataset_id}/groups/{group_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/groups/{group_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,9 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    dataset_id: str, group_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(dataset_id: str, group_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Group Dataset Collaborator
 
      Remove a group's access to a dataset.
@@ -63,12 +63,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, group_id=group_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(dataset_id: str, group_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(dataset_id: str, group_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Group Dataset Collaborator
 
      Remove a group's access to a dataset.
@@ -89,7 +89,7 @@ def sync(dataset_id: str, group_id: str, *, client: AuthenticatedClient) -> Opti
 
 
 async def asyncio_detailed(
-    dataset_id: str, group_id: str, *, client: AuthenticatedClient
+    dataset_id: str, group_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Group Dataset Collaborator
 
@@ -109,14 +109,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, group_id=group_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    dataset_id: str, group_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(dataset_id: str, group_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Group Dataset Collaborator
 
      Remove a group's access to a dataset.

--- a/src/galileo/resources/api/datasets/delete_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_delete.py
+++ b/src/galileo/resources/api/datasets/delete_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, dataset_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/projects/{project_id}/prompt_datasets/{dataset_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/prompt_datasets/{dataset_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,9 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    project_id: str, dataset_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(project_id: str, dataset_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Prompt Dataset
 
     Args:
@@ -61,12 +61,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, dataset_id=dataset_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(project_id: str, dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(project_id: str, dataset_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Prompt Dataset
 
     Args:
@@ -85,7 +85,7 @@ def sync(project_id: str, dataset_id: str, *, client: AuthenticatedClient) -> Op
 
 
 async def asyncio_detailed(
-    project_id: str, dataset_id: str, *, client: AuthenticatedClient
+    project_id: str, dataset_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Prompt Dataset
 
@@ -103,14 +103,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, dataset_id=dataset_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    project_id: str, dataset_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(project_id: str, dataset_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Prompt Dataset
 
     Args:

--- a/src/galileo/resources/api/datasets/delete_user_dataset_collaborator_datasets_dataset_id_users_user_id_delete.py
+++ b/src/galileo/resources/api/datasets/delete_user_dataset_collaborator_datasets_dataset_id_users_user_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(dataset_id: str, user_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/datasets/{dataset_id}/users/{user_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/users/{user_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,9 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    dataset_id: str, user_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(dataset_id: str, user_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Delete User Dataset Collaborator
 
      Remove a user's access to a dataset.
@@ -63,12 +63,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, user_id=user_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(dataset_id: str, user_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(dataset_id: str, user_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete User Dataset Collaborator
 
      Remove a user's access to a dataset.
@@ -89,7 +89,7 @@ def sync(dataset_id: str, user_id: str, *, client: AuthenticatedClient) -> Optio
 
 
 async def asyncio_detailed(
-    dataset_id: str, user_id: str, *, client: AuthenticatedClient
+    dataset_id: str, user_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete User Dataset Collaborator
 
@@ -109,14 +109,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, user_id=user_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    dataset_id: str, user_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(dataset_id: str, user_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete User Dataset Collaborator
 
      Remove a user's access to a dataset.

--- a/src/galileo/resources/api/datasets/download_dataset_datasets_dataset_id_download_get.py
+++ b/src/galileo/resources/api/datasets/download_dataset_datasets_dataset_id_download_get.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(dataset_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/datasets/{dataset_id}/download"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/download",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,7 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(dataset_id: str, *, client: AuthenticatedClient) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(dataset_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Download Dataset
 
     Args:
@@ -58,12 +60,12 @@ def sync_detailed(dataset_id: str, *, client: AuthenticatedClient) -> Response[U
 
     kwargs = _get_kwargs(dataset_id=dataset_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(dataset_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Download Dataset
 
     Args:
@@ -80,9 +82,7 @@ def sync(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any,
     return sync_detailed(dataset_id=dataset_id, client=client).parsed
 
 
-async def asyncio_detailed(
-    dataset_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+async def asyncio_detailed(dataset_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Download Dataset
 
     Args:
@@ -98,12 +98,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(dataset_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Download Dataset
 
     Args:

--- a/src/galileo/resources/api/datasets/download_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_get.py
+++ b/src/galileo/resources/api/datasets/download_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_get.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, dataset_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/prompt_datasets/{dataset_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/prompt_datasets/{dataset_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = cast(Any, None)
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,9 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    project_id: str, dataset_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(project_id: str, dataset_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Download Prompt Dataset
 
     Args:
@@ -61,12 +61,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, dataset_id=dataset_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(project_id: str, dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(project_id: str, dataset_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Download Prompt Dataset
 
     Args:
@@ -85,7 +85,7 @@ def sync(project_id: str, dataset_id: str, *, client: AuthenticatedClient) -> Op
 
 
 async def asyncio_detailed(
-    project_id: str, dataset_id: str, *, client: AuthenticatedClient
+    project_id: str, dataset_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Download Prompt Dataset
 
@@ -103,14 +103,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, dataset_id=dataset_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    project_id: str, dataset_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(project_id: str, dataset_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Download Prompt Dataset
 
     Args:

--- a/src/galileo/resources/api/datasets/extend_dataset_content_datasets_extend_post.py
+++ b/src/galileo/resources/api/datasets/extend_dataset_content_datasets_extend_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.synthetic_dataset_extension_request import SyntheticDatasetExtensionRequest
 from ...models.synthetic_dataset_extension_response import SyntheticDatasetExtensionResponse
@@ -14,7 +16,7 @@ from ...types import Response
 def _get_kwargs(*, body: SyntheticDatasetExtensionRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/datasets/extend"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/datasets/extend"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +27,7 @@ def _get_kwargs(*, body: SyntheticDatasetExtensionRequest) -> dict[str, Any]:
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, SyntheticDatasetExtensionResponse]]:
     if response.status_code == 200:
         response_200 = SyntheticDatasetExtensionResponse.from_dict(response.json())
@@ -42,7 +44,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, SyntheticDatasetExtensionResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +55,7 @@ def _build_response(
 
 
 def sync_detailed(
-    *, client: AuthenticatedClient, body: SyntheticDatasetExtensionRequest
+    *, client: ApiClient, body: SyntheticDatasetExtensionRequest
 ) -> Response[Union[HTTPValidationError, SyntheticDatasetExtensionResponse]]:
     """Extend Dataset Content
 
@@ -72,13 +74,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    *, client: AuthenticatedClient, body: SyntheticDatasetExtensionRequest
+    *, client: ApiClient, body: SyntheticDatasetExtensionRequest
 ) -> Optional[Union[HTTPValidationError, SyntheticDatasetExtensionResponse]]:
     """Extend Dataset Content
 
@@ -99,7 +101,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, body: SyntheticDatasetExtensionRequest
+    *, client: ApiClient, body: SyntheticDatasetExtensionRequest
 ) -> Response[Union[HTTPValidationError, SyntheticDatasetExtensionResponse]]:
     """Extend Dataset Content
 
@@ -118,13 +120,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    *, client: AuthenticatedClient, body: SyntheticDatasetExtensionRequest
+    *, client: ApiClient, body: SyntheticDatasetExtensionRequest
 ) -> Optional[Union[HTTPValidationError, SyntheticDatasetExtensionResponse]]:
     """Extend Dataset Content
 

--- a/src/galileo/resources/api/datasets/extend_dataset_content_datasets_extend_post.py
+++ b/src/galileo/resources/api/datasets/extend_dataset_content_datasets_extend_post.py
@@ -22,7 +22,7 @@ def _get_kwargs(*, body: SyntheticDatasetExtensionRequest) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/get_dataset_content_datasets_dataset_id_content_get.py
+++ b/src/galileo/resources/api/datasets/get_dataset_content_datasets_dataset_id_content_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_content import DatasetContent
 from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/datasets/{dataset_id}/content", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/content",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[DatasetContent, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DatasetContent.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[DatasetContent, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[DatasetContent, HTTPValidationError]]:
     """Get Dataset Content
 
@@ -78,17 +81,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[DatasetContent, HTTPValidationError]]:
     """Get Dataset Content
 
@@ -109,11 +108,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[DatasetContent, HTTPValidationError]]:
     """Get Dataset Content
 
@@ -132,17 +127,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[DatasetContent, HTTPValidationError]]:
     """Get Dataset Content
 

--- a/src/galileo/resources/api/datasets/get_dataset_datasets_dataset_id_get.py
+++ b/src/galileo/resources/api/datasets/get_dataset_datasets_dataset_id_get.py
@@ -3,22 +3,26 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_db import DatasetDB
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(dataset_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/datasets/{dataset_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DatasetDB, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[DatasetDB, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DatasetDB.from_dict(response.json())
 
@@ -33,9 +37,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[DatasetDB, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[DatasetDB, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -44,7 +46,7 @@ def _build_response(
     )
 
 
-def sync_detailed(dataset_id: str, *, client: AuthenticatedClient) -> Response[Union[DatasetDB, HTTPValidationError]]:
+def sync_detailed(dataset_id: str, *, client: ApiClient) -> Response[Union[DatasetDB, HTTPValidationError]]:
     """Get Dataset
 
     Args:
@@ -60,12 +62,12 @@ def sync_detailed(dataset_id: str, *, client: AuthenticatedClient) -> Response[U
 
     kwargs = _get_kwargs(dataset_id=dataset_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[DatasetDB, HTTPValidationError]]:
+def sync(dataset_id: str, *, client: ApiClient) -> Optional[Union[DatasetDB, HTTPValidationError]]:
     """Get Dataset
 
     Args:
@@ -82,9 +84,7 @@ def sync(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[Data
     return sync_detailed(dataset_id=dataset_id, client=client).parsed
 
 
-async def asyncio_detailed(
-    dataset_id: str, *, client: AuthenticatedClient
-) -> Response[Union[DatasetDB, HTTPValidationError]]:
+async def asyncio_detailed(dataset_id: str, *, client: ApiClient) -> Response[Union[DatasetDB, HTTPValidationError]]:
     """Get Dataset
 
     Args:
@@ -100,12 +100,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[DatasetDB, HTTPValidationError]]:
+async def asyncio(dataset_id: str, *, client: ApiClient) -> Optional[Union[DatasetDB, HTTPValidationError]]:
     """Get Dataset
 
     Args:

--- a/src/galileo/resources/api/datasets/get_dataset_synthetic_extend_status_datasets_extend_dataset_id_get.py
+++ b/src/galileo/resources/api/datasets/get_dataset_synthetic_extend_status_datasets_extend_dataset_id_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.job_progress import JobProgress
 from ...types import Response
 
 
 def _get_kwargs(dataset_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/datasets/extend/{dataset_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/datasets/extend/{dataset_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, JobProgress]]:
     if response.status_code == 200:
         response_200 = JobProgress.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, JobProgress]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -44,7 +50,7 @@ def _build_response(
     )
 
 
-def sync_detailed(dataset_id: str, *, client: AuthenticatedClient) -> Response[Union[HTTPValidationError, JobProgress]]:
+def sync_detailed(dataset_id: str, *, client: ApiClient) -> Response[Union[HTTPValidationError, JobProgress]]:
     """Get Dataset Synthetic Extend Status
 
     Args:
@@ -60,12 +66,12 @@ def sync_detailed(dataset_id: str, *, client: AuthenticatedClient) -> Response[U
 
     kwargs = _get_kwargs(dataset_id=dataset_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPValidationError, JobProgress]]:
+def sync(dataset_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, JobProgress]]:
     """Get Dataset Synthetic Extend Status
 
     Args:
@@ -82,9 +88,7 @@ def sync(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTP
     return sync_detailed(dataset_id=dataset_id, client=client).parsed
 
 
-async def asyncio_detailed(
-    dataset_id: str, *, client: AuthenticatedClient
-) -> Response[Union[HTTPValidationError, JobProgress]]:
+async def asyncio_detailed(dataset_id: str, *, client: ApiClient) -> Response[Union[HTTPValidationError, JobProgress]]:
     """Get Dataset Synthetic Extend Status
 
     Args:
@@ -100,12 +104,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(dataset_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPValidationError, JobProgress]]:
+async def asyncio(dataset_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, JobProgress]]:
     """Get Dataset Synthetic Extend Status
 
     Args:

--- a/src/galileo/resources/api/datasets/get_dataset_version_content_datasets_dataset_id_versions_version_index_content_get.py
+++ b/src/galileo/resources/api/datasets/get_dataset_version_content_datasets_dataset_id_versions_version_index_content_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_content import DatasetContent
 from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response, Unset
@@ -22,8 +24,9 @@ def _get_kwargs(
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
-        "method": "get",
-        "url": f"/datasets/{dataset_id}/versions/{version_index}/content",
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/versions/{version_index}/content",
         "params": params,
     }
 
@@ -31,7 +34,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[DatasetContent, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DatasetContent.from_dict(response.json())
@@ -48,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[DatasetContent, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -62,7 +65,7 @@ def sync_detailed(
     dataset_id: str,
     version_index: int,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
 ) -> Response[Union[DatasetContent, HTTPValidationError]]:
@@ -84,7 +87,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, version_index=version_index, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -93,7 +96,7 @@ def sync(
     dataset_id: str,
     version_index: int,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
 ) -> Optional[Union[DatasetContent, HTTPValidationError]]:
@@ -122,7 +125,7 @@ async def asyncio_detailed(
     dataset_id: str,
     version_index: int,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
 ) -> Response[Union[DatasetContent, HTTPValidationError]]:
@@ -144,7 +147,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, version_index=version_index, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -153,7 +156,7 @@ async def asyncio(
     dataset_id: str,
     version_index: int,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
 ) -> Optional[Union[DatasetContent, HTTPValidationError]]:

--- a/src/galileo/resources/api/datasets/list_dataset_projects_datasets_dataset_id_projects_get.py
+++ b/src/galileo/resources/api/datasets/list_dataset_projects_datasets_dataset_id_projects_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_dataset_projects_response import ListDatasetProjectsResponse
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/datasets/{dataset_id}/projects", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/projects",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListDatasetProjectsResponse]]:
     if response.status_code == 200:
         response_200 = ListDatasetProjectsResponse.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListDatasetProjectsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListDatasetProjectsResponse]]:
     """List Dataset Projects
 
@@ -78,17 +81,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListDatasetProjectsResponse]]:
     """List Dataset Projects
 
@@ -109,11 +108,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListDatasetProjectsResponse]]:
     """List Dataset Projects
 
@@ -132,17 +127,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListDatasetProjectsResponse]]:
     """List Dataset Projects
 

--- a/src/galileo/resources/api/datasets/list_datasets_datasets_get.py
+++ b/src/galileo/resources/api/datasets/list_datasets_datasets_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_action import DatasetAction
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_dataset_response import ListDatasetResponse
@@ -34,13 +36,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": "/datasets", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": "/datasets",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListDatasetResponse]]:
     if response.status_code == 200:
         response_200 = ListDatasetResponse.from_dict(response.json())
@@ -57,7 +64,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListDatasetResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -69,7 +76,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     actions: Union[Unset, list[DatasetAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -92,14 +99,14 @@ def sync_detailed(
 
     kwargs = _get_kwargs(actions=actions, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     actions: Union[Unset, list[DatasetAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -125,7 +132,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     actions: Union[Unset, list[DatasetAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -148,14 +155,14 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(actions=actions, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     actions: Union[Unset, list[DatasetAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/datasets/list_group_dataset_collaborators_datasets_dataset_id_groups_get.py
+++ b/src/galileo/resources/api/datasets/list_group_dataset_collaborators_datasets_dataset_id_groups_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_group_collaborators_response import ListGroupCollaboratorsResponse
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/datasets/{dataset_id}/groups", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/groups",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     if response.status_code == 200:
         response_200 = ListGroupCollaboratorsResponse.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     """List Group Dataset Collaborators
 
@@ -80,17 +83,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     """List Group Dataset Collaborators
 
@@ -113,11 +112,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     """List Group Dataset Collaborators
 
@@ -138,17 +133,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     """List Group Dataset Collaborators
 

--- a/src/galileo/resources/api/datasets/list_prompt_datasets_projects_project_id_prompt_datasets_get.py
+++ b/src/galileo/resources/api/datasets/list_prompt_datasets_projects_project_id_prompt_datasets_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_prompt_dataset_response import ListPromptDatasetResponse
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/prompt_datasets", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/prompt_datasets",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListPromptDatasetResponse]]:
     if response.status_code == 200:
         response_200 = ListPromptDatasetResponse.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListPromptDatasetResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListPromptDatasetResponse]]:
     """List Prompt Datasets
 
@@ -78,17 +81,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListPromptDatasetResponse]]:
     """List Prompt Datasets
 
@@ -109,11 +108,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListPromptDatasetResponse]]:
     """List Prompt Datasets
 
@@ -132,17 +127,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListPromptDatasetResponse]]:
     """List Prompt Datasets
 

--- a/src/galileo/resources/api/datasets/list_user_dataset_collaborators_datasets_dataset_id_users_get.py
+++ b/src/galileo/resources/api/datasets/list_user_dataset_collaborators_datasets_dataset_id_users_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_user_collaborators_response import ListUserCollaboratorsResponse
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/datasets/{dataset_id}/users", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/users",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     if response.status_code == 200:
         response_200 = ListUserCollaboratorsResponse.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Dataset Collaborators
 
@@ -80,17 +83,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Dataset Collaborators
 
@@ -113,11 +112,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Dataset Collaborators
 
@@ -138,17 +133,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    dataset_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Dataset Collaborators
 

--- a/src/galileo/resources/api/datasets/preview_dataset_datasets_dataset_id_preview_post.py
+++ b/src/galileo/resources/api/datasets/preview_dataset_datasets_dataset_id_preview_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_content import DatasetContent
 from ...models.http_validation_error import HTTPValidationError
 from ...models.preview_dataset_request import PreviewDatasetRequest
@@ -28,7 +30,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/datasets/{dataset_id}/preview", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/preview",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -39,7 +46,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[DatasetContent, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DatasetContent.from_dict(response.json())
@@ -56,7 +63,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[DatasetContent, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -69,7 +76,7 @@ def _build_response(
 def sync_detailed(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: PreviewDatasetRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -92,7 +99,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -100,7 +107,7 @@ def sync_detailed(
 def sync(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: PreviewDatasetRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -129,7 +136,7 @@ def sync(
 async def asyncio_detailed(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: PreviewDatasetRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -152,7 +159,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -160,7 +167,7 @@ async def asyncio_detailed(
 async def asyncio(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: PreviewDatasetRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/datasets/preview_dataset_datasets_dataset_id_preview_post.py
+++ b/src/galileo/resources/api/datasets/preview_dataset_datasets_dataset_id_preview_post.py
@@ -41,7 +41,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/query_dataset_content_datasets_dataset_id_content_query_post.py
+++ b/src/galileo/resources/api/datasets/query_dataset_content_datasets_dataset_id_content_query_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_content import DatasetContent
 from ...models.http_validation_error import HTTPValidationError
 from ...models.query_dataset_params import QueryDatasetParams
@@ -24,7 +26,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/datasets/{dataset_id}/content/query", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/content/query",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -35,7 +42,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[DatasetContent, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DatasetContent.from_dict(response.json())
@@ -52,7 +59,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[DatasetContent, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -65,7 +72,7 @@ def _build_response(
 def sync_detailed(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: QueryDatasetParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -88,7 +95,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -96,7 +103,7 @@ def sync_detailed(
 def sync(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: QueryDatasetParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -125,7 +132,7 @@ def sync(
 async def asyncio_detailed(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: QueryDatasetParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -148,7 +155,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -156,7 +163,7 @@ async def asyncio_detailed(
 async def asyncio(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: QueryDatasetParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/datasets/query_dataset_content_datasets_dataset_id_content_query_post.py
+++ b/src/galileo/resources/api/datasets/query_dataset_content_datasets_dataset_id_content_query_post.py
@@ -37,7 +37,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/query_dataset_versions_datasets_dataset_id_versions_query_post.py
+++ b/src/galileo/resources/api/datasets/query_dataset_versions_datasets_dataset_id_versions_query_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_dataset_version_params import ListDatasetVersionParams
 from ...models.list_dataset_version_response import ListDatasetVersionResponse
@@ -28,7 +30,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/datasets/{dataset_id}/versions/query", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/versions/query",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -39,7 +46,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListDatasetVersionResponse]]:
     if response.status_code == 200:
         response_200 = ListDatasetVersionResponse.from_dict(response.json())
@@ -56,7 +63,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListDatasetVersionResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -69,7 +76,7 @@ def _build_response(
 def sync_detailed(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListDatasetVersionParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -92,7 +99,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -100,7 +107,7 @@ def sync_detailed(
 def sync(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListDatasetVersionParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -129,7 +136,7 @@ def sync(
 async def asyncio_detailed(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListDatasetVersionParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -152,7 +159,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -160,7 +167,7 @@ async def asyncio_detailed(
 async def asyncio(
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListDatasetVersionParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/datasets/query_dataset_versions_datasets_dataset_id_versions_query_post.py
+++ b/src/galileo/resources/api/datasets/query_dataset_versions_datasets_dataset_id_versions_query_post.py
@@ -41,7 +41,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/query_datasets_datasets_query_post.py
+++ b/src/galileo/resources/api/datasets/query_datasets_datasets_query_post.py
@@ -51,7 +51,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/query_datasets_datasets_query_post.py
+++ b/src/galileo/resources/api/datasets/query_datasets_datasets_query_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_action import DatasetAction
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_dataset_params import ListDatasetParams
@@ -38,7 +40,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/datasets/query", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": "/datasets/query",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -49,7 +56,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListDatasetResponse]]:
     if response.status_code == 200:
         response_200 = ListDatasetResponse.from_dict(response.json())
@@ -66,7 +73,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListDatasetResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -78,7 +85,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListDatasetParams,
     actions: Union[Unset, list[DatasetAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
@@ -103,14 +110,14 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body, actions=actions, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListDatasetParams,
     actions: Union[Unset, list[DatasetAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
@@ -138,7 +145,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListDatasetParams,
     actions: Union[Unset, list[DatasetAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
@@ -163,14 +170,14 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body, actions=actions, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListDatasetParams,
     actions: Union[Unset, list[DatasetAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,

--- a/src/galileo/resources/api/datasets/update_dataset_content_datasets_dataset_id_content_patch.py
+++ b/src/galileo/resources/api/datasets/update_dataset_content_datasets_dataset_id_content_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.update_dataset_content_request import UpdateDatasetContentRequest
 from ...types import UNSET, Response, Unset
@@ -17,7 +19,11 @@ def _get_kwargs(
     if not isinstance(if_match, Unset):
         headers["If-Match"] = if_match
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/datasets/{dataset_id}/content"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/content",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -27,9 +33,7 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -43,9 +47,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -55,11 +57,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    body: UpdateDatasetContentRequest,
-    if_match: Union[None, Unset, str] = UNSET,
+    dataset_id: str, *, client: ApiClient, body: UpdateDatasetContentRequest, if_match: Union[None, Unset, str] = UNSET
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Update Dataset Content
 
@@ -100,17 +98,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body, if_match=if_match)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    body: UpdateDatasetContentRequest,
-    if_match: Union[None, Unset, str] = UNSET,
+    dataset_id: str, *, client: ApiClient, body: UpdateDatasetContentRequest, if_match: Union[None, Unset, str] = UNSET
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Update Dataset Content
 
@@ -153,11 +147,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    body: UpdateDatasetContentRequest,
-    if_match: Union[None, Unset, str] = UNSET,
+    dataset_id: str, *, client: ApiClient, body: UpdateDatasetContentRequest, if_match: Union[None, Unset, str] = UNSET
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Update Dataset Content
 
@@ -198,17 +188,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body, if_match=if_match)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str,
-    *,
-    client: AuthenticatedClient,
-    body: UpdateDatasetContentRequest,
-    if_match: Union[None, Unset, str] = UNSET,
+    dataset_id: str, *, client: ApiClient, body: UpdateDatasetContentRequest, if_match: Union[None, Unset, str] = UNSET
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Update Dataset Content
 

--- a/src/galileo/resources/api/datasets/update_dataset_content_datasets_dataset_id_content_patch.py
+++ b/src/galileo/resources/api/datasets/update_dataset_content_datasets_dataset_id_content_patch.py
@@ -29,7 +29,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/update_dataset_datasets_dataset_id_patch.py
+++ b/src/galileo/resources/api/datasets/update_dataset_datasets_dataset_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_db import DatasetDB
 from ...models.http_validation_error import HTTPValidationError
 from ...models.update_dataset_request import UpdateDatasetRequest
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(dataset_id: str, *, body: UpdateDatasetRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/datasets/{dataset_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -24,9 +30,7 @@ def _get_kwargs(dataset_id: str, *, body: UpdateDatasetRequest) -> dict[str, Any
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DatasetDB, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[DatasetDB, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DatasetDB.from_dict(response.json())
 
@@ -41,9 +45,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[DatasetDB, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[DatasetDB, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +55,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str, *, client: AuthenticatedClient, body: UpdateDatasetRequest
+    dataset_id: str, *, client: ApiClient, body: UpdateDatasetRequest
 ) -> Response[Union[DatasetDB, HTTPValidationError]]:
     """Update Dataset
 
@@ -71,13 +73,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str, *, client: AuthenticatedClient, body: UpdateDatasetRequest
+    dataset_id: str, *, client: ApiClient, body: UpdateDatasetRequest
 ) -> Optional[Union[DatasetDB, HTTPValidationError]]:
     """Update Dataset
 
@@ -97,7 +99,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str, *, client: AuthenticatedClient, body: UpdateDatasetRequest
+    dataset_id: str, *, client: ApiClient, body: UpdateDatasetRequest
 ) -> Response[Union[DatasetDB, HTTPValidationError]]:
     """Update Dataset
 
@@ -115,13 +117,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str, *, client: AuthenticatedClient, body: UpdateDatasetRequest
+    dataset_id: str, *, client: ApiClient, body: UpdateDatasetRequest
 ) -> Optional[Union[DatasetDB, HTTPValidationError]]:
     """Update Dataset
 

--- a/src/galileo/resources/api/datasets/update_dataset_datasets_dataset_id_patch.py
+++ b/src/galileo/resources/api/datasets/update_dataset_datasets_dataset_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(dataset_id: str, *, body: UpdateDatasetRequest) -> dict[str, Any
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/update_dataset_version_datasets_dataset_id_versions_version_index_patch.py
+++ b/src/galileo/resources/api/datasets/update_dataset_version_datasets_dataset_id_versions_version_index_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.dataset_version_db import DatasetVersionDB
 from ...models.http_validation_error import HTTPValidationError
 from ...models.update_dataset_version_request import UpdateDatasetVersionRequest
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(dataset_id: str, version_index: int, *, body: UpdateDatasetVersionRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/datasets/{dataset_id}/versions/{version_index}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/versions/{version_index}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(dataset_id: str, version_index: int, *, body: UpdateDatasetVersi
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[DatasetVersionDB, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DatasetVersionDB.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[DatasetVersionDB, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str, version_index: int, *, client: AuthenticatedClient, body: UpdateDatasetVersionRequest
+    dataset_id: str, version_index: int, *, client: ApiClient, body: UpdateDatasetVersionRequest
 ) -> Response[Union[DatasetVersionDB, HTTPValidationError]]:
     """Update Dataset Version
 
@@ -72,13 +78,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, version_index=version_index, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str, version_index: int, *, client: AuthenticatedClient, body: UpdateDatasetVersionRequest
+    dataset_id: str, version_index: int, *, client: ApiClient, body: UpdateDatasetVersionRequest
 ) -> Optional[Union[DatasetVersionDB, HTTPValidationError]]:
     """Update Dataset Version
 
@@ -99,7 +105,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str, version_index: int, *, client: AuthenticatedClient, body: UpdateDatasetVersionRequest
+    dataset_id: str, version_index: int, *, client: ApiClient, body: UpdateDatasetVersionRequest
 ) -> Response[Union[DatasetVersionDB, HTTPValidationError]]:
     """Update Dataset Version
 
@@ -118,13 +124,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, version_index=version_index, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str, version_index: int, *, client: AuthenticatedClient, body: UpdateDatasetVersionRequest
+    dataset_id: str, version_index: int, *, client: ApiClient, body: UpdateDatasetVersionRequest
 ) -> Optional[Union[DatasetVersionDB, HTTPValidationError]]:
     """Update Dataset Version
 

--- a/src/galileo/resources/api/datasets/update_dataset_version_datasets_dataset_id_versions_version_index_patch.py
+++ b/src/galileo/resources/api/datasets/update_dataset_version_datasets_dataset_id_versions_version_index_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(dataset_id: str, version_index: int, *, body: UpdateDatasetVersi
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/update_group_dataset_collaborator_datasets_dataset_id_groups_group_id_patch.py
+++ b/src/galileo/resources/api/datasets/update_group_dataset_collaborator_datasets_dataset_id_groups_group_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(dataset_id: str, group_id: str, *, body: CollaboratorUpdate) -> 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/update_group_dataset_collaborator_datasets_dataset_id_groups_group_id_patch.py
+++ b/src/galileo/resources/api/datasets/update_group_dataset_collaborator_datasets_dataset_id_groups_group_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.collaborator_update import CollaboratorUpdate
 from ...models.group_collaborator import GroupCollaborator
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(dataset_id: str, group_id: str, *, body: CollaboratorUpdate) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/datasets/{dataset_id}/groups/{group_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/groups/{group_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(dataset_id: str, group_id: str, *, body: CollaboratorUpdate) -> 
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[GroupCollaborator, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = GroupCollaborator.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[GroupCollaborator, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str, group_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    dataset_id: str, group_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[GroupCollaborator, HTTPValidationError]]:
     """Update Group Dataset Collaborator
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, group_id=group_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str, group_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    dataset_id: str, group_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[GroupCollaborator, HTTPValidationError]]:
     """Update Group Dataset Collaborator
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str, group_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    dataset_id: str, group_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[GroupCollaborator, HTTPValidationError]]:
     """Update Group Dataset Collaborator
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, group_id=group_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str, group_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    dataset_id: str, group_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[GroupCollaborator, HTTPValidationError]]:
     """Update Group Dataset Collaborator
 

--- a/src/galileo/resources/api/datasets/update_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_put.py
+++ b/src/galileo/resources/api/datasets/update_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_put.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.body_update_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_put import (
     BodyUpdatePromptDatasetProjectsProjectIdPromptDatasetsDatasetIdPut,
 )
@@ -53,8 +55,9 @@ def _get_kwargs(
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
-        "method": "put",
-        "url": f"/projects/{project_id}/prompt_datasets/{dataset_id}",
+        "method": RequestMethod.PUT,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/prompt_datasets/{dataset_id}",
         "params": params,
     }
 
@@ -65,7 +68,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, PromptDatasetDB]]:
     if response.status_code == 200:
         response_200 = PromptDatasetDB.from_dict(response.json())
@@ -82,7 +85,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, PromptDatasetDB]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -96,7 +99,7 @@ def sync_detailed(
     project_id: str,
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyUpdatePromptDatasetProjectsProjectIdPromptDatasetsDatasetIdPut,
     file_name: Union[None, Unset, str] = UNSET,
     num_rows: Union[None, Unset, int] = UNSET,
@@ -132,7 +135,7 @@ def sync_detailed(
         hidden=hidden,
     )
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -141,7 +144,7 @@ def sync(
     project_id: str,
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyUpdatePromptDatasetProjectsProjectIdPromptDatasetsDatasetIdPut,
     file_name: Union[None, Unset, str] = UNSET,
     num_rows: Union[None, Unset, int] = UNSET,
@@ -183,7 +186,7 @@ async def asyncio_detailed(
     project_id: str,
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyUpdatePromptDatasetProjectsProjectIdPromptDatasetsDatasetIdPut,
     file_name: Union[None, Unset, str] = UNSET,
     num_rows: Union[None, Unset, int] = UNSET,
@@ -219,7 +222,7 @@ async def asyncio_detailed(
         hidden=hidden,
     )
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -228,7 +231,7 @@ async def asyncio(
     project_id: str,
     dataset_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyUpdatePromptDatasetProjectsProjectIdPromptDatasetsDatasetIdPut,
     file_name: Union[None, Unset, str] = UNSET,
     num_rows: Union[None, Unset, int] = UNSET,

--- a/src/galileo/resources/api/datasets/update_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_put.py
+++ b/src/galileo/resources/api/datasets/update_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_put.py
@@ -63,7 +63,7 @@ def _get_kwargs(
 
     _kwargs["files"] = body.to_multipart()
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/update_user_dataset_collaborator_datasets_dataset_id_users_user_id_patch.py
+++ b/src/galileo/resources/api/datasets/update_user_dataset_collaborator_datasets_dataset_id_users_user_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.collaborator_update import CollaboratorUpdate
 from ...models.http_validation_error import HTTPValidationError
 from ...models.user_collaborator import UserCollaborator
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(dataset_id: str, user_id: str, *, body: CollaboratorUpdate) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/datasets/{dataset_id}/users/{user_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/users/{user_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(dataset_id: str, user_id: str, *, body: CollaboratorUpdate) -> d
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     if response.status_code == 200:
         response_200 = UserCollaborator.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    dataset_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Dataset Collaborator
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, user_id=user_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    dataset_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Dataset Collaborator
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    dataset_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Dataset Collaborator
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, user_id=user_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    dataset_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Dataset Collaborator
 

--- a/src/galileo/resources/api/datasets/update_user_dataset_collaborator_datasets_dataset_id_users_user_id_patch.py
+++ b/src/galileo/resources/api/datasets/update_user_dataset_collaborator_datasets_dataset_id_users_user_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(dataset_id: str, user_id: str, *, body: CollaboratorUpdate) -> d
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/upload_prompt_evaluation_dataset_projects_project_id_prompt_datasets_post.py
+++ b/src/galileo/resources/api/datasets/upload_prompt_evaluation_dataset_projects_project_id_prompt_datasets_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.body_upload_prompt_evaluation_dataset_projects_project_id_prompt_datasets_post import (
     BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost,
 )
@@ -35,7 +37,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/prompt_datasets", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/prompt_datasets",
+        "params": params,
+    }
 
     _kwargs["files"] = body.to_multipart()
 
@@ -44,7 +51,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, PromptDatasetDB]]:
     if response.status_code == 200:
         response_200 = PromptDatasetDB.from_dict(response.json())
@@ -61,7 +68,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, PromptDatasetDB]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -74,7 +81,7 @@ def _build_response(
 def sync_detailed(
     project_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost,
     format_: Union[Unset, DatasetFormat] = UNSET,
     hidden: Union[Unset, bool] = False,
@@ -97,7 +104,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body, format_=format_, hidden=hidden)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -105,7 +112,7 @@ def sync_detailed(
 def sync(
     project_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost,
     format_: Union[Unset, DatasetFormat] = UNSET,
     hidden: Union[Unset, bool] = False,
@@ -132,7 +139,7 @@ def sync(
 async def asyncio_detailed(
     project_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost,
     format_: Union[Unset, DatasetFormat] = UNSET,
     hidden: Union[Unset, bool] = False,
@@ -155,7 +162,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body, format_=format_, hidden=hidden)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -163,7 +170,7 @@ async def asyncio_detailed(
 async def asyncio(
     project_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost,
     format_: Union[Unset, DatasetFormat] = UNSET,
     hidden: Union[Unset, bool] = False,

--- a/src/galileo/resources/api/datasets/upload_prompt_evaluation_dataset_projects_project_id_prompt_datasets_post.py
+++ b/src/galileo/resources/api/datasets/upload_prompt_evaluation_dataset_projects_project_id_prompt_datasets_post.py
@@ -46,7 +46,7 @@ def _get_kwargs(
 
     _kwargs["files"] = body.to_multipart()
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/datasets/upsert_dataset_content_datasets_dataset_id_content_put.py
+++ b/src/galileo/resources/api/datasets/upsert_dataset_content_datasets_dataset_id_content_put.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.rollback_request import RollbackRequest
 from ...models.upsert_dataset_content_request import UpsertDatasetContentRequest
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(dataset_id: str, *, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "put", "url": f"/datasets/{dataset_id}/content"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PUT,
+        "return_raw_response": True,
+        "path": f"/datasets/{dataset_id}/content",
+    }
 
     _kwargs["json"]: dict[str, Any]
     if isinstance(body, RollbackRequest):
@@ -28,9 +34,7 @@ def _get_kwargs(dataset_id: str, *, body: Union["RollbackRequest", "UpsertDatase
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -44,9 +48,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -56,7 +58,7 @@ def _build_response(
 
 
 def sync_detailed(
-    dataset_id: str, *, client: AuthenticatedClient, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]
+    dataset_id: str, *, client: ApiClient, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Upsert Dataset Content
 
@@ -76,13 +78,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    dataset_id: str, *, client: AuthenticatedClient, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]
+    dataset_id: str, *, client: ApiClient, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Upsert Dataset Content
 
@@ -104,7 +106,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    dataset_id: str, *, client: AuthenticatedClient, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]
+    dataset_id: str, *, client: ApiClient, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Upsert Dataset Content
 
@@ -124,13 +126,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(dataset_id=dataset_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    dataset_id: str, *, client: AuthenticatedClient, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]
+    dataset_id: str, *, client: ApiClient, body: Union["RollbackRequest", "UpsertDatasetContentRequest"]
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Upsert Dataset Content
 

--- a/src/galileo/resources/api/datasets/upsert_dataset_content_datasets_dataset_id_content_put.py
+++ b/src/galileo/resources/api/datasets/upsert_dataset_content_datasets_dataset_id_content_put.py
@@ -30,7 +30,7 @@ def _get_kwargs(dataset_id: str, *, body: Union["RollbackRequest", "UpsertDatase
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/experiment/create_experiment_projects_project_id_experiments_post.py
+++ b/src/galileo/resources/api/experiment/create_experiment_projects_project_id_experiments_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: ExperimentCreateRequest) -> dict[str, 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/experiment/create_experiment_projects_project_id_experiments_post.py
+++ b/src/galileo/resources/api/experiment/create_experiment_projects_project_id_experiments_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.experiment_create_request import ExperimentCreateRequest
 from ...models.experiment_response import ExperimentResponse
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: ExperimentCreateRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/experiments"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/experiments",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: ExperimentCreateRequest) -> dict[str, 
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = ExperimentResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: ExperimentCreateRequest
+    project_id: str, *, client: ApiClient, body: ExperimentCreateRequest
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     """Create Experiment
 
@@ -73,13 +79,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: ExperimentCreateRequest
+    project_id: str, *, client: ApiClient, body: ExperimentCreateRequest
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     """Create Experiment
 
@@ -101,7 +107,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: ExperimentCreateRequest
+    project_id: str, *, client: ApiClient, body: ExperimentCreateRequest
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     """Create Experiment
 
@@ -121,13 +127,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: ExperimentCreateRequest
+    project_id: str, *, client: ApiClient, body: ExperimentCreateRequest
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     """Create Experiment
 

--- a/src/galileo/resources/api/experiment/delete_experiment_projects_project_id_experiments_experiment_id_delete.py
+++ b/src/galileo/resources/api/experiment/delete_experiment_projects_project_id_experiments_experiment_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, experiment_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/projects/{project_id}/experiments/{experiment_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/experiments/{experiment_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -43,7 +45,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient
+    project_id: str, experiment_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Experiment
 
@@ -63,14 +65,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, experiment_id=experiment_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(project_id: str, experiment_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Experiment
 
      Delete a specific experiment.
@@ -91,7 +91,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient
+    project_id: str, experiment_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Experiment
 
@@ -111,13 +111,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, experiment_id=experiment_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient
+    project_id: str, experiment_id: str, *, client: ApiClient
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Experiment
 

--- a/src/galileo/resources/api/experiment/experiments_available_columns_projects_project_id_experiments_available_columns_post.py
+++ b/src/galileo/resources/api/experiment/experiments_available_columns_projects_project_id_experiments_available_columns_post.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.experiments_available_columns_response import ExperimentsAvailableColumnsResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/experiments/available_columns"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/experiments/available_columns",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[ExperimentsAvailableColumnsResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = ExperimentsAvailableColumnsResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[ExperimentsAvailableColumnsResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[ExperimentsAvailableColumnsResponse, HTTPValidationError]]:
     """Experiments Available Columns
 
@@ -64,13 +70,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Optional[Union[ExperimentsAvailableColumnsResponse, HTTPValidationError]]:
     """Experiments Available Columns
 
@@ -91,7 +97,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[ExperimentsAvailableColumnsResponse, HTTPValidationError]]:
     """Experiments Available Columns
 
@@ -110,13 +116,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Optional[Union[ExperimentsAvailableColumnsResponse, HTTPValidationError]]:
     """Experiments Available Columns
 

--- a/src/galileo/resources/api/experiment/get_experiment_metrics_projects_project_id_experiments_experiment_id_metrics_post.py
+++ b/src/galileo/resources/api/experiment/get_experiment_metrics_projects_project_id_experiments_experiment_id_metrics_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.experiment_metrics_request import ExperimentMetricsRequest
 from ...models.experiment_metrics_response import ExperimentMetricsResponse
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, experiment_id: str, *, body: ExperimentMetricsRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/experiments/{experiment_id}/metrics"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/experiments/{experiment_id}/metrics",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, experiment_id: str, *, body: ExperimentMetricsR
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = ExperimentMetricsResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient, body: ExperimentMetricsRequest
+    project_id: str, experiment_id: str, *, client: ApiClient, body: ExperimentMetricsRequest
 ) -> Response[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     """Get Experiment Metrics
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, experiment_id=experiment_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient, body: ExperimentMetricsRequest
+    project_id: str, experiment_id: str, *, client: ApiClient, body: ExperimentMetricsRequest
 ) -> Optional[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     """Get Experiment Metrics
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient, body: ExperimentMetricsRequest
+    project_id: str, experiment_id: str, *, client: ApiClient, body: ExperimentMetricsRequest
 ) -> Response[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     """Get Experiment Metrics
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, experiment_id=experiment_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient, body: ExperimentMetricsRequest
+    project_id: str, experiment_id: str, *, client: ApiClient, body: ExperimentMetricsRequest
 ) -> Optional[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     """Get Experiment Metrics
 

--- a/src/galileo/resources/api/experiment/get_experiment_metrics_projects_project_id_experiments_experiment_id_metrics_post.py
+++ b/src/galileo/resources/api/experiment/get_experiment_metrics_projects_project_id_experiments_experiment_id_metrics_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, experiment_id: str, *, body: ExperimentMetricsR
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/experiment/get_experiment_projects_project_id_experiments_experiment_id_get.py
+++ b/src/galileo/resources/api/experiment/get_experiment_projects_project_id_experiments_experiment_id_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.experiment_response import ExperimentResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, experiment_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/experiments/{experiment_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/experiments/{experiment_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = ExperimentResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient
+    project_id: str, experiment_id: str, *, client: ApiClient
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     """Get Experiment
 
@@ -65,13 +71,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, experiment_id=experiment_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient
+    project_id: str, experiment_id: str, *, client: ApiClient
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     """Get Experiment
 
@@ -93,7 +99,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient
+    project_id: str, experiment_id: str, *, client: ApiClient
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     """Get Experiment
 
@@ -113,13 +119,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, experiment_id=experiment_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient
+    project_id: str, experiment_id: str, *, client: ApiClient
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     """Get Experiment
 

--- a/src/galileo/resources/api/experiment/get_experiments_metrics_projects_project_id_experiments_metrics_post.py
+++ b/src/galileo/resources/api/experiment/get_experiments_metrics_projects_project_id_experiments_metrics_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.experiment_metrics_request import ExperimentMetricsRequest
 from ...models.experiment_metrics_response import ExperimentMetricsResponse
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: ExperimentMetricsRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/experiments/metrics"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/experiments/metrics",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: ExperimentMetricsRequest) -> dict[str,
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = ExperimentMetricsResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: ExperimentMetricsRequest
+    project_id: str, *, client: ApiClient, body: ExperimentMetricsRequest
 ) -> Response[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     """Get Experiments Metrics
 
@@ -73,13 +79,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: ExperimentMetricsRequest
+    project_id: str, *, client: ApiClient, body: ExperimentMetricsRequest
 ) -> Optional[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     """Get Experiments Metrics
 
@@ -101,7 +107,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: ExperimentMetricsRequest
+    project_id: str, *, client: ApiClient, body: ExperimentMetricsRequest
 ) -> Response[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     """Get Experiments Metrics
 
@@ -121,13 +127,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: ExperimentMetricsRequest
+    project_id: str, *, client: ApiClient, body: ExperimentMetricsRequest
 ) -> Optional[Union[ExperimentMetricsResponse, HTTPValidationError]]:
     """Get Experiments Metrics
 

--- a/src/galileo/resources/api/experiment/get_experiments_metrics_projects_project_id_experiments_metrics_post.py
+++ b/src/galileo/resources/api/experiment/get_experiments_metrics_projects_project_id_experiments_metrics_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: ExperimentMetricsRequest) -> dict[str,
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/experiment/list_experiments_projects_project_id_experiments_get.py
+++ b/src/galileo/resources/api/experiment/list_experiments_projects_project_id_experiments_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.experiment_response import ExperimentResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/experiments"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/experiments",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["ExperimentResponse"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -39,7 +45,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["ExperimentResponse"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -50,7 +56,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, list["ExperimentResponse"]]]:
     """List Experiments
 
@@ -69,14 +75,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    project_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[HTTPValidationError, list["ExperimentResponse"]]]:
+def sync(project_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, list["ExperimentResponse"]]]:
     """List Experiments
 
      Retrieve all experiments for a project.
@@ -96,7 +100,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, list["ExperimentResponse"]]]:
     """List Experiments
 
@@ -115,13 +119,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, list["ExperimentResponse"]]]:
     """List Experiments
 

--- a/src/galileo/resources/api/experiment/update_experiment_projects_project_id_experiments_experiment_id_put.py
+++ b/src/galileo/resources/api/experiment/update_experiment_projects_project_id_experiments_experiment_id_put.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, experiment_id: str, *, body: ExperimentUpdateRe
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/experiment/update_experiment_projects_project_id_experiments_experiment_id_put.py
+++ b/src/galileo/resources/api/experiment/update_experiment_projects_project_id_experiments_experiment_id_put.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.experiment_response import ExperimentResponse
 from ...models.experiment_update_request import ExperimentUpdateRequest
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, experiment_id: str, *, body: ExperimentUpdateRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "put", "url": f"/projects/{project_id}/experiments/{experiment_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PUT,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/experiments/{experiment_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, experiment_id: str, *, body: ExperimentUpdateRe
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = ExperimentResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient, body: ExperimentUpdateRequest
+    project_id: str, experiment_id: str, *, client: ApiClient, body: ExperimentUpdateRequest
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     """Update Experiment
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, experiment_id=experiment_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient, body: ExperimentUpdateRequest
+    project_id: str, experiment_id: str, *, client: ApiClient, body: ExperimentUpdateRequest
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     """Update Experiment
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient, body: ExperimentUpdateRequest
+    project_id: str, experiment_id: str, *, client: ApiClient, body: ExperimentUpdateRequest
 ) -> Response[Union[ExperimentResponse, HTTPValidationError]]:
     """Update Experiment
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, experiment_id=experiment_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, experiment_id: str, *, client: AuthenticatedClient, body: ExperimentUpdateRequest
+    project_id: str, experiment_id: str, *, client: ApiClient, body: ExperimentUpdateRequest
 ) -> Optional[Union[ExperimentResponse, HTTPValidationError]]:
     """Update Experiment
 

--- a/src/galileo/resources/api/health/healthcheck_healthcheck_get.py
+++ b/src/galileo/resources/api/health/healthcheck_healthcheck_get.py
@@ -1,23 +1,23 @@
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.healthcheck_response import HealthcheckResponse
 from ...types import Response
 
 
 def _get_kwargs() -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": "/healthcheck"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.GET, "return_raw_response": True, "path": "/healthcheck"}
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[HealthcheckResponse]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[HealthcheckResponse]:
     if response.status_code == 200:
         response_200 = HealthcheckResponse.from_dict(response.json())
 
@@ -28,9 +28,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[HealthcheckResponse]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[HealthcheckResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -39,7 +37,7 @@ def _build_response(
     )
 
 
-def sync_detailed(*, client: Union[AuthenticatedClient, Client]) -> Response[HealthcheckResponse]:
+def sync_detailed(*, client: ApiClient) -> Response[HealthcheckResponse]:
     """Healthcheck
 
     Raises:
@@ -52,12 +50,12 @@ def sync_detailed(*, client: Union[AuthenticatedClient, Client]) -> Response[Hea
 
     kwargs = _get_kwargs()
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(*, client: Union[AuthenticatedClient, Client]) -> Optional[HealthcheckResponse]:
+def sync(*, client: ApiClient) -> Optional[HealthcheckResponse]:
     """Healthcheck
 
     Raises:
@@ -71,7 +69,7 @@ def sync(*, client: Union[AuthenticatedClient, Client]) -> Optional[HealthcheckR
     return sync_detailed(client=client).parsed
 
 
-async def asyncio_detailed(*, client: Union[AuthenticatedClient, Client]) -> Response[HealthcheckResponse]:
+async def asyncio_detailed(*, client: ApiClient) -> Response[HealthcheckResponse]:
     """Healthcheck
 
     Raises:
@@ -84,12 +82,12 @@ async def asyncio_detailed(*, client: Union[AuthenticatedClient, Client]) -> Res
 
     kwargs = _get_kwargs()
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(*, client: Union[AuthenticatedClient, Client]) -> Optional[HealthcheckResponse]:
+async def asyncio(*, client: ApiClient) -> Optional[HealthcheckResponse]:
     """Healthcheck
 
     Raises:

--- a/src/galileo/resources/api/jobs/create_job_jobs_post.py
+++ b/src/galileo/resources/api/jobs/create_job_jobs_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.create_job_request import CreateJobRequest
 from ...models.create_job_response import CreateJobResponse
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,7 @@ from ...types import Response
 def _get_kwargs(*, body: CreateJobRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/jobs"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/jobs"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +27,7 @@ def _get_kwargs(*, body: CreateJobRequest) -> dict[str, Any]:
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[CreateJobResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = CreateJobResponse.from_dict(response.json())
@@ -42,7 +44,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[CreateJobResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +55,7 @@ def _build_response(
 
 
 def sync_detailed(
-    *, client: AuthenticatedClient, body: CreateJobRequest
+    *, client: ApiClient, body: CreateJobRequest
 ) -> Response[Union[CreateJobResponse, HTTPValidationError]]:
     """Create Job
 
@@ -70,14 +72,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    *, client: AuthenticatedClient, body: CreateJobRequest
-) -> Optional[Union[CreateJobResponse, HTTPValidationError]]:
+def sync(*, client: ApiClient, body: CreateJobRequest) -> Optional[Union[CreateJobResponse, HTTPValidationError]]:
     """Create Job
 
     Args:
@@ -95,7 +95,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, body: CreateJobRequest
+    *, client: ApiClient, body: CreateJobRequest
 ) -> Response[Union[CreateJobResponse, HTTPValidationError]]:
     """Create Job
 
@@ -112,13 +112,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    *, client: AuthenticatedClient, body: CreateJobRequest
+    *, client: ApiClient, body: CreateJobRequest
 ) -> Optional[Union[CreateJobResponse, HTTPValidationError]]:
     """Create Job
 

--- a/src/galileo/resources/api/jobs/create_job_jobs_post.py
+++ b/src/galileo/resources/api/jobs/create_job_jobs_post.py
@@ -22,7 +22,7 @@ def _get_kwargs(*, body: CreateJobRequest) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/jobs/get_job_jobs_job_id_get.py
+++ b/src/galileo/resources/api/jobs/get_job_jobs_job_id_get.py
@@ -3,22 +3,22 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.job_db import JobDB
 from ...types import Response
 
 
 def _get_kwargs(job_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/jobs/{job_id}"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.GET, "return_raw_response": True, "path": f"/jobs/{job_id}"}
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, JobDB]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, JobDB]]:
     if response.status_code == 200:
         response_200 = JobDB.from_dict(response.json())
 
@@ -33,9 +33,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, JobDB]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, JobDB]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -44,7 +42,7 @@ def _build_response(
     )
 
 
-def sync_detailed(job_id: str, *, client: AuthenticatedClient) -> Response[Union[HTTPValidationError, JobDB]]:
+def sync_detailed(job_id: str, *, client: ApiClient) -> Response[Union[HTTPValidationError, JobDB]]:
     """Get Job
 
      Get a job by id.
@@ -62,12 +60,12 @@ def sync_detailed(job_id: str, *, client: AuthenticatedClient) -> Response[Union
 
     kwargs = _get_kwargs(job_id=job_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(job_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPValidationError, JobDB]]:
+def sync(job_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, JobDB]]:
     """Get Job
 
      Get a job by id.
@@ -86,7 +84,7 @@ def sync(job_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPVali
     return sync_detailed(job_id=job_id, client=client).parsed
 
 
-async def asyncio_detailed(job_id: str, *, client: AuthenticatedClient) -> Response[Union[HTTPValidationError, JobDB]]:
+async def asyncio_detailed(job_id: str, *, client: ApiClient) -> Response[Union[HTTPValidationError, JobDB]]:
     """Get Job
 
      Get a job by id.
@@ -104,12 +102,12 @@ async def asyncio_detailed(job_id: str, *, client: AuthenticatedClient) -> Respo
 
     kwargs = _get_kwargs(job_id=job_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(job_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPValidationError, JobDB]]:
+async def asyncio(job_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, JobDB]]:
     """Get Job
 
      Get a job by id.

--- a/src/galileo/resources/api/jobs/get_jobs_for_project_run_projects_project_id_runs_run_id_jobs_get.py
+++ b/src/galileo/resources/api/jobs/get_jobs_for_project_run_projects_project_id_runs_run_id_jobs_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.job_db import JobDB
 from ...types import UNSET, Response, Unset
@@ -22,13 +24,18 @@ def _get_kwargs(project_id: str, run_id: str, *, status: Union[None, Unset, str]
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/runs/{run_id}/jobs", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/runs/{run_id}/jobs",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["JobDB"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -50,7 +57,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["JobDB"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -61,7 +68,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, status: Union[None, Unset, str] = UNSET
+    project_id: str, run_id: str, *, client: ApiClient, status: Union[None, Unset, str] = UNSET
 ) -> Response[Union[HTTPValidationError, list["JobDB"]]]:
     """Get Jobs For Project Run
 
@@ -84,13 +91,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id, status=status)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, status: Union[None, Unset, str] = UNSET
+    project_id: str, run_id: str, *, client: ApiClient, status: Union[None, Unset, str] = UNSET
 ) -> Optional[Union[HTTPValidationError, list["JobDB"]]]:
     """Get Jobs For Project Run
 
@@ -115,7 +122,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, status: Union[None, Unset, str] = UNSET
+    project_id: str, run_id: str, *, client: ApiClient, status: Union[None, Unset, str] = UNSET
 ) -> Response[Union[HTTPValidationError, list["JobDB"]]]:
     """Get Jobs For Project Run
 
@@ -138,13 +145,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id, status=status)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, status: Union[None, Unset, str] = UNSET
+    project_id: str, run_id: str, *, client: ApiClient, status: Union[None, Unset, str] = UNSET
 ) -> Optional[Union[HTTPValidationError, list["JobDB"]]]:
     """Get Jobs For Project Run
 

--- a/src/galileo/resources/api/jobs/get_latest_job_for_project_run_projects_project_id_runs_run_id_jobs_latest_get.py
+++ b/src/galileo/resources/api/jobs/get_latest_job_for_project_run_projects_project_id_runs_run_id_jobs_latest_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.job_db import JobDB
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, run_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/runs/{run_id}/jobs/latest"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/runs/{run_id}/jobs/latest",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, Union["JobDB", None]]]:
     if response.status_code == 200:
 
@@ -48,7 +54,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, Union["JobDB", None]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -59,7 +65,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient
+    project_id: str, run_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, Union["JobDB", None]]]:
     """Get Latest Job For Project Run
 
@@ -79,13 +85,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, run_id: str, *, client: AuthenticatedClient
+    project_id: str, run_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, Union["JobDB", None]]]:
     """Get Latest Job For Project Run
 
@@ -107,7 +113,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient
+    project_id: str, run_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, Union["JobDB", None]]]:
     """Get Latest Job For Project Run
 
@@ -127,13 +133,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, run_id: str, *, client: AuthenticatedClient
+    project_id: str, run_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, Union["JobDB", None]]]:
     """Get Latest Job For Project Run
 

--- a/src/galileo/resources/api/log_stream/create_log_stream_projects_project_id_log_streams_post.py
+++ b/src/galileo/resources/api/log_stream/create_log_stream_projects_project_id_log_streams_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_stream_create_request import LogStreamCreateRequest
 from ...models.log_stream_response import LogStreamResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogStreamCreateRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/log_streams"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/log_streams",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogStreamCreateRequest) -> dict[str, A
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     if response.status_code == 200:
         response_200 = LogStreamResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogStreamCreateRequest
+    project_id: str, *, client: ApiClient, body: LogStreamCreateRequest
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     """Create Log Stream
 
@@ -73,13 +79,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogStreamCreateRequest
+    project_id: str, *, client: ApiClient, body: LogStreamCreateRequest
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     """Create Log Stream
 
@@ -101,7 +107,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogStreamCreateRequest
+    project_id: str, *, client: ApiClient, body: LogStreamCreateRequest
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     """Create Log Stream
 
@@ -121,13 +127,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogStreamCreateRequest
+    project_id: str, *, client: ApiClient, body: LogStreamCreateRequest
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     """Create Log Stream
 

--- a/src/galileo/resources/api/log_stream/create_log_stream_projects_project_id_log_streams_post.py
+++ b/src/galileo/resources/api/log_stream/create_log_stream_projects_project_id_log_streams_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogStreamCreateRequest) -> dict[str, A
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/log_stream/delete_log_stream_projects_project_id_log_streams_log_stream_id_delete.py
+++ b/src/galileo/resources/api/log_stream/delete_log_stream_projects_project_id_log_streams_log_stream_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, log_stream_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/projects/{project_id}/log_streams/{log_stream_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/log_streams/{log_stream_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -43,7 +45,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient
+    project_id: str, log_stream_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Log Stream
 
@@ -63,14 +65,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, log_stream_id=log_stream_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(project_id: str, log_stream_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Log Stream
 
      Delete a specific log stream.
@@ -91,7 +91,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient
+    project_id: str, log_stream_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Log Stream
 
@@ -111,13 +111,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, log_stream_id=log_stream_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient
+    project_id: str, log_stream_id: str, *, client: ApiClient
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Log Stream
 

--- a/src/galileo/resources/api/log_stream/get_log_stream_projects_project_id_log_streams_log_stream_id_get.py
+++ b/src/galileo/resources/api/log_stream/get_log_stream_projects_project_id_log_streams_log_stream_id_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_stream_response import LogStreamResponse
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, log_stream_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/log_streams/{log_stream_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/log_streams/{log_stream_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     if response.status_code == 200:
         response_200 = LogStreamResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient
+    project_id: str, log_stream_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     """Get Log Stream
 
@@ -65,13 +71,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, log_stream_id=log_stream_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient
+    project_id: str, log_stream_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     """Get Log Stream
 
@@ -93,7 +99,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient
+    project_id: str, log_stream_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     """Get Log Stream
 
@@ -113,13 +119,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, log_stream_id=log_stream_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient
+    project_id: str, log_stream_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     """Get Log Stream
 

--- a/src/galileo/resources/api/log_stream/list_log_streams_projects_project_id_log_streams_get.py
+++ b/src/galileo/resources/api/log_stream/list_log_streams_projects_project_id_log_streams_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_stream_response import LogStreamResponse
 from ...types import Response
 
 
 def _get_kwargs(project_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/log_streams"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/log_streams",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["LogStreamResponse"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -39,7 +45,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["LogStreamResponse"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -50,7 +56,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, list["LogStreamResponse"]]]:
     """List Log Streams
 
@@ -69,14 +75,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    project_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[HTTPValidationError, list["LogStreamResponse"]]]:
+def sync(project_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, list["LogStreamResponse"]]]:
     """List Log Streams
 
      Retrieve all log streams for a project.
@@ -96,7 +100,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, list["LogStreamResponse"]]]:
     """List Log Streams
 
@@ -115,13 +119,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, list["LogStreamResponse"]]]:
     """List Log Streams
 

--- a/src/galileo/resources/api/log_stream/update_log_stream_projects_project_id_log_streams_log_stream_id_put.py
+++ b/src/galileo/resources/api/log_stream/update_log_stream_projects_project_id_log_streams_log_stream_id_put.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_stream_response import LogStreamResponse
 from ...models.log_stream_update_request import LogStreamUpdateRequest
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, log_stream_id: str, *, body: LogStreamUpdateRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "put", "url": f"/projects/{project_id}/log_streams/{log_stream_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PUT,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/log_streams/{log_stream_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, log_stream_id: str, *, body: LogStreamUpdateReq
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     if response.status_code == 200:
         response_200 = LogStreamResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient, body: LogStreamUpdateRequest
+    project_id: str, log_stream_id: str, *, client: ApiClient, body: LogStreamUpdateRequest
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     """Update Log Stream
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, log_stream_id=log_stream_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient, body: LogStreamUpdateRequest
+    project_id: str, log_stream_id: str, *, client: ApiClient, body: LogStreamUpdateRequest
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     """Update Log Stream
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient, body: LogStreamUpdateRequest
+    project_id: str, log_stream_id: str, *, client: ApiClient, body: LogStreamUpdateRequest
 ) -> Response[Union[HTTPValidationError, LogStreamResponse]]:
     """Update Log Stream
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, log_stream_id=log_stream_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, log_stream_id: str, *, client: AuthenticatedClient, body: LogStreamUpdateRequest
+    project_id: str, log_stream_id: str, *, client: ApiClient, body: LogStreamUpdateRequest
 ) -> Optional[Union[HTTPValidationError, LogStreamResponse]]:
     """Update Log Stream
 

--- a/src/galileo/resources/api/log_stream/update_log_stream_projects_project_id_log_streams_log_stream_id_put.py
+++ b/src/galileo/resources/api/log_stream/update_log_stream_projects_project_id_log_streams_log_stream_id_put.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, log_stream_id: str, *, body: LogStreamUpdateReq
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/create_group_project_collaborators_projects_project_id_groups_post.py
+++ b/src/galileo/resources/api/projects/create_group_project_collaborators_projects_project_id_groups_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.group_collaborator import GroupCollaborator
 from ...models.group_collaborator_create import GroupCollaboratorCreate
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: list["GroupCollaboratorCreate"]) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/groups"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/groups",
+    }
 
     _kwargs["json"] = []
     for body_item_data in body:
@@ -28,7 +34,7 @@ def _get_kwargs(project_id: str, *, body: list["GroupCollaboratorCreate"]) -> di
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -50,7 +56,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -61,7 +67,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: list["GroupCollaboratorCreate"]
+    project_id: str, *, client: ApiClient, body: list["GroupCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     """Create Group Project Collaborators
 
@@ -81,13 +87,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: list["GroupCollaboratorCreate"]
+    project_id: str, *, client: ApiClient, body: list["GroupCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     """Create Group Project Collaborators
 
@@ -109,7 +115,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: list["GroupCollaboratorCreate"]
+    project_id: str, *, client: ApiClient, body: list["GroupCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     """Create Group Project Collaborators
 
@@ -129,13 +135,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: list["GroupCollaboratorCreate"]
+    project_id: str, *, client: ApiClient, body: list["GroupCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["GroupCollaborator"]]]:
     """Create Group Project Collaborators
 

--- a/src/galileo/resources/api/projects/create_group_project_collaborators_projects_project_id_groups_post.py
+++ b/src/galileo/resources/api/projects/create_group_project_collaborators_projects_project_id_groups_post.py
@@ -29,7 +29,7 @@ def _get_kwargs(project_id: str, *, body: list["GroupCollaboratorCreate"]) -> di
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/create_project_projects_post.py
+++ b/src/galileo/resources/api/projects/create_project_projects_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.project_create import ProjectCreate
 from ...models.project_create_response import ProjectCreateResponse
@@ -14,7 +16,7 @@ from ...types import Response
 def _get_kwargs(*, body: ProjectCreate) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/projects"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/projects"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +27,7 @@ def _get_kwargs(*, body: ProjectCreate) -> dict[str, Any]:
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ProjectCreateResponse]]:
     if response.status_code == 200:
         response_200 = ProjectCreateResponse.from_dict(response.json())
@@ -42,7 +44,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ProjectCreateResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +55,7 @@ def _build_response(
 
 
 def sync_detailed(
-    *, client: AuthenticatedClient, body: ProjectCreate
+    *, client: ApiClient, body: ProjectCreate
 ) -> Response[Union[HTTPValidationError, ProjectCreateResponse]]:
     """Create Project
 
@@ -72,14 +74,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    *, client: AuthenticatedClient, body: ProjectCreate
-) -> Optional[Union[HTTPValidationError, ProjectCreateResponse]]:
+def sync(*, client: ApiClient, body: ProjectCreate) -> Optional[Union[HTTPValidationError, ProjectCreateResponse]]:
     """Create Project
 
      Create a new project.
@@ -99,7 +99,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, body: ProjectCreate
+    *, client: ApiClient, body: ProjectCreate
 ) -> Response[Union[HTTPValidationError, ProjectCreateResponse]]:
     """Create Project
 
@@ -118,13 +118,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    *, client: AuthenticatedClient, body: ProjectCreate
+    *, client: ApiClient, body: ProjectCreate
 ) -> Optional[Union[HTTPValidationError, ProjectCreateResponse]]:
     """Create Project
 

--- a/src/galileo/resources/api/projects/create_project_projects_post.py
+++ b/src/galileo/resources/api/projects/create_project_projects_post.py
@@ -22,7 +22,7 @@ def _get_kwargs(*, body: ProjectCreate) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/create_user_project_collaborators_projects_project_id_users_post.py
+++ b/src/galileo/resources/api/projects/create_user_project_collaborators_projects_project_id_users_post.py
@@ -29,7 +29,7 @@ def _get_kwargs(project_id: str, *, body: list["UserCollaboratorCreate"]) -> dic
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/create_user_project_collaborators_projects_project_id_users_post.py
+++ b/src/galileo/resources/api/projects/create_user_project_collaborators_projects_project_id_users_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.user_collaborator import UserCollaborator
 from ...models.user_collaborator_create import UserCollaboratorCreate
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: list["UserCollaboratorCreate"]) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/users"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/users",
+    }
 
     _kwargs["json"] = []
     for body_item_data in body:
@@ -28,7 +34,7 @@ def _get_kwargs(project_id: str, *, body: list["UserCollaboratorCreate"]) -> dic
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -50,7 +56,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -61,7 +67,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    project_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Project Collaborators
 
@@ -81,13 +87,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    project_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Project Collaborators
 
@@ -109,7 +115,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    project_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Project Collaborators
 
@@ -129,13 +135,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    project_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Project Collaborators
 

--- a/src/galileo/resources/api/projects/delete_group_project_collaborator_projects_project_id_groups_group_id_delete.py
+++ b/src/galileo/resources/api/projects/delete_group_project_collaborator_projects_project_id_groups_group_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, group_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/projects/{project_id}/groups/{group_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/groups/{group_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,9 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    project_id: str, group_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(project_id: str, group_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Group Project Collaborator
 
      Remove a group's access to a project.
@@ -63,12 +63,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, group_id=group_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(project_id: str, group_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(project_id: str, group_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Group Project Collaborator
 
      Remove a group's access to a project.
@@ -89,7 +89,7 @@ def sync(project_id: str, group_id: str, *, client: AuthenticatedClient) -> Opti
 
 
 async def asyncio_detailed(
-    project_id: str, group_id: str, *, client: AuthenticatedClient
+    project_id: str, group_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete Group Project Collaborator
 
@@ -109,14 +109,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, group_id=group_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    project_id: str, group_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(project_id: str, group_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete Group Project Collaborator
 
      Remove a group's access to a project.

--- a/src/galileo/resources/api/projects/delete_project_projects_project_id_delete.py
+++ b/src/galileo/resources/api/projects/delete_project_projects_project_id_delete.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.project_delete_response import ProjectDeleteResponse
 from ...types import Response
 
 
 def _get_kwargs(project_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/projects/{project_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ProjectDeleteResponse]]:
     if response.status_code == 200:
         response_200 = ProjectDeleteResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ProjectDeleteResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -44,9 +50,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient
-) -> Response[Union[HTTPValidationError, ProjectDeleteResponse]]:
+def sync_detailed(project_id: str, *, client: ApiClient) -> Response[Union[HTTPValidationError, ProjectDeleteResponse]]:
     """Delete Project
 
      Deletes a project and all associated runs and objects.
@@ -67,14 +71,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    project_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[HTTPValidationError, ProjectDeleteResponse]]:
+def sync(project_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, ProjectDeleteResponse]]:
     """Delete Project
 
      Deletes a project and all associated runs and objects.
@@ -97,7 +99,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, ProjectDeleteResponse]]:
     """Delete Project
 
@@ -119,14 +121,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    project_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[HTTPValidationError, ProjectDeleteResponse]]:
+async def asyncio(project_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, ProjectDeleteResponse]]:
     """Delete Project
 
      Deletes a project and all associated runs and objects.

--- a/src/galileo/resources/api/projects/delete_user_project_collaborator_projects_project_id_users_user_id_delete.py
+++ b/src/galileo/resources/api/projects/delete_user_project_collaborator_projects_project_id_users_user_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, user_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/projects/{project_id}/users/{user_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/users/{user_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,9 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    project_id: str, user_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(project_id: str, user_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Delete User Project Collaborator
 
      Remove a user's access to a project.
@@ -63,12 +63,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, user_id=user_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(project_id: str, user_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(project_id: str, user_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete User Project Collaborator
 
      Remove a user's access to a project.
@@ -89,7 +89,7 @@ def sync(project_id: str, user_id: str, *, client: AuthenticatedClient) -> Optio
 
 
 async def asyncio_detailed(
-    project_id: str, user_id: str, *, client: AuthenticatedClient
+    project_id: str, user_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete User Project Collaborator
 
@@ -109,14 +109,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, user_id=user_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    project_id: str, user_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(project_id: str, user_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete User Project Collaborator
 
      Remove a user's access to a project.

--- a/src/galileo/resources/api/projects/get_all_projects_projects_all_get.py
+++ b/src/galileo/resources/api/projects/get_all_projects_projects_all_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.project_db_thin import ProjectDBThin
 from ...models.project_type import ProjectType
@@ -25,13 +27,18 @@ def _get_kwargs(*, type_: Union[None, ProjectType, Unset] = UNSET) -> dict[str, 
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": "/projects/all", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": "/projects/all",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["ProjectDBThin"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -53,7 +60,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["ProjectDBThin"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -64,7 +71,7 @@ def _build_response(
 
 
 def sync_detailed(
-    *, client: AuthenticatedClient, type_: Union[None, ProjectType, Unset] = UNSET
+    *, client: ApiClient, type_: Union[None, ProjectType, Unset] = UNSET
 ) -> Response[Union[HTTPValidationError, list["ProjectDBThin"]]]:
     """Get All Projects
 
@@ -87,13 +94,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(type_=type_)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    *, client: AuthenticatedClient, type_: Union[None, ProjectType, Unset] = UNSET
+    *, client: ApiClient, type_: Union[None, ProjectType, Unset] = UNSET
 ) -> Optional[Union[HTTPValidationError, list["ProjectDBThin"]]]:
     """Get All Projects
 
@@ -118,7 +125,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, type_: Union[None, ProjectType, Unset] = UNSET
+    *, client: ApiClient, type_: Union[None, ProjectType, Unset] = UNSET
 ) -> Response[Union[HTTPValidationError, list["ProjectDBThin"]]]:
     """Get All Projects
 
@@ -141,13 +148,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(type_=type_)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    *, client: AuthenticatedClient, type_: Union[None, ProjectType, Unset] = UNSET
+    *, client: ApiClient, type_: Union[None, ProjectType, Unset] = UNSET
 ) -> Optional[Union[HTTPValidationError, list["ProjectDBThin"]]]:
     """Get All Projects
 

--- a/src/galileo/resources/api/projects/get_collaborator_roles_collaborator_roles_get.py
+++ b/src/galileo/resources/api/projects/get_collaborator_roles_collaborator_roles_get.py
@@ -1,23 +1,23 @@
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.collaborator_role_info import CollaboratorRoleInfo
 from ...types import Response
 
 
 def _get_kwargs() -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": "/collaborator_roles"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.GET, "return_raw_response": True, "path": "/collaborator_roles"}
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["CollaboratorRoleInfo"]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[list["CollaboratorRoleInfo"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -33,9 +33,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["CollaboratorRoleInfo"]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[list["CollaboratorRoleInfo"]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -44,7 +42,7 @@ def _build_response(
     )
 
 
-def sync_detailed(*, client: AuthenticatedClient) -> Response[list["CollaboratorRoleInfo"]]:
+def sync_detailed(*, client: ApiClient) -> Response[list["CollaboratorRoleInfo"]]:
     """Get Collaborator Roles
 
     Raises:
@@ -57,12 +55,12 @@ def sync_detailed(*, client: AuthenticatedClient) -> Response[list["Collaborator
 
     kwargs = _get_kwargs()
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(*, client: AuthenticatedClient) -> Optional[list["CollaboratorRoleInfo"]]:
+def sync(*, client: ApiClient) -> Optional[list["CollaboratorRoleInfo"]]:
     """Get Collaborator Roles
 
     Raises:
@@ -76,7 +74,7 @@ def sync(*, client: AuthenticatedClient) -> Optional[list["CollaboratorRoleInfo"
     return sync_detailed(client=client).parsed
 
 
-async def asyncio_detailed(*, client: AuthenticatedClient) -> Response[list["CollaboratorRoleInfo"]]:
+async def asyncio_detailed(*, client: ApiClient) -> Response[list["CollaboratorRoleInfo"]]:
     """Get Collaborator Roles
 
     Raises:
@@ -89,12 +87,12 @@ async def asyncio_detailed(*, client: AuthenticatedClient) -> Response[list["Col
 
     kwargs = _get_kwargs()
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(*, client: AuthenticatedClient) -> Optional[list["CollaboratorRoleInfo"]]:
+async def asyncio(*, client: ApiClient) -> Optional[list["CollaboratorRoleInfo"]]:
     """Get Collaborator Roles
 
     Raises:

--- a/src/galileo/resources/api/projects/get_project_projects_project_id_get.py
+++ b/src/galileo/resources/api/projects/get_project_projects_project_id_get.py
@@ -3,22 +3,26 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.project_db import ProjectDB
 from ...types import Response
 
 
 def _get_kwargs(project_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, ProjectDB]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, ProjectDB]]:
     if response.status_code == 200:
         response_200 = ProjectDB.from_dict(response.json())
 
@@ -33,9 +37,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, ProjectDB]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, ProjectDB]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -44,7 +46,7 @@ def _build_response(
     )
 
 
-def sync_detailed(project_id: str, *, client: AuthenticatedClient) -> Response[Union[HTTPValidationError, ProjectDB]]:
+def sync_detailed(project_id: str, *, client: ApiClient) -> Response[Union[HTTPValidationError, ProjectDB]]:
     """Get Project
 
     Args:
@@ -60,12 +62,12 @@ def sync_detailed(project_id: str, *, client: AuthenticatedClient) -> Response[U
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(project_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPValidationError, ProjectDB]]:
+def sync(project_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, ProjectDB]]:
     """Get Project
 
     Args:
@@ -82,9 +84,7 @@ def sync(project_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTP
     return sync_detailed(project_id=project_id, client=client).parsed
 
 
-async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient
-) -> Response[Union[HTTPValidationError, ProjectDB]]:
+async def asyncio_detailed(project_id: str, *, client: ApiClient) -> Response[Union[HTTPValidationError, ProjectDB]]:
     """Get Project
 
     Args:
@@ -100,12 +100,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(project_id: str, *, client: AuthenticatedClient) -> Optional[Union[HTTPValidationError, ProjectDB]]:
+async def asyncio(project_id: str, *, client: ApiClient) -> Optional[Union[HTTPValidationError, ProjectDB]]:
     """Get Project
 
     Args:

--- a/src/galileo/resources/api/projects/get_projects_count_projects_count_post.py
+++ b/src/galileo/resources/api/projects/get_projects_count_projects_count_post.py
@@ -21,7 +21,7 @@ def _get_kwargs(*, body: ProjectCollectionParams) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/get_projects_count_projects_count_post.py
+++ b/src/galileo/resources/api/projects/get_projects_count_projects_count_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.project_collection_params import ProjectCollectionParams
 from ...types import Response
@@ -13,7 +15,7 @@ from ...types import Response
 def _get_kwargs(*, body: ProjectCollectionParams) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/projects/count"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/projects/count"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -23,9 +25,7 @@ def _get_kwargs(*, body: ProjectCollectionParams) -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, int]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, int]]:
     if response.status_code == 200:
         response_200 = cast(int, response.json())
         return response_200
@@ -39,9 +39,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, int]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, int]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,9 +48,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    *, client: AuthenticatedClient, body: ProjectCollectionParams
-) -> Response[Union[HTTPValidationError, int]]:
+def sync_detailed(*, client: ApiClient, body: ProjectCollectionParams) -> Response[Union[HTTPValidationError, int]]:
     """Get Projects Count
 
      Gets total count of projects for a user with applied filters.
@@ -70,12 +66,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(*, client: AuthenticatedClient, body: ProjectCollectionParams) -> Optional[Union[HTTPValidationError, int]]:
+def sync(*, client: ApiClient, body: ProjectCollectionParams) -> Optional[Union[HTTPValidationError, int]]:
     """Get Projects Count
 
      Gets total count of projects for a user with applied filters.
@@ -95,7 +91,7 @@ def sync(*, client: AuthenticatedClient, body: ProjectCollectionParams) -> Optio
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, body: ProjectCollectionParams
+    *, client: ApiClient, body: ProjectCollectionParams
 ) -> Response[Union[HTTPValidationError, int]]:
     """Get Projects Count
 
@@ -114,14 +110,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    *, client: AuthenticatedClient, body: ProjectCollectionParams
-) -> Optional[Union[HTTPValidationError, int]]:
+async def asyncio(*, client: ApiClient, body: ProjectCollectionParams) -> Optional[Union[HTTPValidationError, int]]:
     """Get Projects Count
 
      Gets total count of projects for a user with applied filters.

--- a/src/galileo/resources/api/projects/get_projects_paginated_projects_paginated_post.py
+++ b/src/galileo/resources/api/projects/get_projects_paginated_projects_paginated_post.py
@@ -51,7 +51,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/get_projects_paginated_projects_paginated_post.py
+++ b/src/galileo/resources/api/projects/get_projects_paginated_projects_paginated_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.get_projects_paginated_response import GetProjectsPaginatedResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...models.project_action import ProjectAction
@@ -38,7 +40,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/projects/paginated", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": "/projects/paginated",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -49,7 +56,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[GetProjectsPaginatedResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = GetProjectsPaginatedResponse.from_dict(response.json())
@@ -66,7 +73,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[GetProjectsPaginatedResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -78,7 +85,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ProjectCollectionParams,
     actions: Union[Unset, list[ProjectAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
@@ -107,14 +114,14 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body, actions=actions, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ProjectCollectionParams,
     actions: Union[Unset, list[ProjectAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
@@ -146,7 +153,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ProjectCollectionParams,
     actions: Union[Unset, list[ProjectAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,
@@ -175,14 +182,14 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body, actions=actions, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ProjectCollectionParams,
     actions: Union[Unset, list[ProjectAction]] = UNSET,
     starting_token: Union[Unset, int] = 0,

--- a/src/galileo/resources/api/projects/get_projects_projects_get.py
+++ b/src/galileo/resources/api/projects/get_projects_projects_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.project_db import ProjectDB
 from ...models.project_type import ProjectType
@@ -34,13 +36,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": "/projects", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": "/projects",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["ProjectDB"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -62,7 +69,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["ProjectDB"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -73,10 +80,7 @@ def _build_response(
 
 
 def sync_detailed(
-    *,
-    client: AuthenticatedClient,
-    project_name: Union[None, Unset, str] = UNSET,
-    type_: Union[None, ProjectType, Unset] = UNSET,
+    *, client: ApiClient, project_name: Union[None, Unset, str] = UNSET, type_: Union[None, ProjectType, Unset] = UNSET
 ) -> Response[Union[HTTPValidationError, list["ProjectDB"]]]:
     """Get Projects
 
@@ -100,16 +104,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_name=project_name, type_=type_)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    *,
-    client: AuthenticatedClient,
-    project_name: Union[None, Unset, str] = UNSET,
-    type_: Union[None, ProjectType, Unset] = UNSET,
+    *, client: ApiClient, project_name: Union[None, Unset, str] = UNSET, type_: Union[None, ProjectType, Unset] = UNSET
 ) -> Optional[Union[HTTPValidationError, list["ProjectDB"]]]:
     """Get Projects
 
@@ -135,10 +136,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *,
-    client: AuthenticatedClient,
-    project_name: Union[None, Unset, str] = UNSET,
-    type_: Union[None, ProjectType, Unset] = UNSET,
+    *, client: ApiClient, project_name: Union[None, Unset, str] = UNSET, type_: Union[None, ProjectType, Unset] = UNSET
 ) -> Response[Union[HTTPValidationError, list["ProjectDB"]]]:
     """Get Projects
 
@@ -162,16 +160,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_name=project_name, type_=type_)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    *,
-    client: AuthenticatedClient,
-    project_name: Union[None, Unset, str] = UNSET,
-    type_: Union[None, ProjectType, Unset] = UNSET,
+    *, client: ApiClient, project_name: Union[None, Unset, str] = UNSET, type_: Union[None, ProjectType, Unset] = UNSET
 ) -> Optional[Union[HTTPValidationError, list["ProjectDB"]]]:
     """Get Projects
 

--- a/src/galileo/resources/api/projects/list_group_project_collaborators_projects_project_id_groups_get.py
+++ b/src/galileo/resources/api/projects/list_group_project_collaborators_projects_project_id_groups_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_group_collaborators_response import ListGroupCollaboratorsResponse
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/groups", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/groups",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     if response.status_code == 200:
         response_200 = ListGroupCollaboratorsResponse.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     """List Group Project Collaborators
 
@@ -80,17 +83,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     """List Group Project Collaborators
 
@@ -113,11 +112,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     """List Group Project Collaborators
 
@@ -138,17 +133,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListGroupCollaboratorsResponse]]:
     """List Group Project Collaborators
 

--- a/src/galileo/resources/api/projects/list_user_project_collaborators_projects_project_id_users_get.py
+++ b/src/galileo/resources/api/projects/list_user_project_collaborators_projects_project_id_users_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_user_collaborators_response import ListUserCollaboratorsResponse
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/users", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/users",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     if response.status_code == 200:
         response_200 = ListUserCollaboratorsResponse.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Project Collaborators
 
@@ -80,17 +83,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Project Collaborators
 
@@ -113,11 +112,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Project Collaborators
 
@@ -138,17 +133,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    project_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Project Collaborators
 

--- a/src/galileo/resources/api/projects/update_group_project_collaborator_projects_project_id_groups_group_id_patch.py
+++ b/src/galileo/resources/api/projects/update_group_project_collaborator_projects_project_id_groups_group_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.collaborator_update import CollaboratorUpdate
 from ...models.group_collaborator import GroupCollaborator
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, group_id: str, *, body: CollaboratorUpdate) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/projects/{project_id}/groups/{group_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/groups/{group_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, group_id: str, *, body: CollaboratorUpdate) -> 
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[GroupCollaborator, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = GroupCollaborator.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[GroupCollaborator, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, group_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    project_id: str, group_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[GroupCollaborator, HTTPValidationError]]:
     """Update Group Project Collaborator
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, group_id=group_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, group_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    project_id: str, group_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[GroupCollaborator, HTTPValidationError]]:
     """Update Group Project Collaborator
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, group_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    project_id: str, group_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[GroupCollaborator, HTTPValidationError]]:
     """Update Group Project Collaborator
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, group_id=group_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, group_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    project_id: str, group_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[GroupCollaborator, HTTPValidationError]]:
     """Update Group Project Collaborator
 

--- a/src/galileo/resources/api/projects/update_group_project_collaborator_projects_project_id_groups_group_id_patch.py
+++ b/src/galileo/resources/api/projects/update_group_project_collaborator_projects_project_id_groups_group_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, group_id: str, *, body: CollaboratorUpdate) -> 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/update_project_projects_project_id_put.py
+++ b/src/galileo/resources/api/projects/update_project_projects_project_id_put.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.project_update import ProjectUpdate
 from ...models.project_update_response import ProjectUpdateResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: ProjectUpdate) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "put", "url": f"/projects/{project_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PUT,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: ProjectUpdate) -> dict[str, Any]:
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ProjectUpdateResponse]]:
     if response.status_code == 200:
         response_200 = ProjectUpdateResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ProjectUpdateResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: ProjectUpdate
+    project_id: str, *, client: ApiClient, body: ProjectUpdate
 ) -> Response[Union[HTTPValidationError, ProjectUpdateResponse]]:
     """Update Project
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: ProjectUpdate
+    project_id: str, *, client: ApiClient, body: ProjectUpdate
 ) -> Optional[Union[HTTPValidationError, ProjectUpdateResponse]]:
     """Update Project
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: ProjectUpdate
+    project_id: str, *, client: ApiClient, body: ProjectUpdate
 ) -> Response[Union[HTTPValidationError, ProjectUpdateResponse]]:
     """Update Project
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: ProjectUpdate
+    project_id: str, *, client: ApiClient, body: ProjectUpdate
 ) -> Optional[Union[HTTPValidationError, ProjectUpdateResponse]]:
     """Update Project
 

--- a/src/galileo/resources/api/projects/update_project_projects_project_id_put.py
+++ b/src/galileo/resources/api/projects/update_project_projects_project_id_put.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: ProjectUpdate) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/update_user_project_collaborator_projects_project_id_users_user_id_patch.py
+++ b/src/galileo/resources/api/projects/update_user_project_collaborator_projects_project_id_users_user_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, user_id: str, *, body: CollaboratorUpdate) -> d
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/projects/update_user_project_collaborator_projects_project_id_users_user_id_patch.py
+++ b/src/galileo/resources/api/projects/update_user_project_collaborator_projects_project_id_users_user_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.collaborator_update import CollaboratorUpdate
 from ...models.http_validation_error import HTTPValidationError
 from ...models.user_collaborator import UserCollaborator
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, user_id: str, *, body: CollaboratorUpdate) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/projects/{project_id}/users/{user_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/users/{user_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, user_id: str, *, body: CollaboratorUpdate) -> d
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     if response.status_code == 200:
         response_200 = UserCollaborator.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    project_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Project Collaborator
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, user_id=user_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    project_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Project Collaborator
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    project_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Project Collaborator
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, user_id=user_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    project_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Project Collaborator
 

--- a/src/galileo/resources/api/projects/upload_file_projects_project_id_upload_file_post.py
+++ b/src/galileo/resources/api/projects/upload_file_projects_project_id_upload_file_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.body_upload_file_projects_project_id_upload_file_post import (
     BodyUploadFileProjectsProjectIdUploadFilePost,
 )
@@ -15,7 +17,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: BodyUploadFileProjectsProjectIdUploadFilePost) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/upload_file"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/upload_file",
+    }
 
     _kwargs["files"] = body.to_multipart()
 
@@ -23,9 +29,7 @@ def _get_kwargs(project_id: str, *, body: BodyUploadFileProjectsProjectIdUploadF
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -39,9 +43,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -51,7 +53,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: BodyUploadFileProjectsProjectIdUploadFilePost
+    project_id: str, *, client: ApiClient, body: BodyUploadFileProjectsProjectIdUploadFilePost
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Upload File
 
@@ -69,13 +71,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: BodyUploadFileProjectsProjectIdUploadFilePost
+    project_id: str, *, client: ApiClient, body: BodyUploadFileProjectsProjectIdUploadFilePost
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Upload File
 
@@ -95,7 +97,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: BodyUploadFileProjectsProjectIdUploadFilePost
+    project_id: str, *, client: ApiClient, body: BodyUploadFileProjectsProjectIdUploadFilePost
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Upload File
 
@@ -113,13 +115,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: BodyUploadFileProjectsProjectIdUploadFilePost
+    project_id: str, *, client: ApiClient, body: BodyUploadFileProjectsProjectIdUploadFilePost
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Upload File
 

--- a/src/galileo/resources/api/projects/upload_file_projects_project_id_upload_file_post.py
+++ b/src/galileo/resources/api/projects/upload_file_projects_project_id_upload_file_post.py
@@ -25,7 +25,7 @@ def _get_kwargs(project_id: str, *, body: BodyUploadFileProjectsProjectIdUploadF
 
     _kwargs["files"] = body.to_multipart()
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/create_global_prompt_template_templates_post.py
+++ b/src/galileo/resources/api/prompts/create_global_prompt_template_templates_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_response import BasePromptTemplateResponse
 from ...models.create_prompt_template_with_version_request_body import CreatePromptTemplateWithVersionRequestBody
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,7 @@ from ...types import Response
 def _get_kwargs(*, body: CreatePromptTemplateWithVersionRequestBody) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/templates"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/templates"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +27,7 @@ def _get_kwargs(*, body: CreatePromptTemplateWithVersionRequestBody) -> dict[str
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateResponse.from_dict(response.json())
@@ -42,7 +44,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +55,7 @@ def _build_response(
 
 
 def sync_detailed(
-    *, client: AuthenticatedClient, body: CreatePromptTemplateWithVersionRequestBody
+    *, client: ApiClient, body: CreatePromptTemplateWithVersionRequestBody
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Create Global Prompt Template
 
@@ -89,13 +91,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    *, client: AuthenticatedClient, body: CreatePromptTemplateWithVersionRequestBody
+    *, client: ApiClient, body: CreatePromptTemplateWithVersionRequestBody
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Create Global Prompt Template
 
@@ -133,7 +135,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, body: CreatePromptTemplateWithVersionRequestBody
+    *, client: ApiClient, body: CreatePromptTemplateWithVersionRequestBody
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Create Global Prompt Template
 
@@ -169,13 +171,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    *, client: AuthenticatedClient, body: CreatePromptTemplateWithVersionRequestBody
+    *, client: ApiClient, body: CreatePromptTemplateWithVersionRequestBody
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Create Global Prompt Template
 

--- a/src/galileo/resources/api/prompts/create_global_prompt_template_templates_post.py
+++ b/src/galileo/resources/api/prompts/create_global_prompt_template_templates_post.py
@@ -22,7 +22,7 @@ def _get_kwargs(*, body: CreatePromptTemplateWithVersionRequestBody) -> dict[str
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/create_global_prompt_template_version_templates_template_id_versions_post.py
+++ b/src/galileo/resources/api/prompts/create_global_prompt_template_version_templates_template_id_versions_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(template_id: str, *, body: BasePromptTemplateVersion) -> dict[st
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/create_global_prompt_template_version_templates_template_id_versions_post.py
+++ b/src/galileo/resources/api/prompts/create_global_prompt_template_version_templates_template_id_versions_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_version import BasePromptTemplateVersion
 from ...models.base_prompt_template_version_response import BasePromptTemplateVersionResponse
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(template_id: str, *, body: BasePromptTemplateVersion) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/templates/{template_id}/versions"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}/versions",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(template_id: str, *, body: BasePromptTemplateVersion) -> dict[st
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateVersionResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    template_id: str, *, client: AuthenticatedClient, body: BasePromptTemplateVersion
+    template_id: str, *, client: ApiClient, body: BasePromptTemplateVersion
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Create Global Prompt Template Version
 
@@ -87,13 +93,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    template_id: str, *, client: AuthenticatedClient, body: BasePromptTemplateVersion
+    template_id: str, *, client: ApiClient, body: BasePromptTemplateVersion
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Create Global Prompt Template Version
 
@@ -129,7 +135,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str, *, client: AuthenticatedClient, body: BasePromptTemplateVersion
+    template_id: str, *, client: ApiClient, body: BasePromptTemplateVersion
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Create Global Prompt Template Version
 
@@ -163,13 +169,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    template_id: str, *, client: AuthenticatedClient, body: BasePromptTemplateVersion
+    template_id: str, *, client: ApiClient, body: BasePromptTemplateVersion
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Create Global Prompt Template Version
 

--- a/src/galileo/resources/api/prompts/create_prompt_template_version_projects_project_id_templates_template_id_versions_post.py
+++ b/src/galileo/resources/api/prompts/create_prompt_template_version_projects_project_id_templates_template_id_versions_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_version import BasePromptTemplateVersion
 from ...models.base_prompt_template_version_response import BasePromptTemplateVersionResponse
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, template_id: str, *, body: BasePromptTemplateVersion) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/templates/{template_id}/versions"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/templates/{template_id}/versions",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, template_id: str, *, body: BasePromptTemplateVe
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateVersionResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, template_id: str, *, client: AuthenticatedClient, body: BasePromptTemplateVersion
+    project_id: str, template_id: str, *, client: ApiClient, body: BasePromptTemplateVersion
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Create Prompt Template Version
 
@@ -92,13 +98,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, template_id: str, *, client: AuthenticatedClient, body: BasePromptTemplateVersion
+    project_id: str, template_id: str, *, client: ApiClient, body: BasePromptTemplateVersion
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Create Prompt Template Version
 
@@ -139,7 +145,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, template_id: str, *, client: AuthenticatedClient, body: BasePromptTemplateVersion
+    project_id: str, template_id: str, *, client: ApiClient, body: BasePromptTemplateVersion
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Create Prompt Template Version
 
@@ -178,13 +184,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, template_id: str, *, client: AuthenticatedClient, body: BasePromptTemplateVersion
+    project_id: str, template_id: str, *, client: ApiClient, body: BasePromptTemplateVersion
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Create Prompt Template Version
 

--- a/src/galileo/resources/api/prompts/create_prompt_template_version_projects_project_id_templates_template_id_versions_post.py
+++ b/src/galileo/resources/api/prompts/create_prompt_template_version_projects_project_id_templates_template_id_versions_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, template_id: str, *, body: BasePromptTemplateVe
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/create_prompt_template_with_version_projects_project_id_templates_post.py
+++ b/src/galileo/resources/api/prompts/create_prompt_template_with_version_projects_project_id_templates_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: CreatePromptTemplateWithVersionRequest
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/create_prompt_template_with_version_projects_project_id_templates_post.py
+++ b/src/galileo/resources/api/prompts/create_prompt_template_with_version_projects_project_id_templates_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_response import BasePromptTemplateResponse
 from ...models.create_prompt_template_with_version_request_body import CreatePromptTemplateWithVersionRequestBody
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: CreatePromptTemplateWithVersionRequestBody) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/templates"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/templates",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: CreatePromptTemplateWithVersionRequest
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: CreatePromptTemplateWithVersionRequestBody
+    project_id: str, *, client: ApiClient, body: CreatePromptTemplateWithVersionRequestBody
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Create Prompt Template With Version
 
@@ -96,13 +102,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: CreatePromptTemplateWithVersionRequestBody
+    project_id: str, *, client: ApiClient, body: CreatePromptTemplateWithVersionRequestBody
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Create Prompt Template With Version
 
@@ -147,7 +153,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: CreatePromptTemplateWithVersionRequestBody
+    project_id: str, *, client: ApiClient, body: CreatePromptTemplateWithVersionRequestBody
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Create Prompt Template With Version
 
@@ -190,13 +196,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: CreatePromptTemplateWithVersionRequestBody
+    project_id: str, *, client: ApiClient, body: CreatePromptTemplateWithVersionRequestBody
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Create Prompt Template With Version
 

--- a/src/galileo/resources/api/prompts/create_user_prompt_template_collaborators_templates_template_id_users_post.py
+++ b/src/galileo/resources/api/prompts/create_user_prompt_template_collaborators_templates_template_id_users_post.py
@@ -29,7 +29,7 @@ def _get_kwargs(template_id: str, *, body: list["UserCollaboratorCreate"]) -> di
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/create_user_prompt_template_collaborators_templates_template_id_users_post.py
+++ b/src/galileo/resources/api/prompts/create_user_prompt_template_collaborators_templates_template_id_users_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.user_collaborator import UserCollaborator
 from ...models.user_collaborator_create import UserCollaboratorCreate
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(template_id: str, *, body: list["UserCollaboratorCreate"]) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/templates/{template_id}/users"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}/users",
+    }
 
     _kwargs["json"] = []
     for body_item_data in body:
@@ -28,7 +34,7 @@ def _get_kwargs(template_id: str, *, body: list["UserCollaboratorCreate"]) -> di
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -50,7 +56,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -61,7 +67,7 @@ def _build_response(
 
 
 def sync_detailed(
-    template_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    template_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Prompt Template Collaborators
 
@@ -79,13 +85,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    template_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    template_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Prompt Template Collaborators
 
@@ -105,7 +111,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    template_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Response[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Prompt Template Collaborators
 
@@ -123,13 +129,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    template_id: str, *, client: AuthenticatedClient, body: list["UserCollaboratorCreate"]
+    template_id: str, *, client: ApiClient, body: list["UserCollaboratorCreate"]
 ) -> Optional[Union[HTTPValidationError, list["UserCollaborator"]]]:
     """Create User Prompt Template Collaborators
 

--- a/src/galileo/resources/api/prompts/delete_global_template_templates_template_id_delete.py
+++ b/src/galileo/resources/api/prompts/delete_global_template_templates_template_id_delete.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.delete_prompt_response import DeletePromptResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(template_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/templates/{template_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[DeletePromptResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DeletePromptResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[DeletePromptResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -44,9 +50,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    template_id: str, *, client: AuthenticatedClient
-) -> Response[Union[DeletePromptResponse, HTTPValidationError]]:
+def sync_detailed(template_id: str, *, client: ApiClient) -> Response[Union[DeletePromptResponse, HTTPValidationError]]:
     """Delete Global Template
 
      Delete a global prompt template given a template ID.
@@ -76,14 +80,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    template_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[DeletePromptResponse, HTTPValidationError]]:
+def sync(template_id: str, *, client: ApiClient) -> Optional[Union[DeletePromptResponse, HTTPValidationError]]:
     """Delete Global Template
 
      Delete a global prompt template given a template ID.
@@ -115,7 +117,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str, *, client: AuthenticatedClient
+    template_id: str, *, client: ApiClient
 ) -> Response[Union[DeletePromptResponse, HTTPValidationError]]:
     """Delete Global Template
 
@@ -146,14 +148,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    template_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[DeletePromptResponse, HTTPValidationError]]:
+async def asyncio(template_id: str, *, client: ApiClient) -> Optional[Union[DeletePromptResponse, HTTPValidationError]]:
     """Delete Global Template
 
      Delete a global prompt template given a template ID.

--- a/src/galileo/resources/api/prompts/delete_template_projects_project_id_templates_template_id_delete.py
+++ b/src/galileo/resources/api/prompts/delete_template_projects_project_id_templates_template_id_delete.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.delete_prompt_response import DeletePromptResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, template_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/projects/{project_id}/templates/{template_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/templates/{template_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[DeletePromptResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = DeletePromptResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[DeletePromptResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, template_id: str, *, client: AuthenticatedClient
+    project_id: str, template_id: str, *, client: ApiClient
 ) -> Response[Union[DeletePromptResponse, HTTPValidationError]]:
     """Delete Template
 
@@ -63,13 +69,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, template_id: str, *, client: AuthenticatedClient
+    project_id: str, template_id: str, *, client: ApiClient
 ) -> Optional[Union[DeletePromptResponse, HTTPValidationError]]:
     """Delete Template
 
@@ -89,7 +95,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, template_id: str, *, client: AuthenticatedClient
+    project_id: str, template_id: str, *, client: ApiClient
 ) -> Response[Union[DeletePromptResponse, HTTPValidationError]]:
     """Delete Template
 
@@ -107,13 +113,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, template_id: str, *, client: AuthenticatedClient
+    project_id: str, template_id: str, *, client: ApiClient
 ) -> Optional[Union[DeletePromptResponse, HTTPValidationError]]:
     """Delete Template
 

--- a/src/galileo/resources/api/prompts/delete_user_prompt_template_collaborator_templates_template_id_users_user_id_delete.py
+++ b/src/galileo/resources/api/prompts/delete_user_prompt_template_collaborator_templates_template_id_users_user_id_delete.py
@@ -3,21 +3,25 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(template_id: str, user_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "delete", "url": f"/templates/{template_id}/users/{user_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.DELETE,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}/users/{user_id}",
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -31,9 +35,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,9 +44,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    template_id: str, user_id: str, *, client: AuthenticatedClient
-) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(template_id: str, user_id: str, *, client: ApiClient) -> Response[Union[Any, HTTPValidationError]]:
     """Delete User Prompt Template Collaborator
 
      Remove a user's access to a prompt template.
@@ -63,12 +63,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, user_id=user_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(template_id: str, user_id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(template_id: str, user_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete User Prompt Template Collaborator
 
      Remove a user's access to a prompt template.
@@ -89,7 +89,7 @@ def sync(template_id: str, user_id: str, *, client: AuthenticatedClient) -> Opti
 
 
 async def asyncio_detailed(
-    template_id: str, user_id: str, *, client: AuthenticatedClient
+    template_id: str, user_id: str, *, client: ApiClient
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Delete User Prompt Template Collaborator
 
@@ -109,14 +109,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, user_id=user_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    template_id: str, user_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(template_id: str, user_id: str, *, client: ApiClient) -> Optional[Union[Any, HTTPValidationError]]:
     """Delete User Prompt Template Collaborator
 
      Remove a user's access to a prompt template.

--- a/src/galileo/resources/api/prompts/generate_template_input_stub_input_stub_post.py
+++ b/src/galileo/resources/api/prompts/generate_template_input_stub_input_stub_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.template_stub_request import TemplateStubRequest
 from ...types import Response
@@ -13,7 +15,7 @@ from ...types import Response
 def _get_kwargs(*, body: TemplateStubRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/input_stub"}
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/input_stub"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -23,9 +25,7 @@ def _get_kwargs(*, body: TemplateStubRequest) -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -39,9 +39,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,9 +48,7 @@ def _build_response(
     )
 
 
-def sync_detailed(
-    *, client: AuthenticatedClient, body: TemplateStubRequest
-) -> Response[Union[Any, HTTPValidationError]]:
+def sync_detailed(*, client: ApiClient, body: TemplateStubRequest) -> Response[Union[Any, HTTPValidationError]]:
     """Generate Template Input Stub
 
     Args:
@@ -68,12 +64,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(*, client: AuthenticatedClient, body: TemplateStubRequest) -> Optional[Union[Any, HTTPValidationError]]:
+def sync(*, client: ApiClient, body: TemplateStubRequest) -> Optional[Union[Any, HTTPValidationError]]:
     """Generate Template Input Stub
 
     Args:
@@ -91,7 +87,7 @@ def sync(*, client: AuthenticatedClient, body: TemplateStubRequest) -> Optional[
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, body: TemplateStubRequest
+    *, client: ApiClient, body: TemplateStubRequest
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Generate Template Input Stub
 
@@ -108,14 +104,12 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-async def asyncio(
-    *, client: AuthenticatedClient, body: TemplateStubRequest
-) -> Optional[Union[Any, HTTPValidationError]]:
+async def asyncio(*, client: ApiClient, body: TemplateStubRequest) -> Optional[Union[Any, HTTPValidationError]]:
     """Generate Template Input Stub
 
     Args:

--- a/src/galileo/resources/api/prompts/generate_template_input_stub_input_stub_post.py
+++ b/src/galileo/resources/api/prompts/generate_template_input_stub_input_stub_post.py
@@ -21,7 +21,7 @@ def _get_kwargs(*, body: TemplateStubRequest) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/get_global_template_templates_template_id_get.py
+++ b/src/galileo/resources/api/prompts/get_global_template_templates_template_id_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_response import BasePromptTemplateResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(template_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/templates/{template_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    template_id: str, *, client: AuthenticatedClient
+    template_id: str, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Get Global Template
 
@@ -78,14 +84,12 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
-def sync(
-    template_id: str, *, client: AuthenticatedClient
-) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
+def sync(template_id: str, *, client: ApiClient) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Get Global Template
 
      Get a global prompt template given a template ID.
@@ -119,7 +123,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str, *, client: AuthenticatedClient
+    template_id: str, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Get Global Template
 
@@ -152,13 +156,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    template_id: str, *, client: AuthenticatedClient
+    template_id: str, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Get Global Template
 

--- a/src/galileo/resources/api/prompts/get_global_template_version_templates_template_id_versions_version_get.py
+++ b/src/galileo/resources/api/prompts/get_global_template_version_templates_template_id_versions_version_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_version_response import BasePromptTemplateVersionResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(template_id: str, version: int) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/templates/{template_id}/versions/{version}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}/versions/{version}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateVersionResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    template_id: str, version: int, *, client: AuthenticatedClient
+    template_id: str, version: int, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Global Template Version
 
@@ -79,13 +85,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, version=version)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    template_id: str, version: int, *, client: AuthenticatedClient
+    template_id: str, version: int, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Global Template Version
 
@@ -121,7 +127,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str, version: int, *, client: AuthenticatedClient
+    template_id: str, version: int, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Global Template Version
 
@@ -155,13 +161,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, version=version)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    template_id: str, version: int, *, client: AuthenticatedClient
+    template_id: str, version: int, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Global Template Version
 

--- a/src/galileo/resources/api/prompts/get_project_templates_projects_project_id_templates_get.py
+++ b/src/galileo/resources/api/prompts/get_project_templates_projects_project_id_templates_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_response import BasePromptTemplateResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/templates"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/templates",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, list["BasePromptTemplateResponse"]]]:
     if response.status_code == 200:
         response_200 = []
@@ -39,7 +45,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, list["BasePromptTemplateResponse"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -50,7 +56,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, list["BasePromptTemplateResponse"]]]:
     """Get Project Templates
 
@@ -81,13 +87,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, list["BasePromptTemplateResponse"]]]:
     """Get Project Templates
 
@@ -120,7 +126,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, list["BasePromptTemplateResponse"]]]:
     """Get Project Templates
 
@@ -151,13 +157,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient
+    project_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, list["BasePromptTemplateResponse"]]]:
     """Get Project Templates
 

--- a/src/galileo/resources/api/prompts/get_template_from_project_projects_project_id_templates_template_id_get.py
+++ b/src/galileo/resources/api/prompts/get_template_from_project_projects_project_id_templates_template_id_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_response import BasePromptTemplateResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, template_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/templates/{template_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/templates/{template_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, template_id: str, *, client: AuthenticatedClient
+    project_id: str, template_id: str, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Get Template From Project
 
@@ -79,13 +85,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, template_id: str, *, client: AuthenticatedClient
+    project_id: str, template_id: str, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Get Template From Project
 
@@ -121,7 +127,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, template_id: str, *, client: AuthenticatedClient
+    project_id: str, template_id: str, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Get Template From Project
 
@@ -155,13 +161,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, template_id: str, *, client: AuthenticatedClient
+    project_id: str, template_id: str, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Get Template From Project
 

--- a/src/galileo/resources/api/prompts/get_template_version_by_name_projects_project_id_templates_versions_get.py
+++ b/src/galileo/resources/api/prompts/get_template_version_by_name_projects_project_id_templates_versions_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_version_response import BasePromptTemplateVersionResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response, Unset
@@ -24,13 +26,18 @@ def _get_kwargs(project_id: str, *, template_name: str, version: Union[None, Uns
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/templates/versions", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/templates/versions",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateVersionResponse.from_dict(response.json())
@@ -47,7 +54,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -58,7 +65,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, template_name: str, version: Union[None, Unset, int] = UNSET
+    project_id: str, *, client: ApiClient, template_name: str, version: Union[None, Unset, int] = UNSET
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Template Version By Name
 
@@ -96,13 +103,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_name=template_name, version=version)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, template_name: str, version: Union[None, Unset, int] = UNSET
+    project_id: str, *, client: ApiClient, template_name: str, version: Union[None, Unset, int] = UNSET
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Template Version By Name
 
@@ -142,7 +149,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, template_name: str, version: Union[None, Unset, int] = UNSET
+    project_id: str, *, client: ApiClient, template_name: str, version: Union[None, Unset, int] = UNSET
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Template Version By Name
 
@@ -180,13 +187,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_name=template_name, version=version)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, template_name: str, version: Union[None, Unset, int] = UNSET
+    project_id: str, *, client: ApiClient, template_name: str, version: Union[None, Unset, int] = UNSET
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Template Version By Name
 

--- a/src/galileo/resources/api/prompts/get_template_version_projects_project_id_templates_template_id_versions_version_get.py
+++ b/src/galileo/resources/api/prompts/get_template_version_projects_project_id_templates_template_id_versions_version_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_version_response import BasePromptTemplateVersionResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
@@ -12,15 +14,16 @@ from ...types import Response
 
 def _get_kwargs(project_id: str, template_id: str, version: int) -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
-        "method": "get",
-        "url": f"/projects/{project_id}/templates/{template_id}/versions/{version}",
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/templates/{template_id}/versions/{version}",
     }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateVersionResponse.from_dict(response.json())
@@ -37,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -48,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, template_id: str, version: int, *, client: AuthenticatedClient
+    project_id: str, template_id: str, version: int, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Template Version
 
@@ -83,13 +86,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id, version=version)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, template_id: str, version: int, *, client: AuthenticatedClient
+    project_id: str, template_id: str, version: int, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Template Version
 
@@ -126,7 +129,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, template_id: str, version: int, *, client: AuthenticatedClient
+    project_id: str, template_id: str, version: int, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Template Version
 
@@ -161,13 +164,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id, version=version)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, template_id: str, version: int, *, client: AuthenticatedClient
+    project_id: str, template_id: str, version: int, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateVersionResponse, HTTPValidationError]]:
     """Get Template Version
 

--- a/src/galileo/resources/api/prompts/list_user_prompt_template_collaborators_templates_template_id_users_get.py
+++ b/src/galileo/resources/api/prompts/list_user_prompt_template_collaborators_templates_template_id_users_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_user_collaborators_response import ListUserCollaboratorsResponse
 from ...types import UNSET, Response, Unset
@@ -21,13 +23,18 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/templates/{template_id}/users", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}/users",
+        "params": params,
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     if response.status_code == 200:
         response_200 = ListUserCollaboratorsResponse.from_dict(response.json())
@@ -44,7 +51,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -55,11 +62,7 @@ def _build_response(
 
 
 def sync_detailed(
-    template_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    template_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Prompt Template Collaborators
 
@@ -80,17 +83,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    template_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    template_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Prompt Template Collaborators
 
@@ -113,11 +112,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    template_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Response[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Prompt Template Collaborators
 
@@ -138,17 +133,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    template_id: str,
-    *,
-    client: AuthenticatedClient,
-    starting_token: Union[Unset, int] = 0,
-    limit: Union[Unset, int] = 100,
+    template_id: str, *, client: ApiClient, starting_token: Union[Unset, int] = 0, limit: Union[Unset, int] = 100
 ) -> Optional[Union[HTTPValidationError, ListUserCollaboratorsResponse]]:
     """List User Prompt Template Collaborators
 

--- a/src/galileo/resources/api/prompts/query_template_versions_templates_template_id_versions_query_post.py
+++ b/src/galileo/resources/api/prompts/query_template_versions_templates_template_id_versions_query_post.py
@@ -41,7 +41,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/query_template_versions_templates_template_id_versions_query_post.py
+++ b/src/galileo/resources/api/prompts/query_template_versions_templates_template_id_versions_query_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_prompt_template_version_params import ListPromptTemplateVersionParams
 from ...models.list_prompt_template_version_response import ListPromptTemplateVersionResponse
@@ -28,7 +30,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/templates/{template_id}/versions/query", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}/versions/query",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -39,7 +46,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListPromptTemplateVersionResponse]]:
     if response.status_code == 200:
         response_200 = ListPromptTemplateVersionResponse.from_dict(response.json())
@@ -56,7 +63,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListPromptTemplateVersionResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -69,7 +76,7 @@ def _build_response(
 def sync_detailed(
     template_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListPromptTemplateVersionParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -110,7 +117,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, body=body, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -118,7 +125,7 @@ def sync_detailed(
 def sync(
     template_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListPromptTemplateVersionParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -165,7 +172,7 @@ def sync(
 async def asyncio_detailed(
     template_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListPromptTemplateVersionParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -206,7 +213,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, body=body, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -214,7 +221,7 @@ async def asyncio_detailed(
 async def asyncio(
     template_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListPromptTemplateVersionParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/prompts/query_templates_templates_query_post.py
+++ b/src/galileo/resources/api/prompts/query_templates_templates_query_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_prompt_template_params import ListPromptTemplateParams
 from ...models.list_prompt_template_response import ListPromptTemplateResponse
@@ -24,7 +26,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/templates/query", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": "/templates/query",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -35,7 +42,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, ListPromptTemplateResponse]]:
     if response.status_code == 200:
         response_200 = ListPromptTemplateResponse.from_dict(response.json())
@@ -52,7 +59,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, ListPromptTemplateResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -64,7 +71,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListPromptTemplateParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -102,14 +109,14 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListPromptTemplateParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -150,7 +157,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListPromptTemplateParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -188,14 +195,14 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: ListPromptTemplateParams,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/prompts/query_templates_templates_query_post.py
+++ b/src/galileo/resources/api/prompts/query_templates_templates_query_post.py
@@ -37,7 +37,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/render_template_render_template_post.py
+++ b/src/galileo/resources/api/prompts/render_template_render_template_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.render_template_request import RenderTemplateRequest
 from ...models.render_template_response import RenderTemplateResponse
@@ -24,7 +26,12 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/render_template", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": "/render_template",
+        "params": params,
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -35,7 +42,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, RenderTemplateResponse]]:
     if response.status_code == 200:
         response_200 = RenderTemplateResponse.from_dict(response.json())
@@ -52,7 +59,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, RenderTemplateResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -64,7 +71,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: RenderTemplateRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -86,14 +93,14 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body, starting_token=starting_token, limit=limit)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: RenderTemplateRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -118,7 +125,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: RenderTemplateRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,
@@ -140,14 +147,14 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body, starting_token=starting_token, limit=limit)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     body: RenderTemplateRequest,
     starting_token: Union[Unset, int] = 0,
     limit: Union[Unset, int] = 100,

--- a/src/galileo/resources/api/prompts/render_template_render_template_post.py
+++ b/src/galileo/resources/api/prompts/render_template_render_template_post.py
@@ -37,7 +37,7 @@ def _get_kwargs(
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/set_selected_global_template_version_templates_template_id_versions_version_put.py
+++ b/src/galileo/resources/api/prompts/set_selected_global_template_version_templates_template_id_versions_version_put.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_response import BasePromptTemplateResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(template_id: str, version: int) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "put", "url": f"/templates/{template_id}/versions/{version}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PUT,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}/versions/{version}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    template_id: str, version: int, *, client: AuthenticatedClient
+    template_id: str, version: int, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Set Selected Global Template Version
 
@@ -79,13 +85,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, version=version)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    template_id: str, version: int, *, client: AuthenticatedClient
+    template_id: str, version: int, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Set Selected Global Template Version
 
@@ -121,7 +127,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str, version: int, *, client: AuthenticatedClient
+    template_id: str, version: int, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Set Selected Global Template Version
 
@@ -155,13 +161,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, version=version)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    template_id: str, version: int, *, client: AuthenticatedClient
+    template_id: str, version: int, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Set Selected Global Template Version
 

--- a/src/galileo/resources/api/prompts/set_selected_template_version_projects_project_id_templates_template_id_versions_version_put.py
+++ b/src/galileo/resources/api/prompts/set_selected_template_version_projects_project_id_templates_template_id_versions_version_put.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_response import BasePromptTemplateResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
@@ -12,15 +14,16 @@ from ...types import Response
 
 def _get_kwargs(project_id: str, template_id: str, version: int) -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
-        "method": "put",
-        "url": f"/projects/{project_id}/templates/{template_id}/versions/{version}",
+        "method": RequestMethod.PUT,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/templates/{template_id}/versions/{version}",
     }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateResponse.from_dict(response.json())
@@ -37,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -48,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, template_id: str, version: int, *, client: AuthenticatedClient
+    project_id: str, template_id: str, version: int, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Set Selected Template Version
 
@@ -67,13 +70,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id, version=version)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, template_id: str, version: int, *, client: AuthenticatedClient
+    project_id: str, template_id: str, version: int, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Set Selected Template Version
 
@@ -94,7 +97,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, template_id: str, version: int, *, client: AuthenticatedClient
+    project_id: str, template_id: str, version: int, *, client: ApiClient
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Set Selected Template Version
 
@@ -113,13 +116,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, template_id=template_id, version=version)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, template_id: str, version: int, *, client: AuthenticatedClient
+    project_id: str, template_id: str, version: int, *, client: ApiClient
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Set Selected Template Version
 

--- a/src/galileo/resources/api/prompts/update_global_template_templates_template_id_patch.py
+++ b/src/galileo/resources/api/prompts/update_global_template_templates_template_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.base_prompt_template_response import BasePromptTemplateResponse
 from ...models.http_validation_error import HTTPValidationError
 from ...models.update_prompt_template_request import UpdatePromptTemplateRequest
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(template_id: str, *, body: UpdatePromptTemplateRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/templates/{template_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(template_id: str, *, body: UpdatePromptTemplateRequest) -> dict[
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = BasePromptTemplateResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    template_id: str, *, client: AuthenticatedClient, body: UpdatePromptTemplateRequest
+    template_id: str, *, client: ApiClient, body: UpdatePromptTemplateRequest
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Update Global Template
 
@@ -89,13 +95,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    template_id: str, *, client: AuthenticatedClient, body: UpdatePromptTemplateRequest
+    template_id: str, *, client: ApiClient, body: UpdatePromptTemplateRequest
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Update Global Template
 
@@ -133,7 +139,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str, *, client: AuthenticatedClient, body: UpdatePromptTemplateRequest
+    template_id: str, *, client: ApiClient, body: UpdatePromptTemplateRequest
 ) -> Response[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Update Global Template
 
@@ -169,13 +175,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    template_id: str, *, client: AuthenticatedClient, body: UpdatePromptTemplateRequest
+    template_id: str, *, client: ApiClient, body: UpdatePromptTemplateRequest
 ) -> Optional[Union[BasePromptTemplateResponse, HTTPValidationError]]:
     """Update Global Template
 

--- a/src/galileo/resources/api/prompts/update_global_template_templates_template_id_patch.py
+++ b/src/galileo/resources/api/prompts/update_global_template_templates_template_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(template_id: str, *, body: UpdatePromptTemplateRequest) -> dict[
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/update_user_prompt_template_collaborator_templates_template_id_users_user_id_patch.py
+++ b/src/galileo/resources/api/prompts/update_user_prompt_template_collaborator_templates_template_id_users_user_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(template_id: str, user_id: str, *, body: CollaboratorUpdate) -> 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/prompts/update_user_prompt_template_collaborator_templates_template_id_users_user_id_patch.py
+++ b/src/galileo/resources/api/prompts/update_user_prompt_template_collaborator_templates_template_id_users_user_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.collaborator_update import CollaboratorUpdate
 from ...models.http_validation_error import HTTPValidationError
 from ...models.user_collaborator import UserCollaborator
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(template_id: str, user_id: str, *, body: CollaboratorUpdate) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/templates/{template_id}/users/{user_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/templates/{template_id}/users/{user_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(template_id: str, user_id: str, *, body: CollaboratorUpdate) -> 
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     if response.status_code == 200:
         response_200 = UserCollaborator.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    template_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    template_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Prompt Template Collaborator
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, user_id=user_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    template_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    template_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Prompt Template Collaborator
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    template_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    template_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Response[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Prompt Template Collaborator
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(template_id=template_id, user_id=user_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    template_id: str, user_id: str, *, client: AuthenticatedClient, body: CollaboratorUpdate
+    template_id: str, user_id: str, *, client: ApiClient, body: CollaboratorUpdate
 ) -> Optional[Union[HTTPValidationError, UserCollaborator]]:
     """Update User Prompt Template Collaborator
 

--- a/src/galileo/resources/api/protect/create_stage_projects_project_id_stages_post.py
+++ b/src/galileo/resources/api/protect/create_stage_projects_project_id_stages_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: StageWithRulesets) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/protect/create_stage_projects_project_id_stages_post.py
+++ b/src/galileo/resources/api/protect/create_stage_projects_project_id_stages_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.stage_db import StageDB
 from ...models.stage_with_rulesets import StageWithRulesets
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: StageWithRulesets) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/stages"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/stages",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -24,9 +30,7 @@ def _get_kwargs(project_id: str, *, body: StageWithRulesets) -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, StageDB]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, StageDB]]:
     if response.status_code == 200:
         response_200 = StageDB.from_dict(response.json())
 
@@ -41,9 +45,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, StageDB]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, StageDB]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +55,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: StageWithRulesets
+    project_id: str, *, client: ApiClient, body: StageWithRulesets
 ) -> Response[Union[HTTPValidationError, StageDB]]:
     """Create Stage
 
@@ -71,13 +73,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: StageWithRulesets
+    project_id: str, *, client: ApiClient, body: StageWithRulesets
 ) -> Optional[Union[HTTPValidationError, StageDB]]:
     """Create Stage
 
@@ -97,7 +99,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: StageWithRulesets
+    project_id: str, *, client: ApiClient, body: StageWithRulesets
 ) -> Response[Union[HTTPValidationError, StageDB]]:
     """Create Stage
 
@@ -115,13 +117,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: StageWithRulesets
+    project_id: str, *, client: ApiClient, body: StageWithRulesets
 ) -> Optional[Union[HTTPValidationError, StageDB]]:
     """Create Stage
 

--- a/src/galileo/resources/api/protect/get_stage_projects_project_id_stages_get.py
+++ b/src/galileo/resources/api/protect/get_stage_projects_project_id_stages_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.stage_db import StageDB
 from ...types import UNSET, Response, Unset
@@ -31,14 +33,17 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/stages", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/stages",
+        "params": params,
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, StageDB]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, StageDB]]:
     if response.status_code == 200:
         response_200 = StageDB.from_dict(response.json())
 
@@ -53,9 +58,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, StageDB]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, StageDB]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,7 +70,7 @@ def _build_response(
 def sync_detailed(
     project_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     stage_name: Union[None, Unset, str] = UNSET,
     stage_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, StageDB]]:
@@ -88,7 +91,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, stage_name=stage_name, stage_id=stage_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -96,7 +99,7 @@ def sync_detailed(
 def sync(
     project_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     stage_name: Union[None, Unset, str] = UNSET,
     stage_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, StageDB]]:
@@ -121,7 +124,7 @@ def sync(
 async def asyncio_detailed(
     project_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     stage_name: Union[None, Unset, str] = UNSET,
     stage_id: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[HTTPValidationError, StageDB]]:
@@ -142,7 +145,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, stage_name=stage_name, stage_id=stage_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
@@ -150,7 +153,7 @@ async def asyncio_detailed(
 async def asyncio(
     project_id: str,
     *,
-    client: AuthenticatedClient,
+    client: ApiClient,
     stage_name: Union[None, Unset, str] = UNSET,
     stage_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[HTTPValidationError, StageDB]]:

--- a/src/galileo/resources/api/protect/invoke_protect_invoke_post.py
+++ b/src/galileo/resources/api/protect/invoke_protect_invoke_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.invoke_response import InvokeResponse
 from ...models.request import Request as BaseRequest
@@ -14,7 +16,8 @@ from ...types import Response
 
 def _get_kwargs(*, body: BaseRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
-    _kwargs: dict[str, Any] = {"method": "post", "url": "/protect/invoke"}
+
+    _kwargs: dict[str, Any] = {"method": RequestMethod.POST, "return_raw_response": True, "path": "/protect/invoke"}
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +28,7 @@ def _get_kwargs(*, body: BaseRequest) -> dict[str, Any]:
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, Union["InvokeResponse", "BaseResponse"]]]:
     if response.status_code == 200:
 
@@ -58,7 +61,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, Union["InvokeResponse", "BaseResponse"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -69,7 +72,7 @@ def _build_response(
 
 
 def sync_detailed(
-    *, client: AuthenticatedClient, body: BaseRequest
+    *, client: ApiClient, body: BaseRequest
 ) -> Response[Union[HTTPValidationError, Union["InvokeResponse", "BaseResponse"]]]:
     """Invoke
 
@@ -86,13 +89,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    *, client: AuthenticatedClient, body: BaseRequest
+    *, client: ApiClient, body: BaseRequest
 ) -> Optional[Union[HTTPValidationError, Union["InvokeResponse", "BaseResponse"]]]:
     """Invoke
 
@@ -104,14 +107,14 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, Union['InvokeResponse', 'Response']]
+        Union[HTTPValidationError, Union['InvokeResponse', 'BaseResponse']]
     """
 
     return sync_detailed(client=client, body=body).parsed
 
 
 async def asyncio_detailed(
-    *, client: AuthenticatedClient, body: BaseRequest
+    *, client: ApiClient, body: BaseRequest
 ) -> Response[Union[HTTPValidationError, Union["InvokeResponse", "BaseResponse"]]]:
     """Invoke
 
@@ -128,13 +131,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    *, client: AuthenticatedClient, body: BaseRequest
+    *, client: ApiClient, body: BaseRequest
 ) -> Optional[Union[HTTPValidationError, Union["InvokeResponse", "BaseResponse"]]]:
     """Invoke
 
@@ -146,7 +149,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, Union['InvokeResponse', 'Response']]
+        Union[HTTPValidationError, Union['InvokeResponse', 'BaseResponse']]
     """
 
     return (await asyncio_detailed(client=client, body=body)).parsed

--- a/src/galileo/resources/api/protect/invoke_protect_invoke_post.py
+++ b/src/galileo/resources/api/protect/invoke_protect_invoke_post.py
@@ -23,7 +23,7 @@ def _get_kwargs(*, body: BaseRequest) -> dict[str, Any]:
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/protect/pause_stage_projects_project_id_stages_stage_id_put.py
+++ b/src/galileo/resources/api/protect/pause_stage_projects_project_id_stages_stage_id_put.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.stage_db import StageDB
 from ...types import UNSET, Response, Unset
@@ -17,14 +19,17 @@ def _get_kwargs(project_id: str, stage_id: str, *, pause: Union[Unset, bool] = F
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: dict[str, Any] = {"method": "put", "url": f"/projects/{project_id}/stages/{stage_id}", "params": params}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PUT,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/stages/{stage_id}",
+        "params": params,
+    }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, StageDB]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, StageDB]]:
     if response.status_code == 200:
         response_200 = StageDB.from_dict(response.json())
 
@@ -39,9 +44,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, StageDB]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, StageDB]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -51,7 +54,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, stage_id: str, *, client: AuthenticatedClient, pause: Union[Unset, bool] = False
+    project_id: str, stage_id: str, *, client: ApiClient, pause: Union[Unset, bool] = False
 ) -> Response[Union[HTTPValidationError, StageDB]]:
     """Pause Stage
 
@@ -70,13 +73,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, stage_id=stage_id, pause=pause)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, stage_id: str, *, client: AuthenticatedClient, pause: Union[Unset, bool] = False
+    project_id: str, stage_id: str, *, client: ApiClient, pause: Union[Unset, bool] = False
 ) -> Optional[Union[HTTPValidationError, StageDB]]:
     """Pause Stage
 
@@ -97,7 +100,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, stage_id: str, *, client: AuthenticatedClient, pause: Union[Unset, bool] = False
+    project_id: str, stage_id: str, *, client: ApiClient, pause: Union[Unset, bool] = False
 ) -> Response[Union[HTTPValidationError, StageDB]]:
     """Pause Stage
 
@@ -116,13 +119,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, stage_id=stage_id, pause=pause)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, stage_id: str, *, client: AuthenticatedClient, pause: Union[Unset, bool] = False
+    project_id: str, stage_id: str, *, client: ApiClient, pause: Union[Unset, bool] = False
 ) -> Optional[Union[HTTPValidationError, StageDB]]:
     """Pause Stage
 

--- a/src/galileo/resources/api/protect/update_stage_projects_project_id_stages_stage_id_post.py
+++ b/src/galileo/resources/api/protect/update_stage_projects_project_id_stages_stage_id_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, stage_id: str, *, body: RulesetsMixin) -> dict[
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/protect/update_stage_projects_project_id_stages_stage_id_post.py
+++ b/src/galileo/resources/api/protect/update_stage_projects_project_id_stages_stage_id_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.rulesets_mixin import RulesetsMixin
 from ...models.stage_db import StageDB
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, stage_id: str, *, body: RulesetsMixin) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/stages/{stage_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/stages/{stage_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -24,9 +30,7 @@ def _get_kwargs(project_id: str, stage_id: str, *, body: RulesetsMixin) -> dict[
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[HTTPValidationError, StageDB]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[HTTPValidationError, StageDB]]:
     if response.status_code == 200:
         response_200 = StageDB.from_dict(response.json())
 
@@ -41,9 +45,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[HTTPValidationError, StageDB]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[HTTPValidationError, StageDB]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +55,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, stage_id: str, *, client: AuthenticatedClient, body: RulesetsMixin
+    project_id: str, stage_id: str, *, client: ApiClient, body: RulesetsMixin
 ) -> Response[Union[HTTPValidationError, StageDB]]:
     """Update Stage
 
@@ -72,13 +74,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, stage_id=stage_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, stage_id: str, *, client: AuthenticatedClient, body: RulesetsMixin
+    project_id: str, stage_id: str, *, client: ApiClient, body: RulesetsMixin
 ) -> Optional[Union[HTTPValidationError, StageDB]]:
     """Update Stage
 
@@ -99,7 +101,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, stage_id: str, *, client: AuthenticatedClient, body: RulesetsMixin
+    project_id: str, stage_id: str, *, client: ApiClient, body: RulesetsMixin
 ) -> Response[Union[HTTPValidationError, StageDB]]:
     """Update Stage
 
@@ -118,13 +120,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, stage_id=stage_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, stage_id: str, *, client: AuthenticatedClient, body: RulesetsMixin
+    project_id: str, stage_id: str, *, client: ApiClient, body: RulesetsMixin
 ) -> Optional[Union[HTTPValidationError, StageDB]]:
     """Update Stage
 

--- a/src/galileo/resources/api/run_scorer_settings/get_settings_projects_project_id_runs_run_id_scorer_settings_get.py
+++ b/src/galileo/resources/api/run_scorer_settings/get_settings_projects_project_id_runs_run_id_scorer_settings_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.run_scorer_settings_response import RunScorerSettingsResponse
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, run_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/runs/{run_id}/scorer-settings"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/runs/{run_id}/scorer-settings",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     if response.status_code == 200:
         response_200 = RunScorerSettingsResponse.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient
+    project_id: str, run_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Get Settings
 
@@ -63,13 +69,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, run_id: str, *, client: AuthenticatedClient
+    project_id: str, run_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Get Settings
 
@@ -89,7 +95,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient
+    project_id: str, run_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Get Settings
 
@@ -107,13 +113,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, run_id: str, *, client: AuthenticatedClient
+    project_id: str, run_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Get Settings
 

--- a/src/galileo/resources/api/run_scorer_settings/upsert_scorers_config_projects_project_id_runs_run_id_scorer_settings_patch.py
+++ b/src/galileo/resources/api/run_scorer_settings/upsert_scorers_config_projects_project_id_runs_run_id_scorer_settings_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, run_id: str, *, body: RunScorerSettingsPatchReq
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/run_scorer_settings/upsert_scorers_config_projects_project_id_runs_run_id_scorer_settings_patch.py
+++ b/src/galileo/resources/api/run_scorer_settings/upsert_scorers_config_projects_project_id_runs_run_id_scorer_settings_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.run_scorer_settings_patch_request import RunScorerSettingsPatchRequest
 from ...models.run_scorer_settings_response import RunScorerSettingsResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, run_id: str, *, body: RunScorerSettingsPatchRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/projects/{project_id}/runs/{run_id}/scorer-settings"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/runs/{run_id}/scorer-settings",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, run_id: str, *, body: RunScorerSettingsPatchReq
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     if response.status_code == 200:
         response_200 = RunScorerSettingsResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, body: RunScorerSettingsPatchRequest
+    project_id: str, run_id: str, *, client: ApiClient, body: RunScorerSettingsPatchRequest
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Upsert Scorers Config
 
@@ -72,13 +78,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, body: RunScorerSettingsPatchRequest
+    project_id: str, run_id: str, *, client: ApiClient, body: RunScorerSettingsPatchRequest
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Upsert Scorers Config
 
@@ -99,7 +105,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, body: RunScorerSettingsPatchRequest
+    project_id: str, run_id: str, *, client: ApiClient, body: RunScorerSettingsPatchRequest
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Upsert Scorers Config
 
@@ -118,13 +124,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, body: RunScorerSettingsPatchRequest
+    project_id: str, run_id: str, *, client: ApiClient, body: RunScorerSettingsPatchRequest
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Upsert Scorers Config
 

--- a/src/galileo/resources/api/run_scorer_settings/upsert_scorers_config_projects_project_id_runs_run_id_scorer_settings_post.py
+++ b/src/galileo/resources/api/run_scorer_settings/upsert_scorers_config_projects_project_id_runs_run_id_scorer_settings_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, run_id: str, *, body: RunScorerSettingsPatchReq
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/run_scorer_settings/upsert_scorers_config_projects_project_id_runs_run_id_scorer_settings_post.py
+++ b/src/galileo/resources/api/run_scorer_settings/upsert_scorers_config_projects_project_id_runs_run_id_scorer_settings_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.run_scorer_settings_patch_request import RunScorerSettingsPatchRequest
 from ...models.run_scorer_settings_response import RunScorerSettingsResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, run_id: str, *, body: RunScorerSettingsPatchRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/runs/{run_id}/scorer-settings"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/runs/{run_id}/scorer-settings",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, run_id: str, *, body: RunScorerSettingsPatchReq
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     if response.status_code == 200:
         response_200 = RunScorerSettingsResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, body: RunScorerSettingsPatchRequest
+    project_id: str, run_id: str, *, client: ApiClient, body: RunScorerSettingsPatchRequest
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Upsert Scorers Config
 
@@ -72,13 +78,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, body: RunScorerSettingsPatchRequest
+    project_id: str, run_id: str, *, client: ApiClient, body: RunScorerSettingsPatchRequest
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Upsert Scorers Config
 
@@ -99,7 +105,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, body: RunScorerSettingsPatchRequest
+    project_id: str, run_id: str, *, client: ApiClient, body: RunScorerSettingsPatchRequest
 ) -> Response[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Upsert Scorers Config
 
@@ -118,13 +124,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, run_id=run_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, run_id: str, *, client: AuthenticatedClient, body: RunScorerSettingsPatchRequest
+    project_id: str, run_id: str, *, client: ApiClient, body: RunScorerSettingsPatchRequest
 ) -> Optional[Union[HTTPValidationError, RunScorerSettingsResponse]]:
     """Upsert Scorers Config
 

--- a/src/galileo/resources/api/trace/create_session_projects_project_id_sessions_post.py
+++ b/src/galileo/resources/api/trace/create_session_projects_project_id_sessions_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.session_create_request import SessionCreateRequest
 from ...models.session_create_response import SessionCreateResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: SessionCreateRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/sessions"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/sessions",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: SessionCreateRequest) -> dict[str, Any
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, SessionCreateResponse]]:
     if response.status_code == 200:
         response_200 = SessionCreateResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, SessionCreateResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: SessionCreateRequest
+    project_id: str, *, client: ApiClient, body: SessionCreateRequest
 ) -> Response[Union[HTTPValidationError, SessionCreateResponse]]:
     """Create Session
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: SessionCreateRequest
+    project_id: str, *, client: ApiClient, body: SessionCreateRequest
 ) -> Optional[Union[HTTPValidationError, SessionCreateResponse]]:
     """Create Session
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: SessionCreateRequest
+    project_id: str, *, client: ApiClient, body: SessionCreateRequest
 ) -> Response[Union[HTTPValidationError, SessionCreateResponse]]:
     """Create Session
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: SessionCreateRequest
+    project_id: str, *, client: ApiClient, body: SessionCreateRequest
 ) -> Optional[Union[HTTPValidationError, SessionCreateResponse]]:
     """Create Session
 

--- a/src/galileo/resources/api/trace/create_session_projects_project_id_sessions_post.py
+++ b/src/galileo/resources/api/trace/create_session_projects_project_id_sessions_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: SessionCreateRequest) -> dict[str, Any
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/export_records_projects_project_id_export_records_post.py
+++ b/src/galileo/resources/api/trace/export_records_projects_project_id_export_records_post.py
@@ -25,7 +25,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsExportRequest) -> dict[str, 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/export_records_projects_project_id_export_records_post.py
+++ b/src/galileo/resources/api/trace/export_records_projects_project_id_export_records_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_records_export_request import LogRecordsExportRequest
 from ...types import Response
@@ -13,7 +15,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogRecordsExportRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/export_records"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/export_records",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -23,9 +29,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsExportRequest) -> dict[str, 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: ApiClient, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
@@ -39,9 +43,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: ApiClient, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -51,7 +53,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsExportRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsExportRequest
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Export Records
 
@@ -70,13 +72,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsExportRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsExportRequest
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Export Records
 
@@ -97,7 +99,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsExportRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsExportRequest
 ) -> Response[Union[Any, HTTPValidationError]]:
     """Export Records
 
@@ -116,13 +118,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsExportRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsExportRequest
 ) -> Optional[Union[Any, HTTPValidationError]]:
     """Export Records
 

--- a/src/galileo/resources/api/trace/get_aggregated_trace_view_projects_project_id_traces_aggregated_post.py
+++ b/src/galileo/resources/api/trace/get_aggregated_trace_view_projects_project_id_traces_aggregated_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.aggregated_trace_view_request import AggregatedTraceViewRequest
 from ...models.aggregated_trace_view_response import AggregatedTraceViewResponse
 from ...models.http_validation_error import HTTPValidationError
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: AggregatedTraceViewRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/traces/aggregated"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/traces/aggregated",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: AggregatedTraceViewRequest) -> dict[st
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[AggregatedTraceViewResponse, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = AggregatedTraceViewResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[AggregatedTraceViewResponse, HTTPValidationError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: AggregatedTraceViewRequest
+    project_id: str, *, client: ApiClient, body: AggregatedTraceViewRequest
 ) -> Response[Union[AggregatedTraceViewResponse, HTTPValidationError]]:
     """Get Aggregated Trace View
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: AggregatedTraceViewRequest
+    project_id: str, *, client: ApiClient, body: AggregatedTraceViewRequest
 ) -> Optional[Union[AggregatedTraceViewResponse, HTTPValidationError]]:
     """Get Aggregated Trace View
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: AggregatedTraceViewRequest
+    project_id: str, *, client: ApiClient, body: AggregatedTraceViewRequest
 ) -> Response[Union[AggregatedTraceViewResponse, HTTPValidationError]]:
     """Get Aggregated Trace View
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: AggregatedTraceViewRequest
+    project_id: str, *, client: ApiClient, body: AggregatedTraceViewRequest
 ) -> Optional[Union[AggregatedTraceViewResponse, HTTPValidationError]]:
     """Get Aggregated Trace View
 

--- a/src/galileo/resources/api/trace/get_aggregated_trace_view_projects_project_id_traces_aggregated_post.py
+++ b/src/galileo/resources/api/trace/get_aggregated_trace_view_projects_project_id_traces_aggregated_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: AggregatedTraceViewRequest) -> dict[st
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/get_session_projects_project_id_sessions_session_id_get.py
+++ b/src/galileo/resources/api/trace/get_session_projects_project_id_sessions_session_id_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.session_record_with_children import SessionRecordWithChildren
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, session_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/sessions/{session_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/sessions/{session_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, SessionRecordWithChildren]]:
     if response.status_code == 200:
         response_200 = SessionRecordWithChildren.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, SessionRecordWithChildren]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, session_id: str, *, client: AuthenticatedClient
+    project_id: str, session_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, SessionRecordWithChildren]]:
     """Get Session
 
@@ -63,13 +69,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, session_id=session_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, session_id: str, *, client: AuthenticatedClient
+    project_id: str, session_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, SessionRecordWithChildren]]:
     """Get Session
 
@@ -89,7 +95,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, session_id: str, *, client: AuthenticatedClient
+    project_id: str, session_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, SessionRecordWithChildren]]:
     """Get Session
 
@@ -107,13 +113,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, session_id=session_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, session_id: str, *, client: AuthenticatedClient
+    project_id: str, session_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, SessionRecordWithChildren]]:
     """Get Session
 

--- a/src/galileo/resources/api/trace/get_span_projects_project_id_spans_span_id_get.py
+++ b/src/galileo/resources/api/trace/get_span_projects_project_id_spans_span_id_get.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.agent_span_record_with_children import AgentSpanRecordWithChildren
 from ...models.http_validation_error import HTTPValidationError
 from ...models.llm_span_record import LlmSpanRecord
@@ -15,13 +17,17 @@ from ...types import Response
 
 
 def _get_kwargs(project_id: str, span_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/spans/{span_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/spans/{span_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[
     Union[
         HTTPValidationError,
@@ -97,7 +103,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[
     Union[
         HTTPValidationError,
@@ -119,7 +125,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, span_id: str, *, client: AuthenticatedClient
+    project_id: str, span_id: str, *, client: ApiClient
 ) -> Response[
     Union[
         HTTPValidationError,
@@ -148,13 +154,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, span_id=span_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, span_id: str, *, client: AuthenticatedClient
+    project_id: str, span_id: str, *, client: ApiClient
 ) -> Optional[
     Union[
         HTTPValidationError,
@@ -185,7 +191,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, span_id: str, *, client: AuthenticatedClient
+    project_id: str, span_id: str, *, client: ApiClient
 ) -> Response[
     Union[
         HTTPValidationError,
@@ -214,13 +220,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, span_id=span_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, span_id: str, *, client: AuthenticatedClient
+    project_id: str, span_id: str, *, client: ApiClient
 ) -> Optional[
     Union[
         HTTPValidationError,

--- a/src/galileo/resources/api/trace/get_trace_projects_project_id_traces_trace_id_get.py
+++ b/src/galileo/resources/api/trace/get_trace_projects_project_id_traces_trace_id_get.py
@@ -3,21 +3,27 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.trace_record_with_children import TraceRecordWithChildren
 from ...types import Response
 
 
 def _get_kwargs(project_id: str, trace_id: str) -> dict[str, Any]:
-    _kwargs: dict[str, Any] = {"method": "get", "url": f"/projects/{project_id}/traces/{trace_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.GET,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/traces/{trace_id}",
+    }
 
     return _kwargs
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, TraceRecordWithChildren]]:
     if response.status_code == 200:
         response_200 = TraceRecordWithChildren.from_dict(response.json())
@@ -34,7 +40,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, TraceRecordWithChildren]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -45,7 +51,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, trace_id: str, *, client: AuthenticatedClient
+    project_id: str, trace_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, TraceRecordWithChildren]]:
     """Get Trace
 
@@ -63,13 +69,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, trace_id=trace_id)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, trace_id: str, *, client: AuthenticatedClient
+    project_id: str, trace_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, TraceRecordWithChildren]]:
     """Get Trace
 
@@ -89,7 +95,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, trace_id: str, *, client: AuthenticatedClient
+    project_id: str, trace_id: str, *, client: ApiClient
 ) -> Response[Union[HTTPValidationError, TraceRecordWithChildren]]:
     """Get Trace
 
@@ -107,13 +113,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, trace_id=trace_id)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, trace_id: str, *, client: AuthenticatedClient
+    project_id: str, trace_id: str, *, client: ApiClient
 ) -> Optional[Union[HTTPValidationError, TraceRecordWithChildren]]:
     """Get Trace
 

--- a/src/galileo/resources/api/trace/log_spans_projects_project_id_spans_post.py
+++ b/src/galileo/resources/api/trace/log_spans_projects_project_id_spans_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_spans_ingest_request import LogSpansIngestRequest
 from ...models.log_spans_ingest_response import LogSpansIngestResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogSpansIngestRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/spans"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/spans",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogSpansIngestRequest) -> dict[str, An
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogSpansIngestResponse]]:
     if response.status_code == 200:
         response_200 = LogSpansIngestResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogSpansIngestResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogSpansIngestRequest
+    project_id: str, *, client: ApiClient, body: LogSpansIngestRequest
 ) -> Response[Union[HTTPValidationError, LogSpansIngestResponse]]:
     """Log Spans
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogSpansIngestRequest
+    project_id: str, *, client: ApiClient, body: LogSpansIngestRequest
 ) -> Optional[Union[HTTPValidationError, LogSpansIngestResponse]]:
     """Log Spans
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogSpansIngestRequest
+    project_id: str, *, client: ApiClient, body: LogSpansIngestRequest
 ) -> Response[Union[HTTPValidationError, LogSpansIngestResponse]]:
     """Log Spans
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogSpansIngestRequest
+    project_id: str, *, client: ApiClient, body: LogSpansIngestRequest
 ) -> Optional[Union[HTTPValidationError, LogSpansIngestResponse]]:
     """Log Spans
 

--- a/src/galileo/resources/api/trace/log_spans_projects_project_id_spans_post.py
+++ b/src/galileo/resources/api/trace/log_spans_projects_project_id_spans_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogSpansIngestRequest) -> dict[str, An
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/log_traces_projects_project_id_traces_post.py
+++ b/src/galileo/resources/api/trace/log_traces_projects_project_id_traces_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogTracesIngestRequest) -> dict[str, A
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/log_traces_projects_project_id_traces_post.py
+++ b/src/galileo/resources/api/trace/log_traces_projects_project_id_traces_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_traces_ingest_request import LogTracesIngestRequest
 from ...models.log_traces_ingest_response import LogTracesIngestResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogTracesIngestRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/traces"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/traces",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogTracesIngestRequest) -> dict[str, A
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogTracesIngestResponse]]:
     if response.status_code == 200:
         response_200 = LogTracesIngestResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogTracesIngestResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogTracesIngestRequest
+    project_id: str, *, client: ApiClient, body: LogTracesIngestRequest
 ) -> Response[Union[HTTPValidationError, LogTracesIngestResponse]]:
     """Log Traces
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogTracesIngestRequest
+    project_id: str, *, client: ApiClient, body: LogTracesIngestRequest
 ) -> Optional[Union[HTTPValidationError, LogTracesIngestResponse]]:
     """Log Traces
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogTracesIngestRequest
+    project_id: str, *, client: ApiClient, body: LogTracesIngestRequest
 ) -> Response[Union[HTTPValidationError, LogTracesIngestResponse]]:
     """Log Traces
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogTracesIngestRequest
+    project_id: str, *, client: ApiClient, body: LogTracesIngestRequest
 ) -> Optional[Union[HTTPValidationError, LogTracesIngestResponse]]:
     """Log Traces
 

--- a/src/galileo/resources/api/trace/query_metrics_projects_project_id_metrics_search_post.py
+++ b/src/galileo/resources/api/trace/query_metrics_projects_project_id_metrics_search_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsMetricsQueryRequest) -> dict
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/query_metrics_projects_project_id_metrics_search_post.py
+++ b/src/galileo/resources/api/trace/query_metrics_projects_project_id_metrics_search_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_records_metrics_query_request import LogRecordsMetricsQueryRequest
 from ...models.log_records_metrics_response import LogRecordsMetricsResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogRecordsMetricsQueryRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/metrics/search"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/metrics/search",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsMetricsQueryRequest) -> dict
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogRecordsMetricsResponse]]:
     if response.status_code == 200:
         response_200 = LogRecordsMetricsResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogRecordsMetricsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsMetricsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsMetricsQueryRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsMetricsResponse]]:
     """Query Metrics
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsMetricsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsMetricsQueryRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsMetricsResponse]]:
     """Query Metrics
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsMetricsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsMetricsQueryRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsMetricsResponse]]:
     """Query Metrics
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsMetricsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsMetricsQueryRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsMetricsResponse]]:
     """Query Metrics
 

--- a/src/galileo/resources/api/trace/query_sessions_projects_project_id_sessions_search_post.py
+++ b/src/galileo/resources/api/trace/query_sessions_projects_project_id_sessions_search_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, A
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/query_sessions_projects_project_id_sessions_search_post.py
+++ b/src/galileo/resources/api/trace/query_sessions_projects_project_id_sessions_search_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_records_query_request import LogRecordsQueryRequest
 from ...models.log_records_query_response import LogRecordsQueryResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/sessions/search"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/sessions/search",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, A
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     if response.status_code == 200:
         response_200 = LogRecordsQueryResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Sessions
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Sessions
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Sessions
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Sessions
 

--- a/src/galileo/resources/api/trace/query_spans_projects_project_id_spans_search_post.py
+++ b/src/galileo/resources/api/trace/query_spans_projects_project_id_spans_search_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_records_query_request import LogRecordsQueryRequest
 from ...models.log_records_query_response import LogRecordsQueryResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/spans/search"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/spans/search",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, A
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     if response.status_code == 200:
         response_200 = LogRecordsQueryResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Spans
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Spans
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Spans
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Spans
 

--- a/src/galileo/resources/api/trace/query_spans_projects_project_id_spans_search_post.py
+++ b/src/galileo/resources/api/trace/query_spans_projects_project_id_spans_search_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, A
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/query_traces_projects_project_id_traces_search_post.py
+++ b/src/galileo/resources/api/trace/query_traces_projects_project_id_traces_search_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_records_query_request import LogRecordsQueryRequest
 from ...models.log_records_query_response import LogRecordsQueryResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/traces/search"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/traces/search",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, A
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     if response.status_code == 200:
         response_200 = LogRecordsQueryResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Traces
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Traces
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Traces
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsQueryRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsQueryRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsQueryResponse]]:
     """Query Traces
 

--- a/src/galileo/resources/api/trace/query_traces_projects_project_id_traces_search_post.py
+++ b/src/galileo/resources/api/trace/query_traces_projects_project_id_traces_search_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsQueryRequest) -> dict[str, A
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/sessions_available_columns_projects_project_id_sessions_available_columns_post.py
+++ b/src/galileo/resources/api/trace/sessions_available_columns_projects_project_id_sessions_available_columns_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_records_available_columns_request import LogRecordsAvailableColumnsRequest
 from ...models.log_records_available_columns_response import LogRecordsAvailableColumnsResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/sessions/available_columns"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/sessions/available_columns",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> 
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     if response.status_code == 200:
         response_200 = LogRecordsAvailableColumnsResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Sessions Available Columns
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Sessions Available Columns
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Sessions Available Columns
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Sessions Available Columns
 

--- a/src/galileo/resources/api/trace/sessions_available_columns_projects_project_id_sessions_available_columns_post.py
+++ b/src/galileo/resources/api/trace/sessions_available_columns_projects_project_id_sessions_available_columns_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/spans_available_columns_projects_project_id_spans_available_columns_post.py
+++ b/src/galileo/resources/api/trace/spans_available_columns_projects_project_id_spans_available_columns_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_records_available_columns_request import LogRecordsAvailableColumnsRequest
 from ...models.log_records_available_columns_response import LogRecordsAvailableColumnsResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/spans/available_columns"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/spans/available_columns",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> 
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     if response.status_code == 200:
         response_200 = LogRecordsAvailableColumnsResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Spans Available Columns
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Spans Available Columns
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Spans Available Columns
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Spans Available Columns
 

--- a/src/galileo/resources/api/trace/spans_available_columns_projects_project_id_spans_available_columns_post.py
+++ b/src/galileo/resources/api/trace/spans_available_columns_projects_project_id_spans_available_columns_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/traces_available_columns_projects_project_id_traces_available_columns_post.py
+++ b/src/galileo/resources/api/trace/traces_available_columns_projects_project_id_traces_available_columns_post.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_records_available_columns_request import LogRecordsAvailableColumnsRequest
 from ...models.log_records_available_columns_response import LogRecordsAvailableColumnsResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "post", "url": f"/projects/{project_id}/traces/available_columns"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.POST,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/traces/available_columns",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> 
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     if response.status_code == 200:
         response_200 = LogRecordsAvailableColumnsResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Traces Available Columns
 
@@ -71,13 +77,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Traces Available Columns
 
@@ -97,7 +103,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Response[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Traces Available Columns
 
@@ -115,13 +121,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, *, client: AuthenticatedClient, body: LogRecordsAvailableColumnsRequest
+    project_id: str, *, client: ApiClient, body: LogRecordsAvailableColumnsRequest
 ) -> Optional[Union[HTTPValidationError, LogRecordsAvailableColumnsResponse]]:
     """Traces Available Columns
 

--- a/src/galileo/resources/api/trace/traces_available_columns_projects_project_id_traces_available_columns_post.py
+++ b/src/galileo/resources/api/trace/traces_available_columns_projects_project_id_traces_available_columns_post.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, *, body: LogRecordsAvailableColumnsRequest) -> 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/update_span_projects_project_id_spans_span_id_patch.py
+++ b/src/galileo/resources/api/trace/update_span_projects_project_id_spans_span_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_span_update_request import LogSpanUpdateRequest
 from ...models.log_span_update_response import LogSpanUpdateResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, span_id: str, *, body: LogSpanUpdateRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/projects/{project_id}/spans/{span_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/spans/{span_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, span_id: str, *, body: LogSpanUpdateRequest) ->
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogSpanUpdateResponse]]:
     if response.status_code == 200:
         response_200 = LogSpanUpdateResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogSpanUpdateResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, span_id: str, *, client: AuthenticatedClient, body: LogSpanUpdateRequest
+    project_id: str, span_id: str, *, client: ApiClient, body: LogSpanUpdateRequest
 ) -> Response[Union[HTTPValidationError, LogSpanUpdateResponse]]:
     """Update Span
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, span_id=span_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, span_id: str, *, client: AuthenticatedClient, body: LogSpanUpdateRequest
+    project_id: str, span_id: str, *, client: ApiClient, body: LogSpanUpdateRequest
 ) -> Optional[Union[HTTPValidationError, LogSpanUpdateResponse]]:
     """Update Span
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, span_id: str, *, client: AuthenticatedClient, body: LogSpanUpdateRequest
+    project_id: str, span_id: str, *, client: ApiClient, body: LogSpanUpdateRequest
 ) -> Response[Union[HTTPValidationError, LogSpanUpdateResponse]]:
     """Update Span
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, span_id=span_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, span_id: str, *, client: AuthenticatedClient, body: LogSpanUpdateRequest
+    project_id: str, span_id: str, *, client: ApiClient, body: LogSpanUpdateRequest
 ) -> Optional[Union[HTTPValidationError, LogSpanUpdateResponse]]:
     """Update Span
 

--- a/src/galileo/resources/api/trace/update_span_projects_project_id_spans_span_id_patch.py
+++ b/src/galileo/resources/api/trace/update_span_projects_project_id_spans_span_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, span_id: str, *, body: LogSpanUpdateRequest) ->
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/update_trace_projects_project_id_traces_trace_id_patch.py
+++ b/src/galileo/resources/api/trace/update_trace_projects_project_id_traces_trace_id_patch.py
@@ -26,7 +26,7 @@ def _get_kwargs(project_id: str, trace_id: str, *, body: LogTraceUpdateRequest) 
 
     headers["Content-Type"] = "application/json"
 
-    _kwargs["headers"] = headers
+    _kwargs["content_headers"] = headers
     return _kwargs
 
 

--- a/src/galileo/resources/api/trace/update_trace_projects_project_id_traces_trace_id_patch.py
+++ b/src/galileo/resources/api/trace/update_trace_projects_project_id_traces_trace_id_patch.py
@@ -3,8 +3,10 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from galileo_core.constants.request_method import RequestMethod
+from galileo_core.helpers.api_client import ApiClient
+
 from ... import errors
-from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.log_trace_update_request import LogTraceUpdateRequest
 from ...models.log_trace_update_response import LogTraceUpdateResponse
@@ -14,7 +16,11 @@ from ...types import Response
 def _get_kwargs(project_id: str, trace_id: str, *, body: LogTraceUpdateRequest) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
-    _kwargs: dict[str, Any] = {"method": "patch", "url": f"/projects/{project_id}/traces/{trace_id}"}
+    _kwargs: dict[str, Any] = {
+        "method": RequestMethod.PATCH,
+        "return_raw_response": True,
+        "path": f"/projects/{project_id}/traces/{trace_id}",
+    }
 
     _kwargs["json"] = body.to_dict()
 
@@ -25,7 +31,7 @@ def _get_kwargs(project_id: str, trace_id: str, *, body: LogTraceUpdateRequest) 
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Optional[Union[HTTPValidationError, LogTraceUpdateResponse]]:
     if response.status_code == 200:
         response_200 = LogTraceUpdateResponse.from_dict(response.json())
@@ -42,7 +48,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+    *, client: ApiClient, response: httpx.Response
 ) -> Response[Union[HTTPValidationError, LogTraceUpdateResponse]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
@@ -53,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    project_id: str, trace_id: str, *, client: AuthenticatedClient, body: LogTraceUpdateRequest
+    project_id: str, trace_id: str, *, client: ApiClient, body: LogTraceUpdateRequest
 ) -> Response[Union[HTTPValidationError, LogTraceUpdateResponse]]:
     """Update Trace
 
@@ -74,13 +80,13 @@ def sync_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, trace_id=trace_id, body=body)
 
-    response = client.get_httpx_client().request(**kwargs)
+    response = client.request(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 def sync(
-    project_id: str, trace_id: str, *, client: AuthenticatedClient, body: LogTraceUpdateRequest
+    project_id: str, trace_id: str, *, client: ApiClient, body: LogTraceUpdateRequest
 ) -> Optional[Union[HTTPValidationError, LogTraceUpdateResponse]]:
     """Update Trace
 
@@ -103,7 +109,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    project_id: str, trace_id: str, *, client: AuthenticatedClient, body: LogTraceUpdateRequest
+    project_id: str, trace_id: str, *, client: ApiClient, body: LogTraceUpdateRequest
 ) -> Response[Union[HTTPValidationError, LogTraceUpdateResponse]]:
     """Update Trace
 
@@ -124,13 +130,13 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(project_id=project_id, trace_id=trace_id, body=body)
 
-    response = await client.get_async_httpx_client().request(**kwargs)
+    response = await client.arequest(**kwargs)
 
     return _build_response(client=client, response=response)
 
 
 async def asyncio(
-    project_id: str, trace_id: str, *, client: AuthenticatedClient, body: LogTraceUpdateRequest
+    project_id: str, trace_id: str, *, client: ApiClient, body: LogTraceUpdateRequest
 ) -> Optional[Union[HTTPValidationError, LogTraceUpdateResponse]]:
     """Update Trace
 

--- a/src/galileo/resources/models/body_create_code_scorer_version_scorers_scorer_id_version_code_post.py
+++ b/src/galileo/resources/models/body_create_code_scorer_version_scorers_scorer_id_version_code_post.py
@@ -5,7 +5,6 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost")
@@ -30,15 +29,16 @@ class BodyCreateCodeScorerVersionScorersScorerIdVersionCodePost:
 
         return field_dict
 
-    def to_multipart(self) -> types.RequestFiles:
-        files: types.RequestFiles = []
+    def to_multipart(self) -> dict[str, Any]:
+        file = self.file.to_tuple()
 
-        files.append(("file", self.file.to_tuple()))
-
+        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
+            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
 
-        return files
+        field_dict.update({"file": file})
+
+        return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/src/galileo/resources/models/body_create_dataset_datasets_post.py
+++ b/src/galileo/resources/models/body_create_dataset_datasets_post.py
@@ -5,8 +5,7 @@ from typing import Any, TypeVar, Union, cast
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from .. import types
-from ..types import UNSET, File, FileTypes, Unset
+from ..types import UNSET, File, FileJsonType, Unset
 
 T = TypeVar("T", bound="BodyCreateDatasetDatasetsPost")
 
@@ -46,7 +45,7 @@ class BodyCreateDatasetDatasetsPost:
 
         draft = self.draft
 
-        file: Union[FileTypes, None, Unset]
+        file: Union[FileJsonType, None, Unset]
         if isinstance(self.file, Unset):
             file = UNSET
         elif isinstance(self.file, File):
@@ -81,53 +80,66 @@ class BodyCreateDatasetDatasetsPost:
 
         return field_dict
 
-    def to_multipart(self) -> types.RequestFiles:
-        files: types.RequestFiles = []
+    def to_multipart(self) -> dict[str, Any]:
+        copy_from_dataset_id: Union[Unset, tuple[None, bytes, str]]
 
-        if not isinstance(self.copy_from_dataset_id, Unset):
-            if isinstance(self.copy_from_dataset_id, str):
-                files.append(("copy_from_dataset_id", (None, str(self.copy_from_dataset_id).encode(), "text/plain")))
-            else:
-                files.append(("copy_from_dataset_id", (None, str(self.copy_from_dataset_id).encode(), "text/plain")))
+        if isinstance(self.copy_from_dataset_id, Unset):
+            copy_from_dataset_id = UNSET
+        elif isinstance(self.copy_from_dataset_id, str):
+            copy_from_dataset_id = (None, str(self.copy_from_dataset_id).encode(), "text/plain")
+        else:
+            copy_from_dataset_id = (None, str(self.copy_from_dataset_id).encode(), "text/plain")
 
-        if not isinstance(self.copy_from_dataset_version_index, Unset):
-            if isinstance(self.copy_from_dataset_version_index, int):
-                files.append(
-                    (
-                        "copy_from_dataset_version_index",
-                        (None, str(self.copy_from_dataset_version_index).encode(), "text/plain"),
-                    )
-                )
-            else:
-                files.append(
-                    (
-                        "copy_from_dataset_version_index",
-                        (None, str(self.copy_from_dataset_version_index).encode(), "text/plain"),
-                    )
-                )
+        copy_from_dataset_version_index: Union[Unset, tuple[None, bytes, str]]
 
-        if not isinstance(self.draft, Unset):
-            files.append(("draft", (None, str(self.draft).encode(), "text/plain")))
+        if isinstance(self.copy_from_dataset_version_index, Unset):
+            copy_from_dataset_version_index = UNSET
+        elif isinstance(self.copy_from_dataset_version_index, int):
+            copy_from_dataset_version_index = (None, str(self.copy_from_dataset_version_index).encode(), "text/plain")
+        else:
+            copy_from_dataset_version_index = (None, str(self.copy_from_dataset_version_index).encode(), "text/plain")
 
-        if not isinstance(self.file, Unset):
-            if isinstance(self.file, File):
-                files.append(("file", self.file.to_tuple()))
-            else:
-                files.append(("file", (None, str(self.file).encode(), "text/plain")))
+        draft = self.draft if isinstance(self.draft, Unset) else (None, str(self.draft).encode(), "text/plain")
 
-        if not isinstance(self.hidden, Unset):
-            files.append(("hidden", (None, str(self.hidden).encode(), "text/plain")))
+        file: Union[Unset, tuple[None, bytes, str]]
 
-        if not isinstance(self.name, Unset):
-            if isinstance(self.name, str):
-                files.append(("name", (None, str(self.name).encode(), "text/plain")))
-            else:
-                files.append(("name", (None, str(self.name).encode(), "text/plain")))
+        if isinstance(self.file, Unset):
+            file = UNSET
+        elif isinstance(self.file, File):
+            file = self.file.to_tuple()
+        else:
+            file = (None, str(self.file).encode(), "text/plain")
 
+        hidden = self.hidden if isinstance(self.hidden, Unset) else (None, str(self.hidden).encode(), "text/plain")
+
+        name: Union[Unset, tuple[None, bytes, str]]
+
+        if isinstance(self.name, Unset):
+            name = UNSET
+        elif isinstance(self.name, str):
+            name = (None, str(self.name).encode(), "text/plain")
+        else:
+            name = (None, str(self.name).encode(), "text/plain")
+
+        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
+            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
 
-        return files
+        field_dict.update({})
+        if copy_from_dataset_id is not UNSET:
+            field_dict["copy_from_dataset_id"] = copy_from_dataset_id
+        if copy_from_dataset_version_index is not UNSET:
+            field_dict["copy_from_dataset_version_index"] = copy_from_dataset_version_index
+        if draft is not UNSET:
+            field_dict["draft"] = draft
+        if file is not UNSET:
+            field_dict["file"] = file
+        if hidden is not UNSET:
+            field_dict["hidden"] = hidden
+        if name is not UNSET:
+            field_dict["name"] = name
+
+        return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/src/galileo/resources/models/body_update_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_put.py
+++ b/src/galileo/resources/models/body_update_prompt_dataset_projects_project_id_prompt_datasets_dataset_id_put.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Mapping
 from io import BytesIO
 from typing import Any, TypeVar, Union, cast
@@ -5,8 +6,7 @@ from typing import Any, TypeVar, Union, cast
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from .. import types
-from ..types import UNSET, File, FileTypes, Unset
+from ..types import UNSET, File, FileJsonType, Unset
 
 T = TypeVar("T", bound="BodyUpdatePromptDatasetProjectsProjectIdPromptDatasetsDatasetIdPut")
 
@@ -33,7 +33,7 @@ class BodyUpdatePromptDatasetProjectsProjectIdPromptDatasetsDatasetIdPut:
         else:
             column_names = self.column_names
 
-        file: Union[FileTypes, None, Unset]
+        file: Union[FileJsonType, None, Unset]
         if isinstance(self.file, Unset):
             file = UNSET
         elif isinstance(self.file, File):
@@ -52,26 +52,37 @@ class BodyUpdatePromptDatasetProjectsProjectIdPromptDatasetsDatasetIdPut:
 
         return field_dict
 
-    def to_multipart(self) -> types.RequestFiles:
-        files: types.RequestFiles = []
+    def to_multipart(self) -> dict[str, Any]:
+        column_names: Union[Unset, tuple[None, bytes, str]]
 
-        if not isinstance(self.column_names, Unset):
-            if isinstance(self.column_names, list):
-                for column_names_type_0_item_element in self.column_names:
-                    files.append(("column_names", (None, str(column_names_type_0_item_element).encode(), "text/plain")))
-            else:
-                files.append(("column_names", (None, str(self.column_names).encode(), "text/plain")))
+        if isinstance(self.column_names, Unset):
+            column_names = UNSET
+        elif isinstance(self.column_names, list):
+            _temp_column_names = self.column_names
+            column_names = (None, json.dumps(_temp_column_names).encode(), "application/json")
+        else:
+            column_names = (None, str(self.column_names).encode(), "text/plain")
 
-        if not isinstance(self.file, Unset):
-            if isinstance(self.file, File):
-                files.append(("file", self.file.to_tuple()))
-            else:
-                files.append(("file", (None, str(self.file).encode(), "text/plain")))
+        file: Union[Unset, tuple[None, bytes, str]]
 
+        if isinstance(self.file, Unset):
+            file = UNSET
+        elif isinstance(self.file, File):
+            file = self.file.to_tuple()
+        else:
+            file = (None, str(self.file).encode(), "text/plain")
+
+        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
+            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
 
-        return files
+        field_dict.update({})
+        if column_names is not UNSET:
+            field_dict["column_names"] = column_names
+        if file is not UNSET:
+            field_dict["file"] = file
+
+        return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/src/galileo/resources/models/body_upload_file_projects_project_id_upload_file_post.py
+++ b/src/galileo/resources/models/body_upload_file_projects_project_id_upload_file_post.py
@@ -5,7 +5,6 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="BodyUploadFileProjectsProjectIdUploadFilePost")
@@ -34,17 +33,18 @@ class BodyUploadFileProjectsProjectIdUploadFilePost:
 
         return field_dict
 
-    def to_multipart(self) -> types.RequestFiles:
-        files: types.RequestFiles = []
+    def to_multipart(self) -> dict[str, Any]:
+        file = self.file.to_tuple()
 
-        files.append(("file", self.file.to_tuple()))
+        upload_metadata = (None, str(self.upload_metadata).encode(), "text/plain")
 
-        files.append(("upload_metadata", (None, str(self.upload_metadata).encode(), "text/plain")))
-
+        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
+            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
 
-        return files
+        field_dict.update({"file": file, "upload_metadata": upload_metadata})
+
+        return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/src/galileo/resources/models/body_upload_prompt_evaluation_dataset_projects_project_id_prompt_datasets_post.py
+++ b/src/galileo/resources/models/body_upload_prompt_evaluation_dataset_projects_project_id_prompt_datasets_post.py
@@ -5,7 +5,6 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost")
@@ -30,15 +29,16 @@ class BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost:
 
         return field_dict
 
-    def to_multipart(self) -> types.RequestFiles:
-        files: types.RequestFiles = []
+    def to_multipart(self) -> dict[str, Any]:
+        file = self.file.to_tuple()
 
-        files.append(("file", self.file.to_tuple()))
-
+        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
+            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
 
-        return files
+        field_dict.update({"file": file})
+
+        return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/src/galileo/resources/models/create_job_request.py
+++ b/src/galileo/resources/models/create_job_request.py
@@ -7,7 +7,7 @@ from attrs import field as _attrs_field
 
 from ..models.scorer_name import ScorerName
 from ..models.task_type import TaskType
-from ..types import UNSET, File, FileTypes, Unset
+from ..types import UNSET, File, FileJsonType, Unset
 
 if TYPE_CHECKING:
     from ..models.agentic_session_success_scorer import AgenticSessionSuccessScorer
@@ -529,7 +529,7 @@ class CreateJobRequest:
         else:
             prompt_template_version_id = self.prompt_template_version_id
 
-        protect_scorer_payload: Union[FileTypes, None, Unset]
+        protect_scorer_payload: Union[FileJsonType, None, Unset]
         if isinstance(self.protect_scorer_payload, Unset):
             protect_scorer_payload = UNSET
         elif isinstance(self.protect_scorer_payload, File):

--- a/src/galileo/resources/models/create_job_response.py
+++ b/src/galileo/resources/models/create_job_response.py
@@ -7,7 +7,7 @@ from attrs import field as _attrs_field
 
 from ..models.scorer_name import ScorerName
 from ..models.task_type import TaskType
-from ..types import UNSET, File, FileTypes, Unset
+from ..types import UNSET, File, FileJsonType, Unset
 
 if TYPE_CHECKING:
     from ..models.agentic_session_success_scorer import AgenticSessionSuccessScorer
@@ -537,7 +537,7 @@ class CreateJobResponse:
         else:
             prompt_template_version_id = self.prompt_template_version_id
 
-        protect_scorer_payload: Union[FileTypes, None, Unset]
+        protect_scorer_payload: Union[FileJsonType, None, Unset]
         if isinstance(self.protect_scorer_payload, Unset):
             protect_scorer_payload = UNSET
         elif isinstance(self.protect_scorer_payload, File):

--- a/src/galileo/resources/models/document.py
+++ b/src/galileo/resources/models/document.py
@@ -31,7 +31,6 @@ class Document:
             metadata = self.metadata.to_dict()
 
         field_dict: dict[str, Any] = {}
-
         field_dict.update({"page_content": page_content})
         if metadata is not UNSET:
             field_dict["metadata"] = metadata

--- a/src/galileo/resources/models/experiment_response.py
+++ b/src/galileo/resources/models/experiment_response.py
@@ -28,25 +28,6 @@ class ExperimentResponse:
         task_type (TaskType): Valid task types for modeling.
 
             We store these as ints instead of strings because we will be looking this up in the database frequently.
-
-            text_classification = 0
-            text_multi_label = 1
-            text_ner = 2
-            image_classification = 3
-            tabular_classification = 4
-            object_detection = 5
-            semantic_segmentation = 6
-            prompt_evaluation = 7
-            seq2seq = 8
-            llm_monitor = 9
-            seq2seq_completion = 10
-            seq2seq_chat = 11
-            prompt_chain = 12
-            protect = 13
-            prompt_optimization = 14
-            log_stream = 15
-            experiment = 16
-            playground = 17
         aggregate_feedback (Union[Unset, ExperimentResponseAggregateFeedback]): Aggregate feedback information related
             to the experiment
         aggregate_metrics (Union[Unset, ExperimentResponseAggregateMetrics]):

--- a/src/galileo/resources/types.py
+++ b/src/galileo/resources/types.py
@@ -1,8 +1,8 @@
 """Contains some shared types for properties"""
 
-from collections.abc import Mapping, MutableMapping
+from collections.abc import MutableMapping
 from http import HTTPStatus
-from typing import IO, BinaryIO, Generic, Literal, Optional, TypeVar, Union
+from typing import BinaryIO, Generic, Literal, Optional, TypeVar
 
 from attrs import define
 
@@ -14,15 +14,7 @@ class Unset:
 
 UNSET: Unset = Unset()
 
-# The types that `httpx.Client(files=)` can accept, copied from that library.
-FileContent = Union[IO[bytes], bytes, str]
-FileTypes = Union[
-    # (filename, file (or bytes), content_type)
-    tuple[Optional[str], FileContent, Optional[str]],
-    # (filename, file (or bytes), content_type, headers)
-    tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
-]
-RequestFiles = list[tuple[str, FileTypes]]
+FileJsonType = tuple[Optional[str], BinaryIO, Optional[str]]
 
 
 @define
@@ -33,7 +25,7 @@ class File:
     file_name: Optional[str] = None
     mime_type: Optional[str] = None
 
-    def to_tuple(self) -> FileTypes:
+    def to_tuple(self) -> FileJsonType:
         """Return a tuple representation that httpx will accept for multipart/form-data"""
         return self.file_name, self.payload, self.mime_type
 
@@ -51,4 +43,4 @@ class Response(Generic[T]):
     parsed: Optional[T]
 
 
-__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]
+__all__ = ["UNSET", "File", "FileJsonType", "Response", "Unset"]


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/34869/galileo-python-migrate-all-api-interactions-to-use-config-and-api-client-from-galileo-core#activity-36213

**description:** Regenerated resources to use the Core client directly, based on the template changes in [254](https://github.com/rungalileo/galileo-python/pull/254)