### PR TITLE
feat: Paginate list scorers

### DIFF
--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -12,6 +12,7 @@ from galileo.resources.api.run_scorer_settings import (
 from galileo.resources.models import (
     HTTPValidationError,
     ListScorersRequest,
+    ListScorersResponse,
     ScorerConfig,
     ScorerResponse,
     ScorerTypeFilter,
@@ -30,7 +31,7 @@ class Scorers:
     def __init__(self) -> None:
         self.config = GalileoPythonConfig.get()
 
-    def list(self, types: Optional[list[ScorerTypes]] = None) -> Union[Unset, list[ScorerResponse]]:
+    def list(self, types: Optional[list[ScorerTypes]] = None) -> list[ScorerResponse]:
         """
         Args:
             types: List of scorer types to filter by. Defaults to all scorers.
@@ -40,8 +41,28 @@ class Scorers:
         body = ListScorersRequest(
             filters=[ScorerTypeFilter(value=type_, operator=ScorerTypeFilterOperator.EQ) for type_ in (types or [])]
         )
-        result = list_scorers_with_filters_scorers_list_post.sync(client=self.config.api_client, body=body)
-        return result.scorers
+
+        all_scorers: list[ScorerResponse] = []
+        starting_token = 0
+        limit = 100
+
+        while True:
+            result = list_scorers_with_filters_scorers_list_post.sync(
+                client=self.config.api_client, body=body, starting_token=starting_token, limit=limit
+            )
+
+            if not isinstance(result, ListScorersResponse):
+                raise ValueError(f"Failed to list scorers, got response: {result}")
+
+            if not isinstance(result.scorers, Unset) and result.scorers:
+                all_scorers.extend(result.scorers)
+
+            if result.next_starting_token is not None and not isinstance(result.next_starting_token, Unset):
+                starting_token = result.next_starting_token
+            else:
+                break
+
+        return all_scorers
 
     def get_scorer_version(self, scorer_id: UUID, version: int) -> Union[Unset, BaseScorerVersionResponse]:
         """

--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -44,11 +44,9 @@ class Scorers:
 
         all_scorers: list[ScorerResponse] = []
         starting_token = 0
-        limit = 100
-
         while True:
             result = list_scorers_with_filters_scorers_list_post.sync(
-                client=self.config.api_client, body=body, starting_token=starting_token, limit=limit
+                client=self.config.api_client, body=body, starting_token=starting_token
             )
 
             if not isinstance(result, ListScorersResponse):

--- a/src/galileo/scorers.py
+++ b/src/galileo/scorers.py
@@ -54,10 +54,10 @@ class Scorers:
             if not isinstance(result, ListScorersResponse):
                 raise ValueError(f"Failed to list scorers, got response: {result}")
 
-            if not isinstance(result.scorers, Unset) and result.scorers:
+            if not isinstance(result.scorers, Unset):
                 all_scorers.extend(result.scorers)
 
-            if result.next_starting_token is not None and not isinstance(result.next_starting_token, Unset):
+            if isinstance(result.next_starting_token, int):
                 starting_token = result.next_starting_token
             else:
                 break

--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -58,9 +58,7 @@ def test_list_all_scorers(list_scorers_mock: Mock) -> None:
     for r in results:
         actual[r.name] = r.scorer_type.name
     assert actual == {"agentic_workflow_success": "PRESET", "dummy_llm": "LLM"}
-    list_scorers_mock.sync.assert_called_once_with(
-        client=ANY, body=ListScorersRequest(filters=[]), starting_token=0, limit=100
-    )
+    list_scorers_mock.sync.assert_called_once_with(client=ANY, body=ListScorersRequest(filters=[]), starting_token=0)
 
 
 @patch("galileo.scorers.list_scorers_with_filters_scorers_list_post")
@@ -73,7 +71,6 @@ def test_list_all_scorers_preset_filter(list_scorers_mock: Mock) -> None:
             filters=[ScorerTypeFilter(operator=ScorerTypeFilterOperator.EQ, value=ScorerTypes.LLM)]
         ),
         starting_token=0,
-        limit=100,
     )
 
 
@@ -140,8 +137,8 @@ def test_list_all_scorers_paginated(list_scorers_mock: Mock) -> None:
 
     # Verify that the mock was called twice with the correct starting_token
     assert list_scorers_mock.sync.call_count == 2
