### PR TITLE
chore: Adding support for loading  projects from env vars in experiments

### DIFF
--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -1,6 +1,7 @@
 import builtins
 import datetime
 import logging
+import os
 from typing import Any, Callable, Optional, Union
 
 from attrs import define as _attrs_define
@@ -233,6 +234,7 @@ def run_experiment(
     prompt_template: Optional[PromptTemplate] = None,
     prompt_settings: Optional[PromptRunSettings] = None,
     project: Optional[str] = None,
+    project_id: Optional[str] = None,
     dataset: Optional[Union[Dataset, list[dict[str, str]], str]] = None,
     dataset_id: Optional[str] = None,
     dataset_name: Optional[str] = None,
@@ -252,7 +254,8 @@ def run_experiment(
         experiment_name: Name of the experiment
         prompt_template: Template for prompts
         prompt_settings: Settings for prompt runs
-        project: Project name
+        project: Project name. If neither project name nor project_id is provided, the GALILEO_PROJECT environment variable will be used
+        project_id: Project Id. If neither project name nor project_id is provided, the GALILEO_PROJECT environment variable will be used
         dataset: Dataset object, list of records, or dataset name
         dataset_id: ID of the dataset
         dataset_name: Name of the dataset
@@ -265,9 +268,26 @@ def run_experiment(
     Raises:
         ValueError: If required parameters are missing or invalid
     """
-    # Get project
-    if project is None:
-        raise ValueError("A project name must be provided")
+    # Get the project
+    # If the name or Id is set, then use these to get the project. Only one can be provided
+    # If neither are set, use the environment variables to get the project name or Id
+    project_name = project or os.getenv("GALILEO_PROJECT_NAME", os.getenv("GALILEO_PROJECT"))
+    project_id = project_id or os.getenv("GALILEO_PROJECT_ID")
+
+    # Check we only have one of project name or Id.
+    if project_name is None and project_id is None:
+        raise ValueError("A project name or Id must be provided")
+    if project_name is not None and project_id is not None:
+        raise ValueError("Only one of project name or Id should be provided")
+
+    # Get the project from the name or Id
+    project_obj = Projects().get(id=project_id) if project_id else Projects().get(name=project_name)
+
+    # Ensure we have a valid project
+    if not project_obj:
+        if project_id:
+            raise ValueError(f"Project with Id {project_id} does not exist")
+        raise ValueError(f"Project {project_name} does not exist")
 
     # Load dataset and records
     dataset_obj, records = load_dataset_and_records(dataset, dataset_id, dataset_name)
@@ -283,11 +303,6 @@ def run_experiment(
 
     if function and prompt_template:
         raise ValueError("A function or prompt_template should be provided, but not both")
-
-    # Get project
-    project_obj = Projects().get(name=project)
-    if not project_obj:
-        raise ValueError(f"Project {project} does not exist")
 
     # Create or get experiment
     existing_experiment = Experiments().get(project_obj.id, experiment_name)

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -268,6 +268,21 @@ def run_experiment(
     Raises:
         ValueError: If required parameters are missing or invalid
     """
+    # Load dataset and records
+    dataset_obj, records = load_dataset_and_records(dataset, dataset_id, dataset_name)
+
+    # Validate experiment configuration
+    if prompt_template and not dataset_obj:
+        raise ValueError("A dataset record, id, or name of a dataset must be provided when a prompt_template is used")
+
+    if function and not records:
+        raise ValueError(
+            "A dataset record, id or name of a dataset, or list of records must be provided when a function is used"
+        )
+
+    if function and prompt_template:
+        raise ValueError("A function or prompt_template should be provided, but not both")
+
     # Get the project
     # If the name or Id is set, then use these to get the project. Only one can be provided
     # If neither are set, use the environment variables to get the project name or Id
@@ -288,21 +303,6 @@ def run_experiment(
         if project_id:
             raise ValueError(f"Project with Id {project_id} does not exist")
         raise ValueError(f"Project {project_name} does not exist")
-
-    # Load dataset and records
-    dataset_obj, records = load_dataset_and_records(dataset, dataset_id, dataset_name)
-
-    # Validate experiment configuration
-    if prompt_template and not dataset_obj:
-        raise ValueError("A dataset record, id, or name of a dataset must be provided when a prompt_template is used")
-
-    if function and not records:
-        raise ValueError(
-            "A dataset record, id or name of a dataset, or list of records must be provided when a function is used"
-        )
-
-    if function and prompt_template:
-        raise ValueError("A function or prompt_template should be provided, but not both")
 
     # Create or get experiment
     existing_experiment = Experiments().get(project_obj.id, experiment_name)

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -227,47 +227,6 @@ def process_row(row: DatasetRecord, process_func: Callable) -> str:
         _logger.error(output)
     return output
 
-
-def _get_project(project_name: Optional[str] = None, project_id: Optional[str] = None) -> Project:
-    """
-    Gets a project by name or Id, using environment variables if neither are provided.
-
-    Logic flow:
-    1. If project_name or project_id parameters are provided, use these to load the project.
-    2. If neither are provided, use the GALILEO_PROJECT or GALILEO_PROJECT_ID environment variables.
-    3. If both project_name and project_id are provided, raise an error.
-    4. If the project name and Id are not passed, and both GALILEO_PROJECT and GALILEO_PROJECT_ID are provided, raise an error.
-    5. Use the provided or environment variable value to load the project. If the project does not exist, raise an error.
-
-    Args:
-        project_name: Name of the project
-        project_id: Id of the project
-    """
-    # Get the project name or Id from parameters or environment variables, stripping whitespace and converting empty strings to None
-    project_name = (project_name or os.getenv("GALILEO_PROJECT") or "").strip() or None
-    project_id = (project_id or os.getenv("GALILEO_PROJECT_ID") or "").strip() or None
-
-    # Check we have one and only one of project name or Id.
-    if not project_name and not project_id:
-        raise ValueError("A project name or Id must be provided")
-    if project_name and project_id:
-        raise ValueError("Only one of project name or Id should be provided")
-
-    # Get the project from the name or Id
-    project = (
-        Projects().get(id=project_id) if project_id else (Projects().get(name=project_name) if project_name else None)
-    )
-
-    # Ensure we have a valid project
-    if not project:
-        if project_id:
-            raise ValueError(f"Project with Id {project_id} does not exist")
-        raise ValueError(f"Project {project_name} does not exist")
-
-    # Return the project
-    return project
-
-
 def run_experiment(
     experiment_name: str,
     *,
@@ -328,7 +287,13 @@ def run_experiment(
         raise ValueError("A function or prompt_template should be provided, but not both")
 
     # Get the project from the name or Id
-    project_obj = _get_project(project, project_id)
+    project_obj = Projects().get(id=project_id, name=project)
+
+    # Ensure we have a valid project
+    if not project_obj:
+        if project_id:
+            raise ValueError(f"Project with Id {project_id} does not exist")
+        raise ValueError(f"Project {project} does not exist")
 
     # Create or get experiment
     existing_experiment = Experiments().get(project_obj.id, experiment_name)

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -1,7 +1,6 @@
 import builtins
 import datetime
 import logging
-import os
 from typing import Any, Callable, Optional, Union
 
 from attrs import define as _attrs_define
@@ -226,6 +225,7 @@ def process_row(row: DatasetRecord, process_func: Callable) -> str:
         output = f"error during executing: {process_func.__name__}: {exc}"
         _logger.error(output)
     return output
+
 
 def run_experiment(
     experiment_name: str,

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -286,8 +286,13 @@ def run_experiment(
     # Get the project
     # If the name or Id is set, then use these to get the project. Only one can be provided
     # If neither are set, use the environment variables to get the project name or Id
-    project_name = project or os.getenv("GALILEO_PROJECT_NAME", os.getenv("GALILEO_PROJECT"))
+    project_name = project or os.getenv("GALILEO_PROJECT")
     project_id = project_id or os.getenv("GALILEO_PROJECT_ID")
+
+    if project_name == "":
+        project_name = None
+    if project_id == "":
+        project_id = None
 
     # Check we only have one of project name or Id.
     if project_name is None and project_id is None:

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -301,7 +301,9 @@ def run_experiment(
         raise ValueError("Only one of project name or Id should be provided")
 
     # Get the project from the name or Id
-    project_obj = Projects().get(id=project_id) if project_id else Projects().get(name=project_name)
+    project_obj = (
+        Projects().get(id=project_id) if project_id else (Projects().get(name=project_name) if project_name else None)
+    )
 
     # Ensure we have a valid project
     if not project_obj:

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -300,9 +300,7 @@ def run_experiment(
         raise ValueError("Only one of project name or Id should be provided")
 
     # Get the project from the name or Id
-    project_obj = (
-        Projects().get(id=project_id) if project_id else (Projects().get(name=project) if project else None)
-    )
+    project_obj = Projects().get(id=project_id) if project_id else (Projects().get(name=project) if project else None)
 
     # Ensure we have a valid project
     if not project_obj:

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -249,16 +249,14 @@ def run_experiment(
 
     When using a runner function, you can also pass a list of dictionaries to the function to act as a dataset.
 
-    To define the project to use, either set the project or project_id parameters, or set the GALILEO_PROJECT or GALILEO_PROJECT_ID.
-    If you pass the project in the parameters, then only one of project or project_id should be provided. Setting both with give an error.
-    If you don't set either the project or project_id parameters, then only one of GALILEO_PROJECT or GALILEO_PROJECT_ID should be set in the environment variables. Setting both with give an error.
+    The project can be specified by providing exactly one of the project name (via the 'project' parameter or the GALILEO_PROJECT environment variable) or the project ID (via the 'project_id' parameter or the GALILEO_PROJECT_ID environment variable).
 
     Args:
         experiment_name: Name of the experiment
         prompt_template: Template for prompts
         prompt_settings: Settings for prompt runs
-        project: Project name. Pass either only one of project or project_id, or pass nothing and the GALILEO_PROJECT or GALILEO_PROJECT_ID environment variables will be used.
-        project_id: Project Id. Pass either only one of project or project_id, or pass nothing and the GALILEO_PROJECT or GALILEO_PROJECT_ID environment variables will be used.
+        project: Optional project name. Takes preference over the GALILEO_PROJECT environment variable. Leave empty if using project_id
+        project_id: Optional project Id. Takes preference over the GALILEO_PROJECT_ID environment variable. Leave empty if using project
         dataset: Dataset object, list of records, or dataset name
         dataset_id: ID of the dataset
         dataset_name: Name of the dataset

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -285,7 +285,7 @@ def run_experiment(
         raise ValueError("A function or prompt_template should be provided, but not both")
 
     # Get the project from the name or Id
-    project_obj = Projects().get(id=project_id, name=project)
+    project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project)
 
     # Ensure we have a valid project
     if not project_obj:

--- a/src/galileo/projects.py
+++ b/src/galileo/projects.py
@@ -151,7 +151,7 @@ class Projects(BaseClientModel, DecorateAllMethods):
 
         # Check we have one and only one of project name or Id.
         if (not name and not id) or (name and id):
-            raise ValueError("Exactly one of 'id' or 'name' must be provided")
+            raise ValueError("Exactly one of 'id' or 'name' must be provided, or set in the environment variables GALILEO_PROJECT_ID or GALILEO_PROJECT")
 
         project: Optional[Project] = None
 

--- a/src/galileo/projects.py
+++ b/src/galileo/projects.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import os
-from typing import Optional, Union, overload
+from typing import Optional, Union
 
 import httpx
 

--- a/src/galileo/stages.py
+++ b/src/galileo/stages.py
@@ -34,7 +34,7 @@ def _get_project_id(
     if project_id is not None and type(project_id).__name__ == "UUID":
         project_id = str(project_id)
 
-    project = Projects(config=config).get_with_env_fallbacks(name=project_name, id=project_id)  # type: ignore
+    project = Projects(config=config).get_with_env_fallbacks(name=project_name, id=project_id)
     if not project:
         raise ValueError(f"Project with name '{project_name}' not found.")
     return str(project.id)

--- a/src/galileo/stages.py
+++ b/src/galileo/stages.py
@@ -72,7 +72,9 @@ class Stages(BaseClientModel, DecorateAllMethods):
         prioritized_rulesets: Optional[Sequence[Ruleset]] = None,
         description: Optional[str] = None,
     ) -> StageDB:
-        actual_project_id: str = _get_validated_project_id(project_id=project_id, project_name=project_name, config=self.config)
+        actual_project_id: str = _get_validated_project_id(
+            project_id=project_id, project_name=project_name, config=self.config
+        )
 
         actual_name = name or ts_name("stage")
 
@@ -104,7 +106,9 @@ class Stages(BaseClientModel, DecorateAllMethods):
         stage_id: Optional[Union[str, UUID4]] = None,
         stage_name: Optional[str] = None,
     ) -> StageDB:
-        actual_project_id: str = _get_validated_project_id(project_id=project_id, project_name=project_name, config=self.config)
+        actual_project_id: str = _get_validated_project_id(
+            project_id=project_id, project_name=project_name, config=self.config
+        )
 
         if not stage_id and not stage_name:
             raise ValueError("Either stage_id or stage_name must be provided.")
@@ -127,7 +131,9 @@ class Stages(BaseClientModel, DecorateAllMethods):
         stage_name: Optional[str] = None,
         prioritized_rulesets: Optional[Sequence[Ruleset]] = None,
     ) -> StageDB:
-        actual_project_id: str = _get_validated_project_id(project_id=project_id, project_name=project_name, config=self.config)
+        actual_project_id: str = _get_validated_project_id(
+            project_id=project_id, project_name=project_name, config=self.config
+        )
 
         actual_stage_id: str = _get_stage_id(
             stage_id=stage_id, stage_name=stage_name, project_id=actual_project_id, config=self.config
@@ -154,7 +160,9 @@ class Stages(BaseClientModel, DecorateAllMethods):
         stage_name: Optional[str] = None,
     ) -> StageDB:
         """Sets the pause state of a stage."""
-        actual_project_id: str = _get_validated_project_id(project_id=project_id, project_name=project_name, config=self.config)
+        actual_project_id: str = _get_validated_project_id(
+            project_id=project_id, project_name=project_name, config=self.config
+        )
 
         actual_stage_id: str = _get_stage_id(
             stage_id=stage_id, stage_name=stage_name, project_id=actual_project_id, config=self.config

--- a/src/galileo/stages.py
+++ b/src/galileo/stages.py
@@ -22,7 +22,7 @@ from galileo_core.schemas.protect.stage import StageDB, StageType, StageWithRule
 from galileo_core.utils.name import ts_name
 
 
-def _get_project_id(
+def _get_validated_project_id(
     project_id: Optional[Union[str, UUID4]] = None,
     project_name: Optional[str] = None,
     config: Optional[GalileoPythonConfig] = None,
@@ -72,7 +72,7 @@ class Stages(BaseClientModel, DecorateAllMethods):
         prioritized_rulesets: Optional[Sequence[Ruleset]] = None,
         description: Optional[str] = None,
     ) -> StageDB:
-        actual_project_id: str = _get_project_id(project_id=project_id, project_name=project_name, config=self.config)
+        actual_project_id: str = _get_validated_project_id(project_id=project_id, project_name=project_name, config=self.config)
 
         actual_name = name or ts_name("stage")
 
@@ -104,7 +104,7 @@ class Stages(BaseClientModel, DecorateAllMethods):
         stage_id: Optional[Union[str, UUID4]] = None,
         stage_name: Optional[str] = None,
     ) -> StageDB:
-        actual_project_id: str = _get_project_id(project_id=project_id, project_name=project_name, config=self.config)
+        actual_project_id: str = _get_validated_project_id(project_id=project_id, project_name=project_name, config=self.config)
 
         if not stage_id and not stage_name:
             raise ValueError("Either stage_id or stage_name must be provided.")
@@ -127,7 +127,7 @@ class Stages(BaseClientModel, DecorateAllMethods):
         stage_name: Optional[str] = None,
         prioritized_rulesets: Optional[Sequence[Ruleset]] = None,
     ) -> StageDB:
-        actual_project_id: str = _get_project_id(project_id=project_id, project_name=project_name, config=self.config)
+        actual_project_id: str = _get_validated_project_id(project_id=project_id, project_name=project_name, config=self.config)
 
         actual_stage_id: str = _get_stage_id(
             stage_id=stage_id, stage_name=stage_name, project_id=actual_project_id, config=self.config
@@ -154,7 +154,7 @@ class Stages(BaseClientModel, DecorateAllMethods):
         stage_name: Optional[str] = None,
     ) -> StageDB:
         """Sets the pause state of a stage."""
-        actual_project_id: str = _get_project_id(project_id=project_id, project_name=project_name, config=self.config)
+        actual_project_id: str = _get_validated_project_id(project_id=project_id, project_name=project_name, config=self.config)
 
         actual_stage_id: str = _get_stage_id(
             stage_id=stage_id, stage_name=stage_name, project_id=actual_project_id, config=self.config

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -449,6 +449,33 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_empty_project_id_and_name_gives_error(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with pytest.raises(ValueError) as exc_info:
+            with patch.dict("os.environ", {"GALILEO_PROJECT": " "}):
+                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": " "}):
+                    run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
+
+        assert str(exc_info.value) == "A project name or Id must be provided"
+
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
     @patch.object(galileo.experiments.Projects, "get", return_value=None)
     def test_run_experiment_with_invalid_project_id_gives_error(
         self,

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -244,6 +244,223 @@ class TestExperiments:
             load_dataset_and_records(dataset=None, dataset_name=None, dataset_id=None)
         assert str(exc_info.value) == "To load dataset records, dataset, dataset_name, or dataset_id must be provided"
 
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_project_name_loads_project(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                run_experiment(
+                    "test_experiment", 
+                    project="awesome-new-project",
+                    dataset_id=dataset_id,
+                    prompt_template=prompt_template()
+                )
+
+        mock_get_project.assert_called_once_with(name="awesome-new-project")
+
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_project_id_loads_project(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                run_experiment(
+                    "test_experiment", 
+                    project_id="awesome-new-project",
+                    dataset_id=dataset_id,
+                    prompt_template=prompt_template()
+                )
+
+        mock_get_project.assert_called_once_with(id="awesome-new-project")
+
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_project_name_from_env_var_loads_project(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with patch.dict("os.environ", {"GALILEO_PROJECT": "awesome-new-project"}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                run_experiment(
+                    "test_experiment",
+                    dataset_id=dataset_id,
+                    prompt_template=prompt_template()
+                )
+
+        mock_get_project.assert_called_once_with(name="awesome-new-project")
+
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_project_id_from_env_var_loads_project(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "awesome-new-project"}):
+                run_experiment(
+                    "test_experiment",
+                    dataset_id=dataset_id,
+                    prompt_template=prompt_template()
+                )
+
+        mock_get_project.assert_called_once_with(id="awesome-new-project")
+
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_project_id_and_name_gives_error(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with pytest.raises(ValueError) as exc_info:
+            with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                    run_experiment(
+                        "test_experiment", 
+                        project_id="awesome-new-project",
+                        project="awesome-new-project",
+                        dataset_id=dataset_id,
+                        prompt_template=prompt_template()
+                    )
+
+        assert str(exc_info.value) == "Only one of project name or Id should be provided"
+
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_project_id_and_name_from_env_var_gives_error(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with pytest.raises(ValueError) as exc_info:
+            with patch.dict("os.environ", {"GALILEO_PROJECT": "awesome-new-project"}):
+                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "awesome-new-project"}):
+                    run_experiment(
+                        "test_experiment",
+                        dataset_id=dataset_id,
+                        prompt_template=prompt_template()
+                    )
+
+        assert str(exc_info.value) == "Only one of project name or Id should be provided"
+
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_no_project_id_or_name_gives_error(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with pytest.raises(ValueError) as exc_info:
+            with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                    run_experiment(
+                        "test_experiment",
+                        dataset_id=dataset_id,
+                        prompt_template=prompt_template()
+                    )
+
+        assert str(exc_info.value) == "A project name or Id must be provided"
+
     @travel(datetime(2012, 1, 1), tick=False)
     @patch.object(galileo.datasets.Datasets, "get")
     @patch.object(galileo.jobs.Jobs, "create")

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -602,9 +602,14 @@ class TestExperiments:
         assert payload.traces[0].output == "Say hello: Which continent is Spain in?"
 
     @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
     def test_run_experiment_with_prompt_template_and_function(
-        self, mock_get_dataset: Mock, dataset_content: DatasetContent
+        self, mock_get_dataset: Mock,
+        mock_projects_client: Mock,
+        dataset_content: DatasetContent
     ):
+        setup_mock_projects_client(mock_projects_client)
+
         # mock dataset.get_content
         mock_get_dataset_instance = mock_get_dataset.return_value
         mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
@@ -622,7 +627,14 @@ class TestExperiments:
         mock_get_dataset.assert_called_once_with(id="00000000-0000-0000-0000-000000000001", name=None)
         mock_get_dataset_instance.get_content.assert_called()
 
-    def test_run_experiment_with_prompt_template_and_local_dataset(self, local_dataset: list[dict[str, str]]):
+    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    def test_run_experiment_with_prompt_template_and_local_dataset(
+        self,
+        mock_projects_client: Mock,
+        local_dataset: list[dict[str, str]],
+    ):
+        setup_mock_projects_client(mock_projects_client)
+
         with pytest.raises(ValueError) as exc_info:
             run_experiment(
                 "test_experiment",

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -265,10 +265,7 @@ class TestExperiments:
 
         dataset_id = str(UUID(int=0))
         run_experiment(
-            "test_experiment",
-            project="awesome-new-project",
-            dataset_id=dataset_id,
-            prompt_template=prompt_template(),
+            "test_experiment", project="awesome-new-project", dataset_id=dataset_id, prompt_template=prompt_template()
         )
 
         mock_get_project.assert_called_once_with(id=None, name="awesome-new-project")

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -602,14 +602,11 @@ class TestExperiments:
         assert payload.traces[0].output == "Say hello: Which continent is Spain in?"
 
     @patch.object(galileo.datasets.Datasets, "get")
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
     def test_run_experiment_with_prompt_template_and_function(
-        self, mock_get_dataset: Mock,
-        mock_projects_client: Mock,
+        self,
+        mock_get_dataset: Mock,
         dataset_content: DatasetContent
     ):
-        setup_mock_projects_client(mock_projects_client)
-
         # mock dataset.get_content
         mock_get_dataset_instance = mock_get_dataset.return_value
         mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -264,14 +264,12 @@ class TestExperiments:
         mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
 
         dataset_id = str(UUID(int=0))
-        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                run_experiment(
-                    "test_experiment",
-                    project="awesome-new-project",
-                    dataset_id=dataset_id,
-                    prompt_template=prompt_template(),
-                )
+        run_experiment(
+            "test_experiment",
+            project="awesome-new-project",
+            dataset_id=dataset_id,
+            prompt_template=prompt_template(),
+        )
 
         mock_get_project.assert_called_once_with(id=None, name="awesome-new-project")
 
@@ -295,14 +293,12 @@ class TestExperiments:
         mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
 
         dataset_id = str(UUID(int=0))
-        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                run_experiment(
-                    "test_experiment",
-                    project_id="awesome-new-project",
-                    dataset_id=dataset_id,
-                    prompt_template=prompt_template(),
-                )
+        run_experiment(
+            "test_experiment",
+            project_id="awesome-new-project",
+            dataset_id=dataset_id,
+            prompt_template=prompt_template(),
+        )
 
         mock_get_project.assert_called_once_with(id="awesome-new-project", name=None)
 
@@ -327,14 +323,12 @@ class TestExperiments:
 
         dataset_id = str(UUID(int=0))
         with pytest.raises(ValueError) as exc_info:
-            with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                    run_experiment(
-                        "test_experiment",
-                        project_id="awesome-new-project",
-                        dataset_id=dataset_id,
-                        prompt_template=prompt_template(),
-                    )
+            run_experiment(
+                "test_experiment",
+                project_id="awesome-new-project",
+                dataset_id=dataset_id,
+                prompt_template=prompt_template(),
+            )
 
         assert str(exc_info.value) == "Project with Id awesome-new-project does not exist"
 
@@ -359,14 +353,12 @@ class TestExperiments:
 
         dataset_id = str(UUID(int=0))
         with pytest.raises(ValueError) as exc_info:
-            with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                    run_experiment(
-                        "test_experiment",
-                        project="awesome-new-project",
-                        dataset_id=dataset_id,
-                        prompt_template=prompt_template(),
-                    )
+            run_experiment(
+                "test_experiment",
+                project="awesome-new-project",
+                dataset_id=dataset_id,
+                prompt_template=prompt_template(),
+            )
 
         assert str(exc_info.value) == "Project awesome-new-project does not exist"
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,4 +1,5 @@
 import operator
+import os
 from datetime import datetime
 from functools import reduce
 from statistics import mean
@@ -39,8 +40,10 @@ from tests.testutils.setup import setup_mock_core_api_client, setup_mock_logstre
 
 
 @pytest.fixture
-def reset_context():
+def reset_context(auto_use=True):
     galileo_context.reset()
+    os.environ.pop("GALILEO_PROJECT", None)
+    os.environ.pop("GALILEO_PROJECT_ID", None)
 
 
 def project():
@@ -248,7 +251,7 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     def test_run_experiment_with_project_name_loads_project(
         self,
         mock_get_project: Mock,
@@ -274,7 +277,7 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     def test_run_experiment_with_project_id_loads_project(
         self,
         mock_get_project: Mock,
@@ -303,7 +306,7 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=None)
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=None)
     def test_run_experiment_with_invalid_project_id_gives_error(
         self,
         mock_get_project: Mock,
@@ -333,7 +336,7 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=None)
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=None)
     def test_run_experiment_with_invalid_project_name_gives_error(
         self,
         mock_get_project: Mock,
@@ -364,7 +367,7 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     def test_run_experiment_without_metrics(
         self,
         mock_get_project: Mock,
@@ -411,7 +414,7 @@ class TestExperiments:
     @patch.object(galileo.datasets.Datasets, "get")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     @patch.object(galileo.experiments.Scorers, "list", return_value=scorers())
     @patch.object(galileo.experiments.Scorers, "get_scorer_version", return_value=mock_scorer_version_response())
     @patch.object(galileo.experiments.ScorerSettings, "create")
@@ -567,7 +570,7 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     def test_run_experiment_w_prompt_template_and_metrics(
         self,
         mock_get_project: Mock,
@@ -613,7 +616,7 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     def test_run_experiment_w_prompt_template_and_prompt_settings(
         self,
         mock_get_project: Mock,
@@ -665,7 +668,7 @@ class TestExperiments:
     @patch.object(galileo.jobs.Jobs, "create")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     def test_run_experiment_with_runner_and_dataset(
         self,
         mock_get_project: Mock,
@@ -737,7 +740,7 @@ class TestExperiments:
         mock_get_dataset.assert_called_once_with(id="00000000-0000-0000-0000-000000000001", name=None)
         mock_get_dataset_instance.get_content.assert_called()
 
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     def test_run_experiment_with_prompt_template_and_local_dataset(
         self, mock_projects_client: Mock, local_dataset: list[dict[str, str]]
     ):
@@ -759,7 +762,7 @@ class TestExperiments:
     @patch.object(galileo.datasets.Datasets, "get")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     @patch.object(galileo.experiments.Scorers, "list", return_value=scorers())
     @patch.object(galileo.experiments.Scorers, "get_scorer_version", return_value=mock_scorer_version_response())
     @patch.object(galileo.experiments.ScorerSettings, "create", return_value=None)
@@ -875,7 +878,7 @@ class TestExperiments:
     @patch.object(galileo.datasets.Datasets, "get")
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     @patch.object(galileo.experiments.Experiments, "get", return_value=None)
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
     def test_run_experiment_job_creation_failure(
         self,
         mock_get_project: Mock,

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -445,6 +445,70 @@ class TestExperiments:
 
         assert str(exc_info.value) == "A project name or Id must be provided"
 
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=None)
+    def test_run_experiment_with_invalid_project_id_gives_error(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with pytest.raises(ValueError) as exc_info:
+            with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                    run_experiment(
+                        "test_experiment",
+                        project_id="awesome-new-project",
+                        dataset_id=dataset_id,
+                        prompt_template=prompt_template(),
+                    )
+
+        assert str(exc_info.value) == "Project with Id awesome-new-project does not exist"
+
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.jobs.Jobs, "create")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get", return_value=None)
+    def test_run_experiment_with_invalid_project_name_gives_error(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_job: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ):
+        mock_create_job.return_value = MagicMock()
+
+        # mock dataset.get_content
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
+
+        dataset_id = str(UUID(int=0))
+        with pytest.raises(ValueError) as exc_info:
+            with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                    run_experiment(
+                        "test_experiment",
+                        project="awesome-new-project",
+                        dataset_id=dataset_id,
+                        prompt_template=prompt_template(),
+                    )
+
+        assert str(exc_info.value) == "Project awesome-new-project does not exist"
+
     @travel(datetime(2012, 1, 1), tick=False)
     @patch.object(galileo.datasets.Datasets, "get")
     @patch.object(galileo.jobs.Jobs, "create")

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -267,10 +267,10 @@ class TestExperiments:
         with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
             with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
                 run_experiment(
-                    "test_experiment", 
+                    "test_experiment",
                     project="awesome-new-project",
                     dataset_id=dataset_id,
-                    prompt_template=prompt_template()
+                    prompt_template=prompt_template(),
                 )
 
         mock_get_project.assert_called_once_with(name="awesome-new-project")
@@ -298,10 +298,10 @@ class TestExperiments:
         with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
             with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
                 run_experiment(
-                    "test_experiment", 
+                    "test_experiment",
                     project_id="awesome-new-project",
                     dataset_id=dataset_id,
-                    prompt_template=prompt_template()
+                    prompt_template=prompt_template(),
                 )
 
         mock_get_project.assert_called_once_with(id="awesome-new-project")
@@ -328,11 +328,7 @@ class TestExperiments:
         dataset_id = str(UUID(int=0))
         with patch.dict("os.environ", {"GALILEO_PROJECT": "awesome-new-project"}):
             with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                run_experiment(
-                    "test_experiment",
-                    dataset_id=dataset_id,
-                    prompt_template=prompt_template()
-                )
+                run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
 
         mock_get_project.assert_called_once_with(name="awesome-new-project")
 
@@ -358,11 +354,7 @@ class TestExperiments:
         dataset_id = str(UUID(int=0))
         with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
             with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "awesome-new-project"}):
-                run_experiment(
-                    "test_experiment",
-                    dataset_id=dataset_id,
-                    prompt_template=prompt_template()
-                )
+                run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
 
         mock_get_project.assert_called_once_with(id="awesome-new-project")
 
@@ -390,11 +382,11 @@ class TestExperiments:
             with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
                 with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
                     run_experiment(
-                        "test_experiment", 
+                        "test_experiment",
                         project_id="awesome-new-project",
                         project="awesome-new-project",
                         dataset_id=dataset_id,
-                        prompt_template=prompt_template()
+                        prompt_template=prompt_template(),
                     )
 
         assert str(exc_info.value) == "Only one of project name or Id should be provided"
@@ -422,11 +414,7 @@ class TestExperiments:
         with pytest.raises(ValueError) as exc_info:
             with patch.dict("os.environ", {"GALILEO_PROJECT": "awesome-new-project"}):
                 with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "awesome-new-project"}):
-                    run_experiment(
-                        "test_experiment",
-                        dataset_id=dataset_id,
-                        prompt_template=prompt_template()
-                    )
+                    run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
 
         assert str(exc_info.value) == "Only one of project name or Id should be provided"
 
@@ -453,11 +441,7 @@ class TestExperiments:
         with pytest.raises(ValueError) as exc_info:
             with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
                 with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                    run_experiment(
-                        "test_experiment",
-                        dataset_id=dataset_id,
-                        prompt_template=prompt_template()
-                    )
+                    run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
 
         assert str(exc_info.value) == "A project name or Id must be provided"
 
@@ -820,9 +804,7 @@ class TestExperiments:
 
     @patch.object(galileo.datasets.Datasets, "get")
     def test_run_experiment_with_prompt_template_and_function(
-        self,
-        mock_get_dataset: Mock,
-        dataset_content: DatasetContent
+        self, mock_get_dataset: Mock, dataset_content: DatasetContent
     ):
         # mock dataset.get_content
         mock_get_dataset_instance = mock_get_dataset.return_value
@@ -843,9 +825,7 @@ class TestExperiments:
 
     @patch.object(galileo.experiments.Projects, "get", return_value=project())
     def test_run_experiment_with_prompt_template_and_local_dataset(
-        self,
-        mock_projects_client: Mock,
-        local_dataset: list[dict[str, str]],
+        self, mock_projects_client: Mock, local_dataset: list[dict[str, str]]
     ):
         setup_mock_projects_client(mock_projects_client)
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -273,7 +273,7 @@ class TestExperiments:
                     prompt_template=prompt_template(),
                 )
 
-        mock_get_project.assert_called_once_with(name="awesome-new-project")
+        mock_get_project.assert_called_once_with(id=None, name="awesome-new-project")
 
     @patch.object(galileo.datasets.Datasets, "get")
     @patch.object(galileo.jobs.Jobs, "create")
@@ -304,173 +304,7 @@ class TestExperiments:
                     prompt_template=prompt_template(),
                 )
 
-        mock_get_project.assert_called_once_with(id="awesome-new-project")
-
-    @patch.object(galileo.datasets.Datasets, "get")
-    @patch.object(galileo.jobs.Jobs, "create")
-    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
-    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
-    def test_run_experiment_with_project_name_from_env_var_loads_project(
-        self,
-        mock_get_project: Mock,
-        mock_get_experiment: Mock,
-        mock_create_job: Mock,
-        mock_get_dataset: Mock,
-        dataset_content: DatasetContent,
-    ):
-        mock_create_job.return_value = MagicMock()
-
-        # mock dataset.get_content
-        mock_get_dataset_instance = mock_get_dataset.return_value
-        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
-
-        dataset_id = str(UUID(int=0))
-        with patch.dict("os.environ", {"GALILEO_PROJECT": "awesome-new-project"}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
-
-        mock_get_project.assert_called_once_with(name="awesome-new-project")
-
-    @patch.object(galileo.datasets.Datasets, "get")
-    @patch.object(galileo.jobs.Jobs, "create")
-    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
-    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
-    def test_run_experiment_with_project_id_from_env_var_loads_project(
-        self,
-        mock_get_project: Mock,
-        mock_get_experiment: Mock,
-        mock_create_job: Mock,
-        mock_get_dataset: Mock,
-        dataset_content: DatasetContent,
-    ):
-        mock_create_job.return_value = MagicMock()
-
-        # mock dataset.get_content
-        mock_get_dataset_instance = mock_get_dataset.return_value
-        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
-
-        dataset_id = str(UUID(int=0))
-        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "awesome-new-project"}):
-                run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
-
-        mock_get_project.assert_called_once_with(id="awesome-new-project")
-
-    @patch.object(galileo.datasets.Datasets, "get")
-    @patch.object(galileo.jobs.Jobs, "create")
-    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
-    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
-    def test_run_experiment_with_project_id_and_name_gives_error(
-        self,
-        mock_get_project: Mock,
-        mock_get_experiment: Mock,
-        mock_create_job: Mock,
-        mock_get_dataset: Mock,
-        dataset_content: DatasetContent,
-    ):
-        mock_create_job.return_value = MagicMock()
-
-        # mock dataset.get_content
-        mock_get_dataset_instance = mock_get_dataset.return_value
-        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
-
-        dataset_id = str(UUID(int=0))
-        with pytest.raises(ValueError) as exc_info:
-            with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                    run_experiment(
-                        "test_experiment",
-                        project_id="awesome-new-project",
-                        project="awesome-new-project",
-                        dataset_id=dataset_id,
-                        prompt_template=prompt_template(),
-                    )
-
-        assert str(exc_info.value) == "Only one of project name or Id should be provided"
-
-    @patch.object(galileo.datasets.Datasets, "get")
-    @patch.object(galileo.jobs.Jobs, "create")
-    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
-    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
-    def test_run_experiment_with_project_id_and_name_from_env_var_gives_error(
-        self,
-        mock_get_project: Mock,
-        mock_get_experiment: Mock,
-        mock_create_job: Mock,
-        mock_get_dataset: Mock,
-        dataset_content: DatasetContent,
-    ):
-        mock_create_job.return_value = MagicMock()
-
-        # mock dataset.get_content
-        mock_get_dataset_instance = mock_get_dataset.return_value
-        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
-
-        dataset_id = str(UUID(int=0))
-        with pytest.raises(ValueError) as exc_info:
-            with patch.dict("os.environ", {"GALILEO_PROJECT": "awesome-new-project"}):
-                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "awesome-new-project"}):
-                    run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
-
-        assert str(exc_info.value) == "Only one of project name or Id should be provided"
-
-    @patch.object(galileo.datasets.Datasets, "get")
-    @patch.object(galileo.jobs.Jobs, "create")
-    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
-    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
-    def test_run_experiment_with_no_project_id_or_name_gives_error(
-        self,
-        mock_get_project: Mock,
-        mock_get_experiment: Mock,
-        mock_create_job: Mock,
-        mock_get_dataset: Mock,
-        dataset_content: DatasetContent,
-    ):
-        mock_create_job.return_value = MagicMock()
-
-        # mock dataset.get_content
-        mock_get_dataset_instance = mock_get_dataset.return_value
-        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
-
-        dataset_id = str(UUID(int=0))
-        with pytest.raises(ValueError) as exc_info:
-            with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                    run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
-
-        assert str(exc_info.value) == "A project name or Id must be provided"
-
-    @patch.object(galileo.datasets.Datasets, "get")
-    @patch.object(galileo.jobs.Jobs, "create")
-    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
-    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
-    @patch.object(galileo.experiments.Projects, "get", return_value=project())
-    def test_run_experiment_with_empty_project_id_and_name_gives_error(
-        self,
-        mock_get_project: Mock,
-        mock_get_experiment: Mock,
-        mock_create_job: Mock,
-        mock_get_dataset: Mock,
-        dataset_content: DatasetContent,
-    ):
-        mock_create_job.return_value = MagicMock()
-
-        # mock dataset.get_content
-        mock_get_dataset_instance = mock_get_dataset.return_value
-        mock_get_dataset_instance.get_content = MagicMock(return_value=dataset_content)
-
-        dataset_id = str(UUID(int=0))
-        with pytest.raises(ValueError) as exc_info:
-            with patch.dict("os.environ", {"GALILEO_PROJECT": " "}):
-                with patch.dict("os.environ", {"GALILEO_PROJECT_ID": " "}):
-                    run_experiment("test_experiment", dataset_id=dataset_id, prompt_template=prompt_template())
-
-        assert str(exc_info.value) == "A project name or Id must be provided"
+        mock_get_project.assert_called_once_with(id="awesome-new-project", name=None)
 
     @patch.object(galileo.datasets.Datasets, "get")
     @patch.object(galileo.jobs.Jobs, "create")
@@ -564,7 +398,7 @@ class TestExperiments:
         assert result is not None
         assert result["experiment"] is not None
         assert f"/project/{project().id}/experiments/{experiment_response().id}" in result["link"]
-        mock_get_project.assert_called_once_with(name="awesome-new-project")
+        mock_get_project.assert_called_once_with(id=None, name="awesome-new-project")
         mock_get_experiment.assert_called_once_with(project().id, "test_experiment")
         mock_create_experiment.assert_called_once_with(
             project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000", mock_get_dataset.return_value
@@ -694,7 +528,7 @@ class TestExperiments:
         assert result is not None
         assert result["experiment"] is not None
         assert f"/project/{project().id}/experiments/{experiment_response().id}" in result["link"]
-        mock_get_project.assert_called_with(name="awesome-new-project")
+        mock_get_project.assert_called_with(id=None, name="awesome-new-project")
         mock_get_experiment.assert_called_once_with("00000000-0000-0000-0000-000000000000", "test_experiment")
         mock_create_experiment.assert_called_once_with(
             "00000000-0000-0000-0000-000000000000", ANY, mock_get_dataset.return_value
@@ -771,7 +605,7 @@ class TestExperiments:
             metrics=[GalileoScorers.correctness],
         )
 
-        mock_get_project.assert_called_once_with(name="awesome-new-project")
+        mock_get_project.assert_called_once_with(id=None, name="awesome-new-project")
         mock_get_experiment.assert_called_once_with(project().id, "test_experiment")
         mock_create_experiment.assert_called_once_with(
             project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000", mock_get_dataset.return_value
@@ -815,7 +649,7 @@ class TestExperiments:
             prompt_settings=prompt_run_settings(),
         )
 
-        mock_get_project.assert_called_once_with(name="awesome-new-project")
+        mock_get_project.assert_called_once_with(id=None, name="awesome-new-project")
         mock_get_experiment.assert_called_once_with(project().id, "test_experiment")
         mock_create_experiment.assert_called_once_with(
             project().id, "awesome-new-experiment 2012-01-01 at 00:00:00.000", mock_get_dataset.return_value
@@ -876,7 +710,7 @@ class TestExperiments:
         assert result is not None
         assert result["experiment"] is not None
 
-        mock_get_project.assert_called_with(name="awesome-new-project")
+        mock_get_project.assert_called_with(id=None, name="awesome-new-project")
         mock_get_experiment.assert_called_once_with("00000000-0000-0000-0000-000000000000", "test_experiment")
         mock_create_experiment.assert_called_once_with(
             "00000000-0000-0000-0000-000000000000", ANY, mock_get_dataset.return_value
@@ -1079,7 +913,7 @@ class TestExperiments:
         assert exc_info.value.message == "Create job failed"
         assert exc_info.value.status_code == 500
         assert exc_info.value.response_text == str(b'{"detail":"mocked error"}')
-        mock_get_project.assert_called_once_with(name="awesome-new-project")
+        mock_get_project.assert_called_once_with(id=None, name="awesome-new-project")
         assert mock_create_experiment.call_args[0][0] == "00000000-0000-0000-0000-000000000000"
         assert mock_create_experiment.call_args[0][1] == "test_experiment"
         mock_create_job_sync.assert_called_once()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -6,10 +6,12 @@ import pytest
 
 from galileo.projects import Projects
 
+
 @pytest.fixture(autouse=True)
 def reset_env_vars():
-    os.environ.pop('GALILEO_PROJECT', None)
-    os.environ.pop('GALILEO_PROJECT_ID', None)
+    os.environ.pop("GALILEO_PROJECT", None)
+    os.environ.pop("GALILEO_PROJECT_ID", None)
+
 
 class TestProjects:
     @patch("galileo.projects.get_all_projects_projects_all_get")
@@ -63,7 +65,7 @@ class TestProjects:
                 get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
 
     @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
-    def test_get_project_with_id_from_env_var_gets_project_by_id(self, get_project_projects_project_id_get: Mock):        
+    def test_get_project_with_id_from_env_var_gets_project_by_id(self, get_project_projects_project_id_get: Mock):
         with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "123"}):
             Projects().get()
             get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
@@ -82,7 +84,7 @@ class TestProjects:
 
     @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
     def test_get_project_with_name_from_env_var_gets_project_by_name(self, get_projects_projects_get: Mock):
-        os.environ.pop('GALILEO_PROJECT_ID', None)
+        os.environ.pop("GALILEO_PROJECT_ID", None)
 
         with patch.dict("os.environ", {"GALILEO_PROJECT": "my_project"}):
             Projects().get()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,25 +1,8 @@
-from ctypes import Union
-from datetime import datetime
-from http import HTTPStatus
 import logging
 from unittest.mock import ANY, Mock, patch
-from uuid import UUID
 
-from galileo.projects import Project, Projects
-from galileo.resources.models.http_validation_error import HTTPValidationError
-from galileo.resources.models.project_create_response import ProjectCreateResponse
-from galileo.resources.models.project_db import ProjectDB
-from galileo.resources.models.project_type import ProjectType
-from galileo.resources.types import Response
+from galileo.projects import Projects
 
-# def detailed_project_response() -> Response[Union[HTTPValidationError, ProjectDB]]:
-#     now = datetime.now()
-#     return Response(
-#         status_code=HTTPStatus.OK,
-#         content=response.content,
-#         headers=response.headers,
-#         parsed=_parse_response(client=client, response=response),
-#     )
 
 class TestProjects:
     @patch("galileo.projects.get_all_projects_projects_all_get")
@@ -66,7 +49,9 @@ class TestProjects:
                 get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
 
     @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
-    def test_get_project_with_id_with_whitespace_env_vars_gets_project_by_id(self, get_project_projects_project_id_get: Mock):
+    def test_get_project_with_id_with_whitespace_env_vars_gets_project_by_id(
+        self, get_project_projects_project_id_get: Mock
+    ):
         with patch.dict("os.environ", {"GALILEO_PROJECT": "  "}):
             with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "  "}):
                 Projects().get(id="123")

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,17 +1,101 @@
+from ctypes import Union
+from datetime import datetime
+from http import HTTPStatus
 import logging
-from unittest.mock import patch
+from unittest.mock import ANY, Mock, patch
+from uuid import UUID
 
-from galileo.projects import Projects
+from galileo.projects import Project, Projects
+from galileo.resources.models.http_validation_error import HTTPValidationError
+from galileo.resources.models.project_create_response import ProjectCreateResponse
+from galileo.resources.models.project_db import ProjectDB
+from galileo.resources.models.project_type import ProjectType
+from galileo.resources.types import Response
 
+# def detailed_project_response() -> Response[Union[HTTPValidationError, ProjectDB]]:
+#     now = datetime.now()
+#     return Response(
+#         status_code=HTTPStatus.OK,
+#         content=response.content,
+#         headers=response.headers,
+#         parsed=_parse_response(client=client, response=response),
+#     )
 
-@patch("galileo.projects.get_all_projects_projects_all_get")
-def test_get_all_projects_projects_all_get_exc(get_all_projects_projects_all_get, caplog):
-    get_all_projects_projects_all_get.sync.side_effect = ValueError("unable to get all projects")
+class TestProjects:
+    @patch("galileo.projects.get_all_projects_projects_all_get")
+    def test_get_all_projects_projects_all_get_exc(self, get_all_projects_projects_all_get, caplog):
+        get_all_projects_projects_all_get.sync.side_effect = ValueError("unable to get all projects")
 
-    projects_client = Projects()
-    # it doesn't trough exception, because we catch all and log
-    projects_client.list()
-
-    with caplog.at_level(logging.WARNING):
+        projects_client = Projects()
+        # it doesn't trough exception, because we catch all and log
         projects_client.list()
-        assert "Error occurred during execution: list: unable to get all projects" in caplog.text
+
+        with caplog.at_level(logging.WARNING):
+            projects_client.list()
+            assert "Error occurred during execution: list: unable to get all projects" in caplog.text
+
+    def test_get_project_with_no_name_or_id_raises_value_error(self):
+        projects_client = Projects()
+
+        try:
+            projects_client.get()
+        except ValueError as e:
+            assert str(e) == "Exactly one of 'id' or 'name' must be provided"
+
+    def test_get_project_with_name_and_id_raises_value_error(self):
+        projects_client = Projects()
+
+        try:
+            projects_client.get(id="123", name="my_project")
+        except ValueError as e:
+            assert str(e) == "Exactly one of 'id' or 'name' must be provided"
+
+    def test_get_project_with_empty_name_and_id_raises_value_error(self):
+        projects_client = Projects()
+
+        try:
+            projects_client.get(id="", name="")
+        except ValueError as e:
+            assert str(e) == "Exactly one of 'id' or 'name' must be provided"
+
+    @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
+    def test_get_project_with_id_gets_project_by_id(self, get_project_projects_project_id_get: Mock):
+        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                Projects().get(id="123")
+                get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
+
+    @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
+    def test_get_project_with_id_with_whitespace_env_vars_gets_project_by_id(self, get_project_projects_project_id_get: Mock):
+        with patch.dict("os.environ", {"GALILEO_PROJECT": "  "}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "  "}):
+                Projects().get(id="123")
+                get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
+
+    @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
+    def test_get_project_with_id_from_env_var_gets_project_by_id(self, get_project_projects_project_id_get: Mock):
+        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "123"}):
+                Projects().get()
+                get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
+
+    @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
+    def test_get_project_with_name_gets_project_by_name(self, get_projects_projects_get: Mock):
+        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                Projects().get(name="my_project")
+                get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
+
+    @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
+    def test_get_project_with_name_with_whitespace_env_vars_gets_project_by_name(self, get_projects_projects_get: Mock):
+        with patch.dict("os.environ", {"GALILEO_PROJECT": "  "}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "  "}):
+                Projects().get(name="my_project")
+                get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
+
+    @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
+    def test_get_project_with_name_from_env_var_gets_project_by_name(self, get_projects_projects_get: Mock):
+        with patch.dict("os.environ", {"GALILEO_PROJECT": "my_project"}):
+            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
+                Projects().get()
+                get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -61,13 +61,13 @@ class TestProjects:
     ):
         with patch.dict("os.environ", {"GALILEO_PROJECT": "  "}):
             with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "  "}):
-                Projects().get(id="123")
+                Projects().get_with_env_fallbacks(id="123")
                 get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
 
     @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
     def test_get_project_with_id_from_env_var_gets_project_by_id(self, get_project_projects_project_id_get: Mock):
         with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "123"}):
-            Projects().get()
+            Projects().get_with_env_fallbacks()
             get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
 
     @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
@@ -79,7 +79,7 @@ class TestProjects:
     def test_get_project_with_name_with_whitespace_env_vars_gets_project_by_name(self, get_projects_projects_get: Mock):
         with patch.dict("os.environ", {"GALILEO_PROJECT": "  "}):
             with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "  "}):
