### PR TITLE
[Draft] feat: Introduce object-centric API for Galileo with Project and LogStream classes

### DIFF
--- a/src/galileo/__future__/__init__.py
+++ b/src/galileo/__future__/__init__.py
@@ -1,0 +1,32 @@
+"""
+Galileo Future API
+
+This package provides the next-generation object-centric API for Galileo.
+It offers an intuitive, object-oriented interface that simplifies common workflows
+while maintaining full compatibility with the existing service-based functions.
+
+Key Features:
+- Object-centric design for better usability
+- Simplified project and log stream management
+- Backward-compatible with existing service functions
+- Clean, intuitive method chaining and relationships
+
+Example Usage:
+    from galileo.__future__ import Project
+
+    # Create or get a project
+    project = Project(name="My AI Project")
+    project = Project.get(name="My AI Project")
+
+    # List all projects
+    projects = Project.list()
+
+    # Create and manage log streams through the project
+    log_stream = project.create_log_stream(name="Production Logs")
+    log_streams = project.list_log_streams()
+"""
+
+from galileo.__future__.log_stream import LogStream
+from galileo.__future__.project import Project
+
+__all__ = ["Project", "LogStream"]

--- a/src/galileo/__future__/log_stream.py
+++ b/src/galileo/__future__/log_stream.py
@@ -1,0 +1,178 @@
+"""
+LogStream class for the Galileo Future API.
+
+This module provides an object-centric interface for managing Galileo log streams,
+offering a more intuitive alternative to the service-based functions.
+"""
+
+from __future__ import annotations
+
+from galileo.log_streams import LogStream as LegacyLogStream
+from galileo.log_streams import get_log_stream as service_get_log_stream
+from galileo.log_streams import list_log_streams as service_list_log_streams
+from galileo.schema.metrics import GalileoScorers, LocalMetricConfig, Metric
+
+
+class LogStream:
+    """
+    Object-centric interface for Galileo log streams.
+
+    This class provides an intuitive way to work with Galileo log streams,
+    offering methods for managing log streams and their associated metrics.
+
+    Attributes:
+        created_at (datetime.datetime): When the log stream was created.
+        created_by (str): The user who created the log stream.
+        id (str): The unique log stream identifier.
+        name (str): The log stream name.
+        project_id (str): The ID of the project this log stream belongs to.
+        updated_at (datetime.datetime): When the log stream was last updated.
+        additional_properties (dict): Additional properties of the log stream.
+
+    Examples:
+        # LogStreams are typically created through Project instances
+        from galileo.__future__ import Project
+
+        project = Project.get(name="My AI Project")
+        log_stream = project.create_log_stream(name="Production Logs")
+
+        # Enable metrics on the log stream
+        from galileo.schema.metrics import GalileoScorers
+        local_metrics = log_stream.enable_metrics([
+            GalileoScorers.correctness,
+            GalileoScorers.completeness,
+            "context_relevance"
+        ])
+    """
+
+    def __init__(self, *, _legacy_log_stream: LegacyLogStream | None = None) -> None:
+        """
+        Initialize a LogStream instance.
+
+        Note: LogStreams should typically be created through Project methods
+        rather than directly instantiated.
+
+        Args:
+            _legacy_log_stream (Optional[LegacyLogStream]): Internal parameter for
+                wrapping existing log stream instances.
+        """
+        if _legacy_log_stream is not None:
+            # Initialize from existing legacy log stream
+            self._legacy_log_stream = _legacy_log_stream
+            self.created_at = _legacy_log_stream.created_at
+            self.created_by = _legacy_log_stream.created_by
+            self.id = _legacy_log_stream.id
+            self.name = _legacy_log_stream.name
+            self.project_id = _legacy_log_stream.project_id
+            self.updated_at = _legacy_log_stream.updated_at
+            self.additional_properties = _legacy_log_stream.additional_properties
+        else:
+            raise ValueError("LogStream instances should be created through Project methods")
+
+    @classmethod
+    def get(cls, *, name: str, project_id: str | None = None, project_name: str | None = None) -> LogStream | None:
+        """
+        Get an existing log stream by name.
+
+        Args:
+            name (str): The log stream name.
+            project_id (Optional[str]): The project ID.
+            project_name (Optional[str]): The project name.
+
+        Returns:
+            Optional[LogStream]: The log stream if found, None otherwise.
+
+        Raises:
+            ValueError: If neither or both project_id and project_name are provided.
+
+        Examples:
+            # Get by project name
+            log_stream = LogStream.get(
+                name="Production Logs",
+                project_name="My AI Project"
+            )
+
+            # Get by project ID
+            log_stream = LogStream.get(
+                name="Production Logs",
+                project_id="project-123"
+            )
+        """
+        legacy_log_stream = service_get_log_stream(name=name, project_id=project_id, project_name=project_name)
+        if legacy_log_stream is None:
+            return None
+        return cls(_legacy_log_stream=legacy_log_stream)
+
+    @classmethod
+    def list(cls, *, project_id: str | None = None, project_name: str | None = None) -> list[LogStream]:
+        """
+        List all log streams for a project.
+
+        Args:
+            project_id (Optional[str]): The project ID.
+            project_name (Optional[str]): The project name.
+
+        Returns:
+            List[LogStream]: A list of log streams for the project.
+
+        Raises:
+            ValueError: If neither or both project_id and project_name are provided.
+
+        Examples:
+            # List by project name
+            log_streams = LogStream.list(project_name="My AI Project")
+
+            # List by project ID
+            log_streams = LogStream.list(project_id="project-123")
+        """
+        legacy_log_streams = service_list_log_streams(project_id=project_id, project_name=project_name)
+        return [cls(_legacy_log_stream=legacy_stream) for legacy_stream in legacy_log_streams]
+
+    def enable_metrics(
+        self,
+        metrics: list[GalileoScorers | Metric | LocalMetricConfig | str],  # type: ignore[valid-type]
+    ) -> list[LocalMetricConfig]:  # type: ignore[valid-type]
+        """
+        Enable metrics on this log stream.
+
+        This is a convenient method that leverages the log stream's existing
+        project_id and id attributes to enable metrics without requiring
+        redundant parameter specification.
+
+        Args:
+            metrics: List of metrics to enable. Supports:
+                - GalileoScorers enum values (e.g., GalileoScorers.correctness)
+                - Metric objects with name and optional version
+                - LocalMetricConfig objects for custom scoring functions
+                - String names of built-in metrics
+
+        Returns:
+            List[LocalMetricConfig]: Local metric configurations that must be
+                computed client-side.
+
+        Raises:
+            ValueError: If the log stream lacks required id or project_id attributes,
+                or if any specified metrics are unknown.
+
+        Examples:
+            from galileo.schema.metrics import GalileoScorers
+
+            project = Project.get(name="My AI Project")
+            log_stream = project.create_log_stream(name="Production Logs")
+
+            # Enable built-in metrics
+            local_metrics = log_stream.enable_metrics([
+                GalileoScorers.correctness,
+                GalileoScorers.completeness,
+                "context_relevance"
+            ])
+        """
+        return self._legacy_log_stream.enable_metrics(metrics)
+
+    def __str__(self) -> str:
+        """String representation of the log stream."""
+        return f"LogStream(name='{self.name}', id='{self.id}', project_id='{self.project_id}')"
+
+    def __repr__(self) -> str:
+        """Detailed string representation of the log stream."""
+        return f"LogStream(name='{self.name}', id='{self.id}', project_id='{self.project_id}', created_at='{self.created_at}')"