-    list_scorers_mock.sync.assert_any_call(client=ANY, body=ListScorersRequest(filters=[]), starting_token=0, limit=100)
-    list_scorers_mock.sync.assert_any_call(client=ANY, body=ListScorersRequest(filters=[]), starting_token=1, limit=100)
+    list_scorers_mock.sync.assert_any_call(client=ANY, body=ListScorersRequest(filters=[]), starting_token=0)
+    list_scorers_mock.sync.assert_any_call(client=ANY, body=ListScorersRequest(filters=[]), starting_token=1)
 
 
 def create_mock_version_response():

--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -58,18 +58,90 @@ def test_list_all_scorers(list_scorers_mock: Mock) -> None:
     for r in results:
         actual[r.name] = r.scorer_type.name
     assert actual == {"agentic_workflow_success": "PRESET", "dummy_llm": "LLM"}
-    list_scorers_mock.sync.assert_called_once_with(client=ANY, body=ListScorersRequest(filters=[]))
+    list_scorers_mock.sync.assert_called_once_with(
+        client=ANY, body=ListScorersRequest(filters=[]), starting_token=0, limit=100
+    )
 
 
 @patch("galileo.scorers.list_scorers_with_filters_scorers_list_post")
 def test_list_all_scorers_preset_filter(list_scorers_mock: Mock) -> None:
+    list_scorers_mock.sync.return_value = ListScorersResponse(scorers=[])
     Scorers().list(types=[ScorerTypes.LLM])
     list_scorers_mock.sync.assert_called_once_with(
         client=ANY,
         body=ListScorersRequest(
             filters=[ScorerTypeFilter(operator=ScorerTypeFilterOperator.EQ, value=ScorerTypes.LLM)]
         ),
+        starting_token=0,
+        limit=100,
     )
+
+
+@patch("galileo.scorers.list_scorers_with_filters_scorers_list_post")
+def test_list_all_scorers_paginated(list_scorers_mock: Mock) -> None:
+    # Mock the first page of the response
+    page1_response = ListScorersResponse.from_dict(
+        {
+            "limit": 100,
+            "next_starting_token": 1,
+            "paginated": True,
+            "scorers": [
+                {
+                    "label": "Action Advancement",
+                    "id": "f7933a6d-7a65-4ce3-bfe4-b863109a04ee",
+                    "name": "agentic_workflow_success",
+                    "scorer_type": "preset",
+                    "tags": ["preset", "agents"],
+                    "created_at": "2025-03-28T18:54:02.848267+00:00",
+                    "created_by": "d351012a-dd92-4d0c-a356-57161b1377cd",
+                    "defaults": {"filters": None, "model_name": "GPT-4o", "num_judges": 5},
+                    "description": "Detects whether the user successfully accomplished or advanced towards their goal.",
+                    "included_fields": ["model_name", "num_judges", "filters"],
+                    "latest_version": None,
+                    "updated_at": "2025-03-28T18:54:02.848269+00:00",
+                }
+            ],
+            "starting_token": 0,
+        }
+    )
+
+    # Mock the second page of the response
+    page2_response = ListScorersResponse.from_dict(
+        {
+            "limit": 100,
+            "next_starting_token": None,
+            "paginated": True,
+            "scorers": [
+                {
+                    "label": "dummy",
+                    "id": "a7933a6d-7a65-4ce3-bfe4-b863109a0412",
+                    "name": "dummy_llm",
+                    "scorer_type": "llm",
+                    "tags": ["llm"],
+                    "created_at": "2025-03-28T18:54:02.848267+00:00",
+                    "created_by": "d351012a-dd92-4d0c-a356-57161b1377cd",
+                    "updated_at": "2025-03-28T18:54:02.848269+00:00",
+                }
+            ],
+            "starting_token": 1,
+        }
+    )
+
+    # Set the side_effect to return the two pages
+    list_scorers_mock.sync.side_effect = [page1_response, page2_response]
+
+    # Call the method under test
+    results = Scorers().list()
+
+    # Verify the results
+    assert len(results) == 2
+    actual = {r.name: r.scorer_type.name for r in results}
+    assert actual == {"agentic_workflow_success": "PRESET", "dummy_llm": "LLM"}
+
+    # Verify that the mock was called twice with the correct starting_token
+    assert list_scorers_mock.sync.call_count == 2
+    list_scorers_mock.sync.assert_any_call(client=ANY, body=ListScorersRequest(filters=[]), starting_token=0, limit=100)
+    list_scorers_mock.sync.assert_any_call(client=ANY, body=ListScorersRequest(filters=[]), starting_token=1, limit=100)
 
 
 def create_mock_version_response():


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/42082/do-tool-metrics-not-working-on-experiments [sc-42082]

**description:** List scorers endpoint is paginated but the call to it is not handling the pagination.