### PR TITLE
fix: Handle pagination for listing scorers using SDK call

### DIFF
--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -58,18 +58,117 @@ def test_list_all_scorers(list_scorers_mock: Mock) -> None:
     for r in results:
         actual[r.name] = r.scorer_type.name
     assert actual == {"agentic_workflow_success": "PRESET", "dummy_llm": "LLM"}
-    list_scorers_mock.sync.assert_called_once_with(client=ANY, body=ListScorersRequest(filters=[]))
+    list_scorers_mock.sync.assert_called_once_with(client=ANY, body=ListScorersRequest(filters=[]), starting_token=0)
 
 
 @patch("galileo.scorers.list_scorers_with_filters_scorers_list_post")
 def test_list_all_scorers_preset_filter(list_scorers_mock: Mock) -> None:
+    list_scorers_mock.sync.return_value = list_scorers_all()
     Scorers().list(types=[ScorerTypes.LLM])
     list_scorers_mock.sync.assert_called_once_with(
         client=ANY,
         body=ListScorersRequest(
             filters=[ScorerTypeFilter(operator=ScorerTypeFilterOperator.EQ, value=ScorerTypes.LLM)]
         ),
+        starting_token=0,
     )
+
+
+def list_scorers_paginated_page_1():
+    return ListScorersResponse.from_dict(
+        {
+            "limit": 2,
+            "next_starting_token": 2,
+            "paginated": True,
+            "scorers": [
+                {
+                    "label": "Tool Selection Quality",
+                    "id": "f7933a6d-7a65-4ce3-bfe4-b863109a04ee",
+                    "name": "tool_selection_quality",
+                    "scorer_type": "preset",
+                    "tags": ["preset", "tools"],
+                    "created_at": "2025-03-28T18:54:02.848267+00:00",
+                    "created_by": "d351012a-dd92-4d0c-a356-57161b1377cd",
+                    "defaults": {"filters": None, "model_name": "GPT-4o", "num_judges": 3},
+                    "description": "Evaluates tool selection quality.",
+                    "included_fields": ["model_name", "num_judges", "filters"],
+                    "latest_version": None,
+                    "updated_at": "2025-03-28T18:54:02.848269+00:00",
+                },
+                {
+                    "label": "Tool Error Rate",
+                    "id": "a7933a6d-7a65-4ce3-bfe4-b863109a0412",
+                    "name": "tool_error_rate",
+                    "scorer_type": "preset",
+                    "tags": ["preset", "tools"],
+                    "created_at": "2025-03-28T18:54:02.848267+00:00",
+                    "created_by": "d351012a-dd92-4d0c-a356-57161b1377cd",
+                    "defaults": {"filters": None, "model_name": "GPT-4o", "num_judges": 3},
+                    "description": "Evaluates tool error rate.",
+                    "included_fields": ["model_name", "num_judges", "filters"],
+                    "latest_version": None,
+                    "updated_at": "2025-03-28T18:54:02.848269+00:00",
+                },
+            ],
+            "starting_token": 0,
+        }
+    )
+
+
+def list_scorers_paginated_page_2():
+    return ListScorersResponse.from_dict(
+        {
+            "limit": 2,
+            "next_starting_token": None,
+            "paginated": True,
+            "scorers": [
+                {
+                    "label": "Final Scorer",
+                    "id": "c7933a6d-7a65-4ce3-bfe4-b863109a0413",
+                    "name": "final_scorer",
+                    "scorer_type": "preset",
+                    "tags": ["preset", "final"],
+                    "created_at": "2025-03-28T18:54:02.848267+00:00",
+                    "created_by": "d351012a-dd92-4d0c-a356-57161b1377cd",
+                    "defaults": {"filters": None, "model_name": "GPT-4o", "num_judges": 3},
+                    "description": "Final scorer.",
+                    "included_fields": ["model_name", "num_judges", "filters"],
+                    "latest_version": None,
+                    "updated_at": "2025-03-28T18:54:02.848269+00:00",
+                }
+            ],
+            "starting_token": 2,
+        }
+    )
+
+
+@patch("galileo.scorers.list_scorers_with_filters_scorers_list_post")
+def test_list_scorers_with_pagination(list_scorers_mock: Mock) -> None:
+    """Test that Scorers().list() correctly handles pagination by fetching all pages."""
+
+    # Setup mock to return different responses for different starting tokens
+    def mock_sync_side_effect(*args, **kwargs):
+        starting_token = kwargs.get("starting_token", 0)
+        if starting_token == 0:
+            return list_scorers_paginated_page_1()
+        elif starting_token == 2:
+            return list_scorers_paginated_page_2()
+        else:
+            raise ValueError(f"Unexpected starting_token: {starting_token}")
+
+    list_scorers_mock.sync.side_effect = mock_sync_side_effect
+
+    # Execute the method
+    results = Scorers().list()
+
+    # Verify results contain scorers from both pages
+    actual = {r.name: r.scorer_type.name for r in results}
+    assert actual == {"tool_selection_quality": "PRESET", "tool_error_rate": "PRESET", "final_scorer": "PRESET"}
+
+    # Verify both pages were fetched
+    assert list_scorers_mock.sync.call_count == 2
+    list_scorers_mock.sync.assert_any_call(client=ANY, body=ListScorersRequest(filters=[]), starting_token=0)
+    list_scorers_mock.sync.assert_any_call(client=ANY, body=ListScorersRequest(filters=[]), starting_token=2)
 
 
 def create_mock_version_response():


### PR DESCRIPTION
Shortucut: https://app.shortcut.com/galileo/story/42082/do-tool-metrics-not-working-on-experiments

The Problem:
- The /scorers/list API endpoint is paginated with a default limit of 100 scorers per request
- The Scorers().list() method only made one request and returned the first 100 scorers
- If tool_selection_quality and tool_error_rate were ranked beyond position #100, they weren't included in the response
- When create_metric_configs() in metrics.py tried to validate these metrics, they weren't found in the known_metrics dictionary
- This caused them to be incorrectly flagged as "non-existent metrics"

The fix:
- Loops through all pages instead of just fetching the first page
- Uses starting_token and next_starting_token to navigate pagination
- Accumulates all scorers from every page into a complete list
- Stops when next_starting_token is None (indicating the last page)