-                Projects().get(name="my_project")
+                Projects().get_with_env_fallbacks(name="my_project")
                 get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
 
     @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
@@ -87,5 +87,5 @@ class TestProjects:
         os.environ.pop("GALILEO_PROJECT_ID", None)
 
         with patch.dict("os.environ", {"GALILEO_PROJECT": "my_project"}):
-            Projects().get()
+            Projects().get_with_env_fallbacks()
             get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,8 +1,15 @@
 import logging
+import os
 from unittest.mock import ANY, Mock, patch
+
+import pytest
 
 from galileo.projects import Projects
 
+@pytest.fixture(autouse=True)
+def reset_env_vars():
+    os.environ.pop('GALILEO_PROJECT', None)
+    os.environ.pop('GALILEO_PROJECT_ID', None)
 
 class TestProjects:
     @patch("galileo.projects.get_all_projects_projects_all_get")
@@ -43,10 +50,8 @@ class TestProjects:
 
     @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
     def test_get_project_with_id_gets_project_by_id(self, get_project_projects_project_id_get: Mock):
-        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                Projects().get(id="123")
-                get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
+        Projects().get(id="123")
+        get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
 
     @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
     def test_get_project_with_id_with_whitespace_env_vars_gets_project_by_id(
@@ -58,18 +63,15 @@ class TestProjects:
                 get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
 
     @patch("galileo.projects.get_project_projects_project_id_get.sync_detailed", return_value=None)
-    def test_get_project_with_id_from_env_var_gets_project_by_id(self, get_project_projects_project_id_get: Mock):
-        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "123"}):
-                Projects().get()
-                get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
+    def test_get_project_with_id_from_env_var_gets_project_by_id(self, get_project_projects_project_id_get: Mock):        
+        with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "123"}):
+            Projects().get()
+            get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
 
     @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
     def test_get_project_with_name_gets_project_by_name(self, get_projects_projects_get: Mock):
-        with patch.dict("os.environ", {"GALILEO_PROJECT": ""}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                Projects().get(name="my_project")
-                get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
+        Projects().get(name="my_project")
+        get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
 
     @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
     def test_get_project_with_name_with_whitespace_env_vars_gets_project_by_name(self, get_projects_projects_get: Mock):
@@ -80,7 +82,8 @@ class TestProjects:
 
     @patch("galileo.projects.get_projects_projects_get.sync_detailed", return_value=None)
     def test_get_project_with_name_from_env_var_gets_project_by_name(self, get_projects_projects_get: Mock):
+        os.environ.pop('GALILEO_PROJECT_ID', None)
+
         with patch.dict("os.environ", {"GALILEO_PROJECT": "my_project"}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": ""}):
-                Projects().get()
-                get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
+            Projects().get()
+            get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)


### PR DESCRIPTION
The `run_experiment` function expects a project name. To make this more consistent with other functions, this change adds the ability to:

- Pass in a project by Id (the other experiment functions only take the Id)
- Not pass in a project and have it loaded from an environment variable

[SC-40118](https://app.shortcut.com/galileo/story/40118/run-experiment-should-support-project-ids-and-projects-from-env-vars)