### PR TITLE
feat: logging for Protect calls

### DIFF
--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -504,7 +504,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
         name: Optional[str]: Name of the trace.
         duration_ns: Optional[int]: Duration of the trace in nanoseconds.
         created_at: Optional[datetime]: Timestamp of the trace's creation.
-        metadata: Optional[Dict[str, str]]: Metadata associated with this trace.
+        metadata: Optional[dict[str, str]]: Metadata associated with this trace.
         tags: Optional[list[str]]: Tags associated with this trace.
         external_id: Optional[str]: External ID for this trace to connect to external systems.
 
@@ -571,11 +571,11 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             model: Optional[str]: Model used for this span. Feedback from April: Good docs about what model names we use.
             redacted_input: Optional[LlmStepAllowedIOType]: Redacted input to the node.
             redacted_output: Optional[LlmStepAllowedIOType]: Redacted output of the node.
-            tools: Optional[List[Dict]]: List of available tools passed to LLM on invocation.
+            tools: Optional[List[dict]]: List of available tools passed to LLM on invocation.
             name: Optional[str]: Name of the span.
             duration_ns: Optional[int]: duration_ns of the node in nanoseconds.
             created_at: Optional[datetime]: Timestamp of the span's creation.
-            user_metadata: Optional[Dict[str, str]]: Metadata associated with this span.
+            metadata: Optional[dict[str, str]]: Metadata associated with this span.
             num_input_tokens: Optional[int]: Number of input tokens.
             num_output_tokens: Optional[int]: Number of output tokens.
             total_tokens: Optional[int]: Total number of tokens.
@@ -652,11 +652,11 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             model: str: Model used for this span.
             redacted_input: Optional[LlmStepAllowedIOType]: Redacted input to the node.
             redacted_output: Optional[LlmStepAllowedIOType]: Redacted output of the node.
-            tools: Optional[List[Dict]]: List of available tools passed to LLM on invocation.
+            tools: Optional[list[dict]]: List of available tools passed to LLM on invocation.
             name: Optional[str]: Name of the span.
             duration_ns: Optional[int]: duration_ns of the node in nanoseconds.
             created_at: Optional[datetime]: Timestamp of the span's creation.
-            metadata: Optional[Dict[str, str]]: Metadata associated with this span.
+            metadata: Optional[dict[str, str]]: Metadata associated with this span.
             num_input_tokens: Optional[int]: Number of input tokens.
             num_output_tokens: Optional[int]: Number of output tokens.
             total_tokens: Optional[int]: Total number of tokens.
@@ -726,7 +726,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             name: Optional[str]: Name of the span.
             duration_ns: Optional[int]: duration_ns of the node in nanoseconds.
             created_at: Optional[datetime]: Timestamp of the span's creation.
-            metadata: Optional[Dict[str, str]]: Metadata associated with this span.
+            metadata: Optional[dict[str, str]]: Metadata associated with this span.
             status_code: Optional[int]: Status code of the node execution.
             step_number: Optional[int]: Step number of the span.
         Returns:
@@ -817,7 +817,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             name: Optional[str]: Name of the span.
             duration_ns: Optional[int]: duration_ns of the node in nanoseconds.
             created_at: Optional[datetime]: Timestamp of the span's creation.
-            user_metadata: Optional[Dict[str, str]]: Metadata associated with this span.
+            metadata: Optional[dict[str, str]]: Metadata associated with this span.
             status_code: Optional[int]: Status code of the node execution.
             tool_call_id: Optional[str]: Tool call ID.
             step_number: Optional[int]: Step number of the span.
@@ -870,7 +870,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             response: Response: Output of the node. This is the output from the Protect `invoke` method.
             redacted_response: Optional[Response]: Redacted output to the node.
             created_at: Optional[datetime]: Timestamp of the span's creation.
-            metadata: Optional[Dict[str, str]]: Metadata associated with this span.
+            metadata: Optional[dict[str, str]]: Metadata associated with this span.
             tags: Optional[list[str]]: Tags associated with this span.
             status_code: Optional[int]: Status code of the node execution.
             step_number: Optional[int]: Step number of the span.
