### PR TITLE
feat: Delete metric

### DIFF
--- a/src/galileo/metrics.py
+++ b/src/galileo/metrics.py
@@ -34,9 +34,7 @@ class Metrics:
         self.config = GalileoPythonConfig.get()
 
     def delete_metric(self, name: str) -> None:
-        scorers = Scorers().list()
-        scorers_to_delete = [s for s in scorers if s.name == name]
-
+        scorers_to_delete = Scorers().list(name=name)
         if not scorers_to_delete:
             raise ValueError(f"Scorer with name {name} not found.")
 

--- a/src/galileo/metrics.py
+++ b/src/galileo/metrics.py
@@ -214,7 +214,8 @@ def get_metrics(
 def delete_metric(name: str) -> None:
     """
     Deletes a metric by its name.
+
     Args:
-        name: The name of the scorer to delete.
+        name: The name of the metric to delete.
     """
     Metrics().delete_metric(name)

--- a/src/galileo/metrics.py
+++ b/src/galileo/metrics.py
@@ -33,12 +33,20 @@ class Metrics:
     def __init__(self) -> None:
         self.config = GalileoPythonConfig.get()
 
-    def delete_metric(self, scorer_name: str, scorer_type: ScorerTypes) -> None:
-        scorers = Scorers().list(types=[scorer_type])
-        scorer = next((s for s in scorers if s.name == scorer_name), None)
-        if not scorer:
-            raise ValueError(f"Scorer with name {scorer_name} not found.")
-        delete_scorer_scorers_scorer_id_delete.sync(scorer_id=scorer.id, client=self.config.api_client)
+    def delete_metric(self, name: str) -> None:
+        scorers = Scorers().list()
+        scorers_to_delete = [s for s in scorers if s.name == name]
+
+        if not scorers_to_delete:
+            raise ValueError(f"Scorer with name {name} not found.")
+
+        for scorer in scorers_to_delete:
+            response = delete_scorer_scorers_scorer_id_delete.sync(scorer_id=scorer.id, client=self.config.api_client)
+
+            if isinstance(response, HTTPValidationError):
+                raise ValueError(response.detail)
+            if response is None:
+                raise ValueError("Failed to delete metric.")
 
     def create_custom_llm_metric(
         self,
@@ -205,11 +213,10 @@ def get_metrics(
     )
 
 
-def delete_metric(scorer_name: str, scorer_type: ScorerTypes) -> None:
+def delete_metric(name: str) -> None:
     """
-    Deletes a metric by its name and type.
+    Deletes a metric by its name.
     Args:
-        scorer_name: The name of the scorer to delete.
-        scorer_type: The type of the scorer.
+        name: The name of the scorer to delete.
     """
-    Metrics().delete_metric(scorer_name, scorer_type)
+    Metrics().delete_metric(name)

--- a/src/galileo/metrics.py
+++ b/src/galileo/metrics.py
@@ -20,7 +20,7 @@ from galileo.resources.models.create_llm_scorer_version_request import CreateLLM
 from galileo.resources.models.create_scorer_request import CreateScorerRequest
 from galileo.resources.models.output_type_enum import OutputTypeEnum
 from galileo.resources.models.scorer_defaults import ScorerDefaults
-from galileo.scorers import get_scorers
+from galileo.scorers import Scorers
 from galileo.search import FilterType
 from galileo_core.schemas.logging.step import StepType
 
@@ -33,11 +33,11 @@ class Metrics:
     def __init__(self) -> None:
         self.config = GalileoPythonConfig.get()
 
-    def delete_metric(self, name: str, scorer_type: ScorerTypes) -> None:
-        scorers = get_scorers(types=[scorer_type])
-        scorer = next((s for s in scorers if s.name == name), None)
+    def delete_metric(self, scorer_name: str, scorer_type: ScorerTypes) -> None:
+        scorers = Scorers().list(types=[scorer_type])
+        scorer = next((s for s in scorers if s.name == scorer_name), None)
         if not scorer:
-            raise ValueError(f"Scorer with name {name} not found.")
+            raise ValueError(f"Scorer with name {scorer_name} not found.")
         delete_scorer_scorers_scorer_id_delete.sync(scorer_id=scorer.id, client=self.config.api_client)
 
     def create_custom_llm_metric(
@@ -205,11 +205,11 @@ def get_metrics(
     )
 
 
-def delete_metric(name: str, scorer_type: ScorerTypes) -> None:
+def delete_metric(scorer_name: str, scorer_type: ScorerTypes) -> None:
     """
     Deletes a metric by its name and type.
     Args:
-        name: The name of the scorer to delete.
+        scorer_name: The name of the scorer to delete.
         scorer_type: The type of the scorer.
     """
-    Metrics().delete_metric(name, scorer_type)
+    Metrics().delete_metric(scorer_name, scorer_type)

--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -81,3 +81,13 @@ class ScorerSettings:
             client=self.config.api_client,
             body=RunScorerSettingsPatchRequest(run_id=run_id, scorers=scorers),
         )
+
+
+def get_scorers(types: Optional[list[ScorerTypes]] = None) -> Union[Unset, list[ScorerResponse]]:
+    """
+    Args:
+        types: List of scorer types to filter by. Defaults to all scorers.
+    Returns:
+        List of scorers
+    """
+    return Scorers().list(types=types)

--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -81,13 +81,3 @@ class ScorerSettings:
             client=self.config.api_client,
             body=RunScorerSettingsPatchRequest(run_id=run_id, scorers=scorers),
         )
-
-
-def get_scorers(types: Optional[list[ScorerTypes]] = None) -> Union[Unset, list[ScorerResponse]]:
-    """
-    Args:
-        types: List of scorer types to filter by. Defaults to all scorers.
-    Returns:
-        List of scorers
-    """
-    return Scorers().list(types=types)

--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -37,16 +37,25 @@ class Scorers:
         """
         Lists scorers, optionally filtering by name and/or type.
 
+        The filters are combined with an AND condition, while the values within the `types`
+        list are combined with an OR condition. For example, calling
+        `list(name="my_scorer", types=[ScorerTypes.llm, ScorerTypes.code])` will return
+        scorers where the name is "my_scorer" AND the type is either "llm" OR "code".
+
         Args:
             name: Name of the scorer to filter by.
             types: List of scorer types to filter by. Defaults to all scorers.
 
         Returns:
-            A list of scorers that match the filter criteria. If both `name` and `types`
-            are provided, the filters are combined with an AND condition, meaning only
-            scorers that match both the name and one of the types will be returned.
+            A list of scorers that match the filter criteria.
         """
-        filters = [ScorerTypeFilter(value=type_, operator=ScorerTypeFilterOperator.EQ) for type_ in (types or [])]
+        filters = []
+        if types:
+            if len(types) == 1:
+                filters.append(ScorerTypeFilter(value=types[0], operator=ScorerTypeFilterOperator.EQ))
+            else:
+                filters.append(ScorerTypeFilter(value=types, operator=ScorerTypeFilterOperator.ONE_OF))
+
         if name:
             filters.append(ScorerNameFilter(value=name, operator=ScorerNameFilterOperator.EQ))
 

--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -14,6 +14,8 @@ from galileo.resources.models import (
     ListScorersRequest,
     ListScorersResponse,
     ScorerConfig,
+    ScorerNameFilter,
+    ScorerNameFilterOperator,
     ScorerResponse,
     ScorerTypeFilter,
     ScorerTypeFilterOperator,
@@ -31,16 +33,19 @@ class Scorers:
     def __init__(self) -> None:
         self.config = GalileoPythonConfig.get()
 
-    def list(self, types: Optional[list[ScorerTypes]] = None) -> list[ScorerResponse]:
+    def list(self, name: Optional[str] = None, types: Optional[list[ScorerTypes]] = None) -> list[ScorerResponse]:
         """
         Args:
+            name: Name of the scorer to filter by.
             types: List of scorer types to filter by. Defaults to all scorers.
         Returns:
             List of scorers
         """
-        body = ListScorersRequest(
-            filters=[ScorerTypeFilter(value=type_, operator=ScorerTypeFilterOperator.EQ) for type_ in (types or [])]
-        )
+        filters = [ScorerTypeFilter(value=type_, operator=ScorerTypeFilterOperator.EQ) for type_ in (types or [])]
+        if name:
+            filters.append(ScorerNameFilter(value=name, operator=ScorerNameFilterOperator.EQ))
+
+        body = ListScorersRequest(filters=filters)
 
         all_scorers: list[ScorerResponse] = []
         starting_token = 0

--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -38,9 +38,10 @@ class Scorers:
         Lists scorers, optionally filtering by name and/or type.
 
         The filters are combined with an AND condition, while the values within the `types`
-        list are combined with an OR condition. For example, calling
-        `list(name="my_scorer", types=[ScorerTypes.llm, ScorerTypes.code])` will return
-        scorers where the name is "my_scorer" AND the type is either "llm" OR "code".
+        list are combined with an OR condition.
+
+        For example, calling `list(name="my_scorer", types=[ScorerTypes.llm, ScorerTypes.code])`
+        will return scorers where the name is "my_scorer" AND the type is either "llm" OR "code".
 
         Args:
             name: Name of the scorer to filter by.

--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -35,11 +35,16 @@ class Scorers:
 
     def list(self, name: Optional[str] = None, types: Optional[list[ScorerTypes]] = None) -> list[ScorerResponse]:
         """
+        Lists scorers, optionally filtering by name and/or type.
+
         Args:
             name: Name of the scorer to filter by.
             types: List of scorer types to filter by. Defaults to all scorers.
+
         Returns:
-            List of scorers
+            A list of scorers that match the filter criteria. If both `name` and `types`
+            are provided, the filters are combined with an AND condition, meaning only
+            scorers that match both the name and one of the types will be returned.
         """
         filters = [ScorerTypeFilter(value=type_, operator=ScorerTypeFilterOperator.EQ) for type_ in (types or [])]
         if name:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -226,19 +226,19 @@ class TestMetrics:
         mock_logger.info.assert_called_once_with("Created custom LLM metric: %s", "test_metric")
 
     @patch("galileo.metrics.delete_scorer_scorers_scorer_id_delete")
-    @patch("galileo.metrics.get_scorers")
-    def test_delete_metric_success(self, mock_get_scorers, mock_delete_scorer, mock_scorer_response) -> None:
+    @patch("galileo.scorers.Scorers.list")
+    def test_delete_metric_success(self, mock_list_scorers, mock_delete_scorer, mock_scorer_response) -> None:
         """Test successful deletion of a metric."""
         # Setup mocks
-        mock_get_scorers.return_value = [mock_scorer_response]
+        mock_list_scorers.return_value = [mock_scorer_response]
 
         metrics = Metrics()
 
         # Test deleting a metric
-        metrics.delete_metric(name="test_metric", scorer_type=ScorerTypes.LLM)
+        metrics.delete_metric(scorer_name="test_metric", scorer_type=ScorerTypes.LLM)
 
-        # Verify get_scorers was called
-        mock_get_scorers.assert_called_once_with(types=[ScorerTypes.LLM])
+        # Verify list was called
+        mock_list_scorers.assert_called_once_with(types=[ScorerTypes.LLM])
 
         # Verify delete_scorer was called
         mock_delete_scorer.sync.assert_called_once_with(
@@ -326,7 +326,7 @@ class TestPublicFunctions:
         mock_metrics_class.return_value = mock_metrics_instance
 
         # Call the public function
-        delete_metric(name="test_metric", scorer_type=ScorerTypes.LLM)
+        delete_metric(scorer_name="test_metric", scorer_type=ScorerTypes.LLM)
 
         # Verify Metrics class was instantiated
         mock_metrics_class.assert_called_once()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -229,7 +229,7 @@ class TestMetrics:
         metrics = Metrics()
         metrics.delete_metric(name="test_metric")
 
-        mock_list_scorers.assert_called_once_with()
+        mock_list_scorers.assert_called_once_with(name="test_metric")
         mock_delete_scorer.sync.assert_called_once_with(
             scorer_id=mock_scorer_response.id, client=metrics.config.api_client
         )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -225,18 +225,11 @@ class TestMetrics:
     @patch("galileo.scorers.Scorers.list")
     def test_delete_metric_success(self, mock_list_scorers, mock_delete_scorer, mock_scorer_response) -> None:
         """Test successful deletion of a metric."""
-        # Setup mocks
         mock_list_scorers.return_value = [mock_scorer_response]
-
         metrics = Metrics()
-
-        # Test deleting a metric
         metrics.delete_metric(name="test_metric")
 
-        # Verify list was called
         mock_list_scorers.assert_called_once_with()
-
-        # Verify delete_scorer was called
         mock_delete_scorer.sync.assert_called_once_with(
             scorer_id=mock_scorer_response.id, client=metrics.config.api_client
         )
@@ -244,12 +237,9 @@ class TestMetrics:
     @patch("galileo.scorers.Scorers.list")
     def test_delete_metric_not_found(self, mock_list_scorers) -> None:
         """Test deleting a metric that does not exist."""
-        # Setup mocks
         mock_list_scorers.return_value = []
-
         metrics = Metrics()
 
-        # Test that ValueError is raised
         with pytest.raises(ValueError, match="Scorer with name test_metric not found."):
             metrics.delete_metric(name="test_metric")
 
@@ -257,13 +247,10 @@ class TestMetrics:
     @patch("galileo.scorers.Scorers.list")
     def test_delete_metric_api_failure(self, mock_list_scorers, mock_delete_scorer, mock_scorer_response) -> None:
         """Test API failure when deleting a metric."""
-        # Setup mocks
         mock_list_scorers.return_value = [mock_scorer_response]
         mock_delete_scorer.sync.return_value = None
-
         metrics = Metrics()
 
-        # Test that ValueError is raised
         with pytest.raises(ValueError, match="Failed to delete metric."):
             metrics.delete_metric(name="test_metric")
 
@@ -343,17 +330,11 @@ class TestPublicFunctions:
     @patch("galileo.metrics.Metrics")
     def test_delete_metric_function(self, mock_metrics_class) -> None:
         """Test the public delete_metric function."""
-        # Setup mock
         mock_metrics_instance = Mock()
         mock_metrics_class.return_value = mock_metrics_instance
 
-        # Call the public function
         delete_metric(name="test_metric")
-
-        # Verify Metrics class was instantiated
         mock_metrics_class.assert_called_once()
-
-        # Verify the method was called with correct parameters
         mock_metrics_instance.delete_metric.assert_called_once_with("test_metric")
 
 

--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -193,3 +193,22 @@ def test_get_scorer_version_success(get_scorer_version_mock: Mock) -> None:
     # Access generated_scorer as a dictionary
     assert result.generated_scorer["name"] == "test_generated_scorer"
     assert result.registered_scorer is None
+
+
+@patch("galileo.scorers.list_scorers_with_filters_scorers_list_post")
+def test_list_with_multiple_types(mock_list_scorers: Mock) -> None:
+    """Test that listing scorers with multiple types uses the ONE_OF operator."""
+    mock_list_scorers.sync.return_value = ListScorersResponse(scorers=[])
+    scorers_client = Scorers()
+    scorers_client.list(types=[ScorerTypes.LLM, ScorerTypes.CODE])
+
+    mock_list_scorers.sync.assert_called_once()
+    call_args = mock_list_scorers.sync.call_args
+    body = call_args.kwargs["body"]
+
+    assert isinstance(body, ListScorersRequest)
+    assert len(body.filters) == 1
+    type_filter = body.filters[0]
+    assert isinstance(type_filter, ScorerTypeFilter)
+    assert type_filter.operator == ScorerTypeFilterOperator.ONE_OF
+    assert type_filter.value == [ScorerTypes.LLM, ScorerTypes.CODE]


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/40920/python-sdk-no-way-to-delete-a-metric [sc-40920]

**description:** No way to delete a metric in python SDK