### PR TITLE
feat: Implement support for crewai version 0.186.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -901,15 +901,15 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "crewai"
-version = "0.159.0"
+version = "0.177.0"
 description = "Cutting-edge framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together seamlessly, tackling complex tasks."
 optional = true
 python-versions = "<3.14,>=3.10"
 groups = ["main"]
 markers = "python_version >= \"3.10\" and (extra == \"crewai\" or extra == \"all\")"
 files = [
-    {file = "crewai-0.159.0-py3-none-any.whl", hash = "sha256:809719e3d40de850313d600706b0b39bb2e7ff518e90bccfa028d6dc4a06ce17"},
-    {file = "crewai-0.159.0.tar.gz", hash = "sha256:feff7a97a3fa0c7ddb6d8a94d6cb584eb093930e6ca5b330d64c36241381741f"},
+    {file = "crewai-0.177.0-py3-none-any.whl", hash = "sha256:4718335f0c8236ef42740166fe86f9636a9cf628eeea87205d85599ed1b771b4"},
+    {file = "crewai-0.177.0.tar.gz", hash = "sha256:cd34f024881afa163894793e51875a45b02a06f82b342785515455a2e48bb2c0"},
 ]
 
 [package.dependencies]
@@ -941,7 +941,6 @@ tomli-w = ">=1.1.0"
 uv = ">=0.4.25"
 
 [package.extras]
-agentops = ["agentops (==0.3.18)"]
 aisuite = ["aisuite (>=0.1.10)"]
 docling = ["docling (>=2.12.0)"]
 embeddings = ["tiktoken (>=0.8.0,<0.9.0)"]
@@ -949,7 +948,8 @@ mem0 = ["mem0ai (>=0.1.94)"]
 openpyxl = ["openpyxl (>=3.1.5)"]
 pandas = ["pandas (>=2.2.3)"]
 pdfplumber = ["pdfplumber (>=0.11.4)"]