--- a/src/galileo/__future__/project.py
+++ b/src/galileo/__future__/project.py
@@ -1,0 +1,185 @@
+"""
+Project class for the Galileo Future API.
+
+This module provides an object-centric interface for managing Galileo projects,
+offering a more intuitive alternative to the service-based functions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from galileo.projects import Project as LegacyProject
+from galileo.projects import create_project as service_create_project
+from galileo.projects import get_project as service_get_project
+from galileo.projects import list_projects as service_list_projects
+
+if TYPE_CHECKING:
+    from galileo.__future__.log_stream import LogStream
+
+
+class Project:
+    """
+    Object-centric interface for Galileo projects.
+
+    This class provides an intuitive way to work with Galileo projects,
+    encapsulating project management operations and providing seamless
+    integration with log stream management.
+
+    Attributes:
+        created_at (datetime.datetime): When the project was created.
+        created_by (str): The user who created the project.
+        id (str): The unique project identifier.
+        updated_at (datetime.datetime): When the project was last updated.
+        bookmark (Union[Unset, bool]): Whether the project is bookmarked.
+        name (Union[None, Unset, str]): The project name.
+        permissions (Union[Unset, list]): Project permissions.
+        type (Union[None, ProjectType, Unset]): The project type.
+
+    Examples:
+        # Create a new project
+        project = Project(name="My AI Project")
+
+        # Get an existing project
+        project = Project.get(name="My AI Project")
+
+        # List all projects
+        projects = Project.list()
+
+        # Create a log stream for the project
+        log_stream = project.create_log_stream(name="Production Logs")
+
+        # List log streams for the project
+        log_streams = project.list_log_streams()
+    """
+
+    def __init__(self, name: str | None = None, *, _legacy_project: LegacyProject | None = None) -> None:
+        """
+        Initialize a Project instance.
+
+        When called with a name, this creates a new project. To get an existing
+        project, use Project.get() instead.
+
+        Args:
+            name (Optional[str]): The name of the project to create.
+            _legacy_project (Optional[LegacyProject]): Internal parameter for
+                wrapping existing project instances.
+        """
+        if _legacy_project is not None:
+            # Initialize from existing legacy project
+            self._legacy_project = _legacy_project
+            self.created_at = _legacy_project.created_at
+            self.created_by = _legacy_project.created_by
+            self.id = _legacy_project.id
+            self.updated_at = _legacy_project.updated_at
+            self.bookmark = _legacy_project.bookmark
+            self.name = _legacy_project.name
+            self.permissions = _legacy_project.permissions
+            self.type = _legacy_project.type
+        elif name is not None:
+            # Create a new project
+            self._legacy_project = service_create_project(name=name)
+            self.created_at = self._legacy_project.created_at
+            self.created_by = self._legacy_project.created_by
+            self.id = self._legacy_project.id
+            self.updated_at = self._legacy_project.updated_at
+            self.bookmark = self._legacy_project.bookmark
+            self.name = self._legacy_project.name
+            self.permissions = self._legacy_project.permissions
+            self.type = self._legacy_project.type
+        else:
+            raise ValueError(
+                "Either 'name' must be provided to create a project, or use Project.get() to retrieve an existing project"
+            )
+
+    @classmethod
+    def get(cls, *, id: str | None = None, name: str | None = None) -> Project | None:
+        """
+        Get an existing project by ID or name.
+
+        Args:
+            id (Optional[str]): The project ID.
+            name (Optional[str]): The project name.
+
+        Returns:
+            Optional[Project]: The project if found, None otherwise.
+
+        Raises:
+            ValueError: If neither or both id and name are provided.
+
+        Examples:
+            # Get by name
+            project = Project.get(name="My AI Project")
+
+            # Get by ID
+            project = Project.get(id="project-123")
+        """
+        legacy_project = service_get_project(id=id, name=name)
+        if legacy_project is None:
+            return None
+        return cls(_legacy_project=legacy_project)
+
+    @classmethod
+    def list(cls) -> list[Project]:
+        """
+        List all available projects.
+
+        Returns:
+            List[Project]: A list of all projects.
+
+        Examples:
+            projects = Project.list()
+            for project in projects:
+                print(f"Project: {project.name} (ID: {project.id})")
+        """
+        legacy_projects = service_list_projects()
+        return [cls(_legacy_project=legacy_project) for legacy_project in legacy_projects]
+
+    def create_log_stream(self, name: str) -> LogStream:
+        """
+        Create a new log stream for this project.
+
+        Args:
+            name (str): The name of the log stream to create.
+
+        Returns:
+            LogStream: The created log stream.
+
+        Examples:
+            project = Project.get(name="My AI Project")
+            log_stream = project.create_log_stream(name="Production Logs")
+        """
+        # Import here to avoid circular imports
+        from galileo.__future__.log_stream import LogStream
+        from galileo.log_streams import create_log_stream as service_create_log_stream
+
+        legacy_log_stream = service_create_log_stream(name=name, project_id=self.id)
+        return LogStream(_legacy_log_stream=legacy_log_stream)
+
+    def list_log_streams(self) -> list[LogStream]:  # type: ignore[valid-type]
+        """
+        List all log streams for this project.
+
+        Returns:
+            List[LogStream]: A list of log streams belonging to this project.
+
+        Examples:
+            project = Project.get(name="My AI Project")
+            log_streams = project.list_log_streams()
+            for stream in log_streams:
+                print(f"Log Stream: {stream.name} (ID: {stream.id})")
+        """
+        # Import here to avoid circular imports
+        from galileo.__future__.log_stream import LogStream
+        from galileo.log_streams import list_log_streams as service_list_log_streams
+
+        legacy_log_streams = service_list_log_streams(project_id=self.id)
+        return [LogStream(_legacy_log_stream=legacy_stream) for legacy_stream in legacy_log_streams]
+
+    def __str__(self) -> str:
+        """String representation of the project."""
+        return f"Project(name='{self.name}', id='{self.id}')"
+
+    def __repr__(self) -> str:
+        """Detailed string representation of the project."""
+        return f"Project(name='{self.name}', id='{self.id}', created_at='{self.created_at}')"


### PR DESCRIPTION
**Shortcut:**

- [sc-41736 / [Python SDK] Implement Object-Centric Project in __future__](https://app.shortcut.com/galileo/story/41736/python-sdk-implement-object-centric-project-in-future)

**Description:**

This is a draft PR to be used as an example of the suggested implementation approach.

**REPL example:**

```python
import os
os.environ["GALILEO_API_KEY"] = "SETKEY"

from galileo.config import GalileoPythonConfig
config = GalileoPythonConfig.get()

# ------------------------------------------------
## __future__ Project
# ------------------------------------------------

from galileo.__future__ import Project

# Create project
project = Project(name="A new project")

# Get project
project = Project.get(name="A new project")

# List projects
project_list = Project.list()

# Create log stream for project
log_stream = project.create_log_stream(name="A test log stream")

# List log streams for project
log_stream_list = project.list_log_streams()

```

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)
