### PR TITLE
fix: Set a default console url

### DIFF
--- a/src/galileo/config.py
+++ b/src/galileo/config.py
@@ -2,12 +2,15 @@
 # We need to ignore syntax errors until https://github.com/python/mypy/issues/17535 is resolved.
 from typing import Any, Optional
 
+from pydantic_core import Url
+
 from galileo_core.schemas.base_config import GalileoConfig
 
 
 class GalileoPythonConfig(GalileoConfig):
     # Config file for this project.
     config_filename: str = "galileo-python-config.json"
+    console_url: Url = "https://app.galileo.ai"
 
     def reset(self) -> None:
         global _galileo_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+from galileo.config import GalileoPythonConfig
+
+
+@patch("galileo_core.schemas.base_config.GalileoConfig.set_validated_api_client", new=lambda x: x)
+@patch("galileo_core.schemas.base_config.GalileoConfig.get_jwt_token")
+def test_default_console_url(mock_get_jwt_token):
+    """
+    Test that the default console_url is used when GALILEO_CONSOLE_URL is not set.
+    """
+    mock_get_jwt_token.return_value = ("mock_jwt_token", "mock_refresh_token")
+
+    # Unset the environment variable to ensure we test the default
+    with patch.dict("os.environ", {}, clear=True):
+        # Reset the global config object to force re-initialization
+        GalileoPythonConfig.get().reset()
+        config = GalileoPythonConfig.get(api_key="mock_api_key")
+
+        assert str(config.console_url) == "https://app.galileo.ai/"
+        assert str(config.api_url) == "https://api.galileo.ai/"


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/39176/galileo-console-url-not-defaulting-to-plg [sc-39176]

**description:** GALILEO_CONSOLE_URL not defaulting to PLG cluster