### PR TITLE
fix: update get_prompt return type

### DIFF
--- a/src/galileo/prompts.py
+++ b/src/galileo/prompts.py
@@ -362,33 +362,31 @@ def list_prompt_templates(project: str) -> list[PromptTemplate]:
 
 
 @overload
-def get_prompt(*, id: str) -> Optional[PromptTemplateVersion]: ...
+def get_prompt(*, id: str) -> Optional[PromptTemplate]: ...
 
 
 @overload
-def get_prompt(*, name: str) -> Optional[PromptTemplateVersion]: ...
+def get_prompt(*, name: str) -> Optional[PromptTemplate]: ...
 
 
-def get_prompt(
-    *, id: Optional[str] = None, name: Optional[str] = None, version: Optional[int] = None
-) -> Optional[PromptTemplateVersion]:
+def get_prompt(*, id: Optional[str] = None, name: Optional[str] = None) -> Optional[PromptTemplate]:
     """
-    Retrieves a specific global prompt template version.
+    Retrieves a global prompt template.
 
     You must provide either 'id' or 'name', but not both.
-    If 'version' is not provided, the currently selected version is returned.
+
     Parameters
     ----------
     id : str, optional
         The unique identifier of the template to retrieve. Defaults to None.
     name : str, optional
         The name of the template to retrieve. Defaults to None.
-    version : int, optional
-        The version number to retrieve. If not provided, the currently selected version is returned. Defaults to None.
+
     Returns
     -------
-    Optional[PromptTemplateVersion]
-        The template version if found, None otherwise.
+    Optional[PromptTemplate]
+        The template if found, None otherwise.
+
     Raises
     ------
     ValueError
@@ -400,25 +398,12 @@ def get_prompt(
     if (id is not None) and (name is not None):
         raise ValueError("Exactly one of 'id' or 'name' must be provided")
 
-    if version is not None:
-        target_id = id
-        if name:
-            prompt_template = GlobalPromptTemplates().get(name=name)
-            if not prompt_template:
-                return None
-            target_id = prompt_template.id
-
-        if not target_id:
-            raise ValueError("A template id is required to fetch a specific version.")
-
-        return GlobalPromptTemplates().get_version(template_id=target_id, version=version)
-
     prompt_template = GlobalPromptTemplates().get(template_id=id) if id else GlobalPromptTemplates().get(name=name)  # type: ignore[arg-type]
 
-    if not prompt_template or isinstance(prompt_template.selected_version, Unset):
+    if not prompt_template:
         return None
 
-    return PromptTemplateVersion(prompt_template_version=prompt_template.selected_version)
+    return PromptTemplate(prompt_template=prompt_template)
 
 
 @overload

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -533,11 +533,14 @@ def test_create_global_prompt_template_error_scenarios(create_global_prompt_temp
 def test_get_global_prompt_template_by_id(get_global_template_mock: Mock):
     get_global_template_mock.sync.return_value = global_prompt_template()
 
-    version = get_prompt(id="global-template-id-123")
+    template = get_prompt(id="global-template-id-123")
 
-    assert version is not None
-    assert version.id == "global-version-id-456"
-    assert version.version == 1
+    assert template is not None
+    assert template.id == "global-template-id-123"
+    assert template.name == "global-helpful-assistant"
+    assert template.selected_version is not None
+    assert template.selected_version.id == "global-version-id-456"
+    assert template.selected_version.version == 1
     get_global_template_mock.sync.assert_called_once_with(template_id="global-template-id-123", client=ANY)
 
 
@@ -545,11 +548,14 @@ def test_get_global_prompt_template_by_id(get_global_template_mock: Mock):
 def test_get_global_prompt_template_by_name(query_templates_mock: Mock):
     query_templates_mock.sync.return_value = global_templates_list_response()
 
-    version = get_prompt(name="global-helpful-assistant")
+    template = get_prompt(name="global-helpful-assistant")
 
-    assert version is not None
-    assert version.id == "global-version-id-456"
-    assert version.version == 1
+    assert template is not None
+    assert template.id == "global-template-id-123"
+    assert template.name == "global-helpful-assistant"
+    assert template.selected_version is not None
+    assert template.selected_version.id == "global-version-id-456"
+    assert template.selected_version.version == 1
     query_templates_mock.sync.assert_called_once()
 
 
@@ -581,31 +587,6 @@ def test_get_global_prompt_template_validation_errors():
     with pytest.raises(ValueError) as exc_info:
         get_prompt(id="id", name="name")
     assert str(exc_info.value) == "Exactly one of 'id' or 'name' must be provided"
-
-
-@patch("galileo.prompts.get_global_template_version_templates_template_id_versions_version_get")
-def test_get_global_prompt_template_version(get_global_template_version_mock: Mock):
-    get_global_template_version_mock.sync.return_value = global_prompt_template_version()
-
-    version = get_prompt(id="global-template-id-123", version=0)
-
-    assert version is not None
-    assert version.id == "global-version-id-123"
-    assert version.version == 0
-    assert version.template == '[{"content":"you are a helpful assistant","role":"system"}]'
-    get_global_template_version_mock.sync.assert_called_once_with(
-        template_id="global-template-id-123", version=0, client=ANY
-    )
-
-
-@patch("galileo.prompts.get_global_template_version_templates_template_id_versions_version_get")
-def test_get_global_prompt_template_version_not_found(get_global_template_version_mock: Mock):
-    get_global_template_version_mock.sync.return_value = None
-
-    version = get_prompt(id="global-template-id-123", version=99)
-
-    assert version is None
-    get_global_template_version_mock.sync.assert_called_once()
 
 
 @patch("galileo.prompts.query_templates_templates_query_post")


### PR DESCRIPTION
Shortcut:
https://app.shortcut.com/galileo/story/37113/create-prompt-and-get-prompt-should-return-the-same-type

'create_prompt' and 'get_prompt' do not currently return the same type. Updated get_prompt to return PromptTemplate instead of PromptTemplateVersion