### PR TITLE
fix: Fixed streaming logging error display

### DIFF
--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -336,6 +336,9 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
                 self._task_handler.increment_retry(task_id),
                 self._logger.info(f"Retry #{self._task_handler.get_retry_count(task_id)} for task {task_id}"),
             ),
+            on_giveup=lambda details: self._logger.error(
+                f"Task {task_id} failed after {details['tries']} attempts: {details.get('exception')}", exc_info=False
+            ),
         )
         @handle_galileo_http_exceptions_for_retry
         async def ingest_traces_with_backoff(request):
@@ -376,6 +379,9 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
                 self._task_handler.increment_retry(task_id),
                 self._logger.info(f"Retry #{self._task_handler.get_retry_count(task_id)} for task {task_id}"),
             ),
+            on_giveup=lambda details: self._logger.error(
+                f"Task {task_id} failed after {details['tries']} attempts: {details.get('exception')}", exc_info=False
+            ),
         )
         @handle_galileo_http_exceptions_for_retry
         async def ingest_spans_with_backoff(request):
@@ -410,6 +416,10 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
                     self._task_handler.increment_retry(task_id),
                     self._logger.info(f"Retry #{self._task_handler.get_retry_count(task_id)} for task {task_id}"),
                 ),
+                on_giveup=lambda details: self._logger.error(
+                    f"Task {task_id} failed after {details['tries']} attempts: {details.get('exception')}",
+                    exc_info=False,
+                ),
             )
             @handle_galileo_http_exceptions_for_retry
             async def update_trace_with_backoff(request):
@@ -443,6 +453,9 @@ class GalileoLogger(TracesLogger, DecorateAllMethods):
             on_backoff=lambda details: (
                 self._task_handler.increment_retry(task_id),
                 self._logger.info(f"Retry #{self._task_handler.get_retry_count(task_id)} for task {task_id}"),
+            ),
+            on_giveup=lambda details: self._logger.error(
+                f"Task {task_id} failed after {details['tries']} attempts: {details.get('exception')}", exc_info=False
             ),
         )
         @handle_galileo_http_exceptions_for_retry


### PR DESCRIPTION
This is what the details object looks like:

```
{'target': <function GalileoLogger._ingest_span_streaming.<locals>.ingest_spans_with_backoff at 0x1123270a0>, 'args': (SpansIngestRequest(log_stream_id=UUID('123ff10b-ea54-4f30-bdbe-bb54880d99d9'), experiment_id=None, logging_method=<LoggingMethod.api_direct: 'api_direct'>, client_version=None, reliable=True, spans=[LlmSpan(type=<StepType.llm: 'llm'>, input=[Message(content='first llm span input', role=<MessageRole.user: 'user'>, tool_call_id=None, tool_calls=None)], redacted_input=None, output=Message(content='first llm span output', role=<MessageRole.assistant: 'assistant'>, tool_call_id=None, tool_calls=None), redacted_output=None, name='first llm span', created_at=datetime.datetime(2025, 8, 18, 16, 30, 8, 658797, tzinfo=datetime.timezone.utc), user_metadata={}, tags=[], status_code=None, metrics=LlmMetrics(duration_ns=30, num_input_tokens=None, num_output_tokens=None, num_total_tokens=None, time_to_first_token_ns=None), external_id=None, dataset_input=None, dataset_output=None, dataset_metadata={}, id=UUID('41317e1d-649f-4ea2-9442-fa89148dcd6f'), session_id=None, trace_id=None, step_number=None, parent_id=None, tools=None, model='gpt-4o-mini', temperature=None, finish_reason=None)], trace_id=UUID('a82367c9-94d5-474d-a1ec-49065dde9ea2'), parent_id=UUID('a82367c9-94d5-474d-a1ec-49065dde9ea2')),), 'kwargs': {}, 'tries': 1, 'elapsed': 4e-06, 'exception': GalileoHTTPException('Galileo API returned HTTP status code 404. Error was: {"detail":"no traces matched the provided ID"}', 404, '{"detail":"no traces matched the provided ID"}')}
```

I set max_retries = 1

Before my changes:
```
(.venv) pratyushaduvvuri@Mac py_files % python distributed_tracing_streaming_mode.py
👋 You have logged into 🔭 Galileo (https://console-galileo-v2-dev.gcp-dev.galileo.ai/) as pratyusha@galileo.ai.
```

^ even on failure

After my changes:
```
(.venv) pratyushaduvvuri@Mac py_files % python distributed_tracing_streaming_mode.py
👋 You have logged into 🔭 Galileo (https://console-galileo-v2-dev.gcp-dev.galileo.ai/) as pratyusha@galileo.ai.
Task span-ingest-79227dd9-8593-4098-9abc-4c62e52751e6 failed after 1 attempts: ('Galileo API returned HTTP status code 404. Error was: {"detail":"no traces matched the provided ID"}', 404, '{"detail":"no traces matched the provided ID"}')
```

