### PR TITLE
fix: when input had a pydantic class it was breaking the validation

### DIFF
--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -660,9 +660,8 @@ class GalileoDecorator:
                     valid_params = sig.parameters.keys()
 
                     kwargs = {"output": output, **span_params}
-
-                    if span_type != "llm":
-                        kwargs["input"] = kwargs.get("input_serialized", "")
+                    kwargs["input"] = kwargs.get("input_serialized", "")
+                    # kwargs["output"] = json.dumps(kwargs["output"], cls=EventSerializer) when the output is an list/tuple it also breaks the add_llm_span
 
                     if span_type == "llm" and "model" not in kwargs:
                         # TODO: Allow a model to be parsed from the span_params


### PR DESCRIPTION
# Fix: Handle Pydantic model classes in EventSerializer to prevent serialization failures

## Problem
When logging LLM spans with inputs containing Pydantic model classes (not instances), the EventSerializer would fail to properly serialize them, causing logging failures. The existing serialization logic only handled Pydantic model instances (BaseModel objects) but not the classes themselves.

Also, when the span was from type LLM, we were using the raw input, which can also lead to issues.

## Solution

Added Pydantic class detection to EventSerializer.default(), and when it's a class, return the model schema.
Always use the serialized input instead of the raw one.

## Ticket
SC-39698