@@ -879,10 +879,10 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             ToolSpan: The created Protect tool span.
         """
         kwargs = dict(
-            input=payload.model_dump(mode="json"),
-            redacted_input=redacted_payload.model_dump(mode="json") if redacted_payload else None,
-            output=response.model_dump(mode="json") if response else None,
-            redacted_output=redacted_response.model_dump(mode="json") if redacted_response else None,
+            input=json.dumps(payload.model_dump(mode="json")),
+            redacted_input=json.dumps(redacted_payload.model_dump(mode="json")) if redacted_payload else None,
+            output=json.dumps(response.model_dump(mode="json")) if response else None,
+            redacted_output=json.dumps(redacted_response.model_dump(mode="json")) if redacted_response else None,
             name="GalileoProtect",
             duration_ns=response.trace_metadata.response_at - response.trace_metadata.received_at if response else None,
             created_at=created_at,
@@ -927,7 +927,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             name: Optional[str]: Name of the span.
             duration_ns: Optional[int]: duration_ns of the node in nanoseconds.
             created_at: Optional[datetime]: Timestamp of the span's creation.
-            metadata: Optional[Dict[str, str]]: Metadata associated with this span.
+            metadata: Optional[dict[str, str]]: Metadata associated with this span.
             step_number: Optional[int]: Step number of the span.
         Returns:
         -------
@@ -980,7 +980,7 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             name: Optional[str]: Name of the span.
             duration_ns: Optional[int]: duration_ns of the node in nanoseconds.
             created_at: Optional[datetime]: Timestamp of the span's creation.
-            metadata: Optional[Dict[str, str]]: Metadata associated with this span.
+            metadata: Optional[dict[str, str]]: Metadata associated with this span.
             agent_type: Optional[AgentType]: Agent type of the span.
             step_number: Optional[int]: Step number of the span.
 

--- a/src/galileo/utils/core_api_client.py
+++ b/src/galileo/utils/core_api_client.py
@@ -79,8 +79,6 @@ class GalileoCoreApiClient:
 
         json = traces_ingest_request.model_dump(mode="json")
 
-        print(f"calling ingest traces for {traces_ingest_request.traces[0].id}")
-
         return await self._make_async_request(
             RequestMethod.POST, endpoint=Routes.traces.format(project_id=self.project_id), json=json
         )
@@ -105,8 +103,6 @@ class GalileoCoreApiClient:
 
         json = spans_ingest_request.model_dump(mode="json")
 
-        print(f"calling ingest spans for {spans_ingest_request.spans[0].id}")
-
         return await self._make_async_request(
             RequestMethod.POST, endpoint=Routes.spans.format(project_id=self.project_id), json=json
         )
@@ -130,8 +126,6 @@ class GalileoCoreApiClient:
             trace_update_request.log_stream_id = UUID(self.log_stream_id)
 
         json = trace_update_request.model_dump(mode="json")
-
-        print(f"calling update trace for {trace_update_request.trace_id}")
 
         return await self._make_async_request(
             RequestMethod.PATCH,
@@ -160,8 +154,6 @@ class GalileoCoreApiClient:
             span_update_request.log_stream_id = UUID(self.log_stream_id)
 
         json = span_update_request.model_dump(mode="json")
-
-        print(f"calling update span for {span_update_request.span_id}")
 
         return await self._make_async_request(
             RequestMethod.PATCH,

--- a/tests/test_logger_batch.py
+++ b/tests/test_logger_batch.py
@@ -183,8 +183,8 @@ def test_all_span_types_with_redacted_fields(
         status_code=200,
     )
 
-    received_at = int(datetime.datetime(2025, 8, 6, 12, 41, 44).timestamp() * 1_000_000_000)
-    response_at = int(datetime.datetime(2025, 8, 6, 12, 41, 45).timestamp() * 1_000_000_000)
+    received_at = int(created_at.timestamp() * 1_000_000_000)
+    response_at = int((created_at + datetime.timedelta(seconds=1)).timestamp() * 1_000_000_000)
     execution_time = 1000.0
     trace_metadata_id = uuid.uuid4()
 
@@ -455,8 +455,8 @@ def test_add_protect_tool_span(
         input="input", name="test-trace", duration_ns=1_000_000, created_at=created_at, metadata=metadata
     )
 
-    received_at = int(datetime.datetime(2025, 8, 6, 12, 41, 44).timestamp() * 1_000_000_000)
-    response_at = int(datetime.datetime(2025, 8, 6, 12, 41, 45).timestamp() * 1_000_000_000)
+    received_at = int(created_at.timestamp() * 1_000_000_000)
+    response_at = int((created_at + datetime.timedelta(seconds=1)).timestamp() * 1_000_000_000)
     execution_time = 1000.0
     trace_metadata_id = uuid.uuid4()
 

--- a/tests/test_logger_streaming.py
+++ b/tests/test_logger_streaming.py
@@ -184,8 +184,8 @@ def test_add_protect_tool_span(
         input="input", name="test-trace", duration_ns=1_000_000, created_at=created_at, metadata=metadata
     )
 
-    received_at = int(datetime.datetime(2025, 8, 6, 12, 41, 44).timestamp() * 1_000_000_000)
-    response_at = int(datetime.datetime(2025, 8, 6, 12, 41, 45).timestamp() * 1_000_000_000)
+    received_at = int(created_at.timestamp() * 1_000_000_000)
+    response_at = int((created_at + datetime.timedelta(seconds=1)).timestamp() * 1_000_000_000)
     execution_time = 1000.0
     trace_metadata_id = uuid.uuid4()
 
@@ -978,8 +978,8 @@ def test_trace_with_multiple_nested_spans(
         metadata=metadata,
     )
 
-    received_at = int(datetime.datetime(2025, 8, 6, 12, 41, 44).timestamp() * 1_000_000_000)
-    response_at = int(datetime.datetime(2025, 8, 6, 12, 41, 45).timestamp() * 1_000_000_000)
+    received_at = int(created_at.timestamp() * 1_000_000_000)
+    response_at = int((created_at + datetime.timedelta(seconds=1)).timestamp() * 1_000_000_000)
     execution_time = 1000.0
     trace_metadata_id = uuid.uuid4()
 

--- a/tests/test_logger_streaming.py
+++ b/tests/test_logger_streaming.py
@@ -1,6 +1,8 @@
 import asyncio
 import datetime
+import json
 import logging
+import uuid
 from unittest.mock import Mock, patch
 from uuid import UUID
 
@@ -10,6 +12,9 @@ from galileo.logger import GalileoLogger
 from galileo.logger.logger import GalileoLoggerException
 from galileo.schema.trace import SpansIngestRequest, SpanUpdateRequest, TracesIngestRequest, TraceUpdateRequest
 from galileo_core.schemas.logging.llm import Message
+from galileo_core.schemas.protect.execution_status import ExecutionStatus
+from galileo_core.schemas.protect.payload import Payload
+from galileo_core.schemas.protect.response import Response, TraceMetadata
 from galileo_core.schemas.shared.document import Document
 from tests.testutils.setup import (
     setup_mock_core_api_client,
@@ -157,6 +162,111 @@ def test_add_llm_span(mock_core_api_client: Mock, mock_projects_client: Mock, mo
     assert request.spans[0].user_metadata == metadata
     assert request.spans[0].metrics.duration_ns == 1_000_000
     assert request.spans[0].step_number == 1
+
+
+@patch("galileo.logger.logger.LogStreams")
+@patch("galileo.logger.logger.Projects")
+@patch("galileo.logger.logger.GalileoCoreApiClient")
+def test_add_protect_tool_span(
+    mock_core_api_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock
+) -> None:
+    mock_core_api_client_instance = setup_mock_core_api_client(mock_core_api_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+
+    created_at = datetime.datetime.now()
+    metadata = {"key": "value"}
+    logger = GalileoLogger(project="my_project", log_stream="my_log_stream", experimental={"mode": "streaming"})
+
+    capture = setup_thread_pool_request_capture(logger)
+
+    logger.start_trace(
+        input="input", name="test-trace", duration_ns=1_000_000, created_at=created_at, metadata=metadata
+    )
+
+    received_at = int(datetime.datetime(2025, 8, 6, 12, 41, 44).timestamp() * 1_000_000_000)
+    response_at = int(datetime.datetime(2025, 8, 6, 12, 41, 45).timestamp() * 1_000_000_000)
+    execution_time = 1000.0
+    trace_metadata_id = uuid.uuid4()
+
+    logger.add_protect_span(
+        payload=Payload(input="Protect input", output="Protect output"),
+        redacted_payload=Payload(input="Protect redacted input", output="Protect redacted output"),
+        response=Response(
+            status=ExecutionStatus.not_triggered,
+            text="Protect text",
+            trace_metadata=TraceMetadata(
+                id=trace_metadata_id, received_at=received_at, response_at=response_at, execution_time=execution_time
+            ),
+        ),
+        redacted_response=Response(
+            status=ExecutionStatus.not_triggered,
+            text="Protect redacted text",
+            trace_metadata=TraceMetadata(
+                id=trace_metadata_id, received_at=received_at, response_at=response_at, execution_time=execution_time
+            ),
+        ),
+        created_at=created_at,
+        metadata=metadata,
+        status_code=200,
+    )
+
+    assert len(logger._parent_stack) == 1
+
+    captured_task = capture.get_task_by_function_name("ingest_traces_with_backoff")
+    request = captured_task.request
+    assert isinstance(request, TracesIngestRequest)
+
+    asyncio.run(captured_task.task_func())
+    mock_core_api_client_instance.ingest_traces.assert_called_with(request)
+
+    assert request.traces[0].input == "input"
+    assert request.traces[0].name == "test-trace"
+    assert request.traces[0].created_at == created_at
+    assert request.traces[0].user_metadata == metadata
+    assert len(request.traces[0].spans) == 0
+    assert request.traces[0].metrics.duration_ns == 1_000_000
+    trace_id = request.traces[0].id
+
+    captured_task = capture.get_task_by_function_name("ingest_spans_with_backoff")
+    request = captured_task.request
+    assert isinstance(request, SpansIngestRequest)
+
+    asyncio.run(captured_task.task_func())
+    mock_core_api_client_instance.ingest_spans.assert_called_with(request)
+
+    assert request.trace_id == trace_id
+    assert request.parent_id == trace_id
+    protect_span = request.spans[0]
+    assert protect_span.type == "tool"
+    assert json.loads(protect_span.input) == {"input": "Protect input", "output": "Protect output"}
+    assert json.loads(protect_span.redacted_input) == {
+        "input": "Protect redacted input",
+        "output": "Protect redacted output",
+    }
+    assert json.loads(protect_span.output) == {
+        "status": "NOT_TRIGGERED",
+        "text": "Protect text",
+        "trace_metadata": {
+            "id": str(trace_metadata_id),
+            "received_at": received_at,
+            "response_at": response_at,
+            "execution_time": execution_time,
+        },
+    }
+    assert json.loads(protect_span.redacted_output) == {
+        "status": "NOT_TRIGGERED",
+        "text": "Protect redacted text",
+        "trace_metadata": {
+            "id": str(trace_metadata_id),
+            "received_at": received_at,
+            "response_at": response_at,
+            "execution_time": execution_time,
+        },
+    }
+    assert protect_span.name == "GalileoProtect"
+    assert protect_span.created_at == created_at
+    assert protect_span.user_metadata == metadata
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -868,6 +978,25 @@ def test_trace_with_multiple_nested_spans(
         metadata=metadata,
     )
 
+    received_at = int(datetime.datetime(2025, 8, 6, 12, 41, 44).timestamp() * 1_000_000_000)
+    response_at = int(datetime.datetime(2025, 8, 6, 12, 41, 45).timestamp() * 1_000_000_000)
+    execution_time = 1000.0
+    trace_metadata_id = uuid.uuid4()
+
+    logger.add_protect_span(
+        payload=Payload(input="Protect input", output="Protect output"),
+        response=Response(
+            status=ExecutionStatus.not_triggered,
+            text="Protect text",
+            trace_metadata=TraceMetadata(
+                id=trace_metadata_id, received_at=received_at, response_at=response_at, execution_time=execution_time
+            ),
+        ),
+        created_at=created_at,
+        metadata=metadata,
+        status_code=200,
+    )
+
     logger.conclude(output="response2", status_code=200, duration_ns=1_000_000)
 
     logger.conclude(output="response2", status_code=200, duration_ns=1_000_000)
@@ -875,7 +1004,7 @@ def test_trace_with_multiple_nested_spans(
     assert len(logger._parent_stack) == 0
 
     captured_tasks = capture.get_all_tasks()
-    assert len(captured_tasks) == 9
+    assert len(captured_tasks) == 10
 
     captured_task = captured_tasks[0]
     assert captured_task.function_name == "ingest_traces_with_backoff"
@@ -1007,6 +1136,33 @@ def test_trace_with_multiple_nested_spans(
     assert request.spans[0].metrics.duration_ns == 1_000_000
 
     captured_task = captured_tasks[7]
+    assert captured_task.function_name == "ingest_spans_with_backoff"
+    request = captured_task.request
+    assert isinstance(request, SpansIngestRequest)
+
+    asyncio.run(captured_task.task_func())
+    mock_core_api_client_instance.ingest_spans.assert_called_with(request)
+
+    assert request.trace_id == trace_id
+    assert request.parent_id == workflow_span_id
+    protect_span = request.spans[0]
+    assert protect_span.type == "tool"
+    assert json.loads(protect_span.input) == {"input": "Protect input", "output": "Protect output"}
+    assert json.loads(protect_span.output) == {
+        "status": "NOT_TRIGGERED",
+        "text": "Protect text",
+        "trace_metadata": {
+            "id": str(trace_metadata_id),
+            "received_at": received_at,
+            "response_at": response_at,
+            "execution_time": execution_time,
+        },
+    }
+    assert protect_span.name == "GalileoProtect"
+    assert protect_span.created_at == created_at
+    assert protect_span.user_metadata == metadata
+
+    captured_task = captured_tasks[8]
     assert captured_task.function_name == "update_span_with_backoff"
     request = captured_task.request
     assert isinstance(request, SpanUpdateRequest)
@@ -1018,7 +1174,7 @@ def test_trace_with_multiple_nested_spans(
     assert request.output == "response2"
     assert request.status_code == 200
 
-    captured_task = captured_tasks[8]
+    captured_task = captured_tasks[9]
     assert captured_task.function_name == "update_trace_with_backoff"
     request = captured_task.request
     assert isinstance(request, TraceUpdateRequest)


### PR DESCRIPTION
Adding the ability to log a protect call using `add_protect_span` in the GalileoLogger. This is basically a port from 1.0 where a Tool span is created using the serialized payload and response.

https://app.shortcut.com/galileo/story/36673/add-protect-log-functionality-to-our-logger