-tools = ["crewai-tools (>=0.62.0,<0.63.0)"]
+qdrant = ["qdrant-client[fastembed] (>=1.14.3)"]
+tools = ["crewai-tools (>=0.69.0,<0.70.0)"]
 
 [[package]]
 name = "crosshair-tool"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7175,4 +7175,4 @@ openai = ["openai", "openai-agents", "packaging"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9,<3.14"
-content-hash = "8774a34f4186886fe6a50bd7452e8b91b9fa8c55fa62b42c4c79706e17ac10d4"
+content-hash = "efa8bfef322d087e7bf2ef35208e93c158ae8265e7765dfc5dafd6c517e0c1a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ openai = { version = "<1.96.0", optional = true }
 openai-agents = { version = "<0.2.1", optional = true }
 galileo-core = "~=3.64.5"
 backoff = "^2.2.1"
-crewai = { version = ">=0.152.0,<0.160.0", optional = true, python = ">=3.10,<3.14" }
+crewai = { version = ">=0.152.0,<=0.186.1", optional = true, python = ">=3.10,<3.14" }
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.4.0"
@@ -150,7 +150,7 @@ formatter-cmds = ["ruff check --exit-zero --fix $file", "ruff format $file"]
 [project.optional-dependencies]
 langchain = ["langchain-core"]
 openai = ["openai", "packaging (>=24.2,<25.0)", "openai-agents"]
-crewai = ["crewai (>=0.152.0,<0.160.0)"]
+crewai = ["crewai (>=0.152.0,<=0.186.1)"]
 all = ["langchain-core", "openai", "crewai"]
 
 

--- a/src/galileo/handlers/crewai/handler.py
+++ b/src/galileo/handlers/crewai/handler.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from typing import Any, Optional, Union
 from uuid import UUID
 
+from packaging.version import Version
+
 from galileo.handlers.base_handler import GalileoBaseHandler
 from galileo.logger import GalileoLogger
 from galileo.schema.handlers import NodeType
@@ -13,24 +15,64 @@ from galileo.utils.serialization import serialize_to_str
 _logger = logging.getLogger(__name__)
 
 try:
-    from crewai.utilities.events.agent_events import (
-        AgentExecutionCompletedEvent,
-        AgentExecutionErrorEvent,
-        AgentExecutionStartedEvent,
-    )
-    from crewai.utilities.events.base_event_listener import BaseEventListener
-    from crewai.utilities.events.crew_events import (
-        CrewKickoffCompletedEvent,
-        CrewKickoffFailedEvent,
-        CrewKickoffStartedEvent,
-    )
-    from crewai.utilities.events.llm_events import LLMCallCompletedEvent, LLMCallFailedEvent, LLMCallStartedEvent
-    from crewai.utilities.events.task_events import TaskCompletedEvent, TaskFailedEvent, TaskStartedEvent
-    from crewai.utilities.events.tool_usage_events import (
-        ToolUsageErrorEvent,
-        ToolUsageFinishedEvent,
-        ToolUsageStartedEvent,
-    )
+    from crewai import __version__ as CREWAI_VERSION
+
+    CREWAI_VERSION = Version(CREWAI_VERSION)
+    CREWAI_EVENTS_MODULE_AVAILABLE = CREWAI_VERSION >= Version("0.177.0")
+    if CREWAI_EVENTS_MODULE_AVAILABLE:
+        from crewai.events.base_event_listener import BaseEventListener  # pyright: ignore[reportMissingImports]
+        from crewai.events.types.agent_events import (  # pyright: ignore[reportMissingImports]
+            AgentExecutionCompletedEvent,
+            AgentExecutionErrorEvent,
+            AgentExecutionStartedEvent,
+        )
+        from crewai.events.types.crew_events import (  # pyright: ignore[reportMissingImports]
+            CrewKickoffCompletedEvent,
+            CrewKickoffFailedEvent,
+            CrewKickoffStartedEvent,
+        )
+        from crewai.events.types.llm_events import (  # pyright: ignore[reportMissingImports]
+            LLMCallCompletedEvent,
+            LLMCallFailedEvent,
+            LLMCallStartedEvent,
+        )
+        from crewai.events.types.task_events import (  # pyright: ignore[reportMissingImports]
+            TaskCompletedEvent,
+            TaskFailedEvent,
+            TaskStartedEvent,
+        )
+        from crewai.events.types.tool_usage_events import (  # pyright: ignore[reportMissingImports]
+            ToolUsageErrorEvent,
+            ToolUsageFinishedEvent,
+            ToolUsageStartedEvent,
+        )
+    else:
+        from crewai.utilities.events.agent_events import (  # pyright: ignore[reportMissingImports]
+            AgentExecutionCompletedEvent,
+            AgentExecutionErrorEvent,
+            AgentExecutionStartedEvent,
+        )
+        from crewai.utilities.events.base_event_listener import BaseEventListener
+        from crewai.utilities.events.crew_events import (  # pyright: ignore[reportMissingImports]
+            CrewKickoffCompletedEvent,
+            CrewKickoffFailedEvent,
+            CrewKickoffStartedEvent,
+        )
+        from crewai.utilities.events.llm_events import (  # pyright: ignore[reportMissingImports]
+            LLMCallCompletedEvent,
+            LLMCallFailedEvent,
+            LLMCallStartedEvent,
+        )
+        from crewai.utilities.events.task_events import (  # pyright: ignore[reportMissingImports]
+            TaskCompletedEvent,
+            TaskFailedEvent,
+            TaskStartedEvent,
+        )
+        from crewai.utilities.events.tool_usage_events import (  # pyright: ignore[reportMissingImports]
+            ToolUsageErrorEvent,
+            ToolUsageFinishedEvent,
+            ToolUsageStartedEvent,
+        )
 
     CREWAI_AVAILABLE = True
 except ImportError:

--- a/src/galileo/handlers/langchain/utils.py
+++ b/src/galileo/handlers/langchain/utils.py
@@ -13,4 +13,4 @@ def get_agent_name(parent_run_id: Optional[UUID], node_name: str, nodes: dict[st
 
 
 def is_agent_node(node_name: str) -> bool:
-    return node_name in ["LangGraph", "Agent"]
+    return node_name.lower() in ["langgraph", "agent"]


### PR DESCRIPTION
# Support for CrewAI version [0.186.1](https://github.com/crewAIInc/crewAI/releases/tag/0.186.1)
## Summary
This PR implements support for CrewAI version [0.186.1](https://github.com/crewAIInc/crewAI/releases/tag/0.186.1) and includes a bug fix for LangChain agent detection.

## Changes Made
### 🔄 Dependency Updates
- Updated CrewAI dependency version constraint from >=0.152.0,<0.160.0 to >=0.152.0,<=0.186.1
- Updated project optional dependencies to support CrewAI up to version 0.186.1
- Updated poetry.lock with new dependency versions

### 🐛 Bug Fixes
- LangChain Agent Detection: Improved agent node detection by making the comparison case-insensitive (node_name.lower() in ["langgraph", "agent"])

## Testing
- Ensures backward compatibility with existing CrewAI versions
- Maintains proper agent detection for LangChain integrations

## Related
Addresses ticket SC-40330

