### PR TITLE
fix: updating `get_with_env_fallbacks` to not set/pass both id and name

### DIFF
--- a/src/galileo/projects.py
+++ b/src/galileo/projects.py
@@ -150,8 +150,8 @@ class Projects(BaseClientModel, DecorateAllMethods):
             If the request takes longer than Client.timeout.
 
         """
-        name = name or os.getenv("GALILEO_PROJECT")
-        id = id or os.getenv("GALILEO_PROJECT_ID")
+        id = id or (None if name else os.getenv("GALILEO_PROJECT_ID")) or None
+        name = name or (None if id else os.getenv("GALILEO_PROJECT")) or None
 
         return self.get(id=id, name=name)
 


### PR DESCRIPTION
Previously the code was setting both `id` and `name`, backfilled from the env vars. This was causing an issue when, for ex, project_id was passed but the GALILEO_PROJECT env var was set.