### PR TITLE
feat: Add project user management methods

### DIFF
--- a/src/galileo/projects.py
+++ b/src/galileo/projects.py
@@ -421,6 +421,7 @@ def share_project_with_user(
 ) -> UserCollaborator:
     """
     Share a project with a user.
+
     Parameters
     ----------
     project_id : str
@@ -429,10 +430,11 @@ def share_project_with_user(
         The ID of the user.
     role : CollaboratorRole
         The role to assign to the user.
+
     Returns
     -------
     UserCollaborator
-        The response from the server.
+        The created user collaborator object.
     """
     return Projects().share_project_with_user(project_id=project_id, user_id=user_id, role=role)
 
@@ -440,6 +442,7 @@ def share_project_with_user(
 def unshare_project_with_user(project_id: str, user_id: str) -> None:
     """
     Unshare a project with a user.
+
     Parameters
     ----------
     project_id : str
@@ -453,10 +456,12 @@ def unshare_project_with_user(project_id: str, user_id: str) -> None:
 def list_user_project_collaborators(project_id: str) -> list[UserCollaborator]:
     """
     List all users that a project is shared with.
+
     Parameters
     ----------
     project_id : str
         The ID of the project.
+
     Returns
     -------
     List[UserCollaborator]
@@ -470,6 +475,7 @@ def update_user_project_collaborator(
 ) -> UserCollaborator:
     """
     Update a user's role for a project.
+
     Parameters
     ----------
     project_id : str
@@ -478,9 +484,10 @@ def update_user_project_collaborator(
         The ID of the user.
     role : CollaboratorRole
         The new role to assign to the user.
+
     Returns
     -------
     UserCollaborator
-        The response from the server.
+        The updated user collaborator object.
     """
     return Projects().update_user_project_collaborator(project_id=project_id, user_id=user_id, role=role)

--- a/src/galileo/projects.py
+++ b/src/galileo/projects.py
@@ -279,12 +279,20 @@ class Projects(DecorateAllMethods):
         response = create_user_project_collaborators_projects_project_id_users_post.sync(
             project_id=project_id, client=self.config.api_client, body=body
         )
-        return response[0] if response else None
+        if isinstance(response, HTTPValidationError):
+            raise ValueError(response.detail)
+        if response is None:
+            raise ValueError(f"Failed to share project {project_id} with user {user_id}")
+        return response[0]
 
     def unshare_project_with_user(self, project_id: str, user_id: str) -> None:
-        delete_user_project_collaborator_projects_project_id_users_user_id_delete.sync(
+        response = delete_user_project_collaborator_projects_project_id_users_user_id_delete.sync(
             project_id=project_id, user_id=user_id, client=self.config.api_client
         )
+        if isinstance(response, HTTPValidationError):
+            raise ValueError(response.detail)
+        if response is None:
+            raise ValueError(f"Failed to unshare project {project_id} with user {user_id}")
 
     def list_user_project_collaborators(self, project_id: str) -> builtins.list[UserCollaborator]:
         all_collaborators: list[UserCollaborator] = []
@@ -294,11 +302,15 @@ class Projects(DecorateAllMethods):
             response = list_user_project_collaborators_projects_project_id_users_get.sync(
                 project_id=project_id, client=self.config.api_client, starting_token=starting_token
             )
+            if isinstance(response, HTTPValidationError):
+                raise ValueError(response.detail)
+            if response is None:
+                raise ValueError(f"Failed to list collaborators for project {project_id}")
 
-            if response and response.collaborators:
+            if response.collaborators:
                 all_collaborators.extend(response.collaborators)
 
-            if response and response.paginated and response.next_starting_token is not None:
+            if response.paginated and response.next_starting_token is not None:
                 starting_token = response.next_starting_token
             else:
                 starting_token = None
@@ -308,9 +320,14 @@ class Projects(DecorateAllMethods):
         self, project_id: str, user_id: str, role: CollaboratorRole = CollaboratorRole.VIEWER
     ) -> UserCollaborator:
         body = CollaboratorUpdate(role=role)
-        return update_user_project_collaborator_projects_project_id_users_user_id_patch.sync(
+        response = update_user_project_collaborator_projects_project_id_users_user_id_patch.sync(
             project_id=project_id, user_id=user_id, client=self.config.api_client, body=body
         )
+        if isinstance(response, HTTPValidationError):
+            raise ValueError(response.detail)
+        if response is None:
+            raise ValueError(f"Failed to update collaborator for project {project_id}")
+        return response
 
 
 #

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -21,7 +21,7 @@ class TestProjects:
         get_all_projects_projects_all_get.sync.side_effect = ValueError("unable to get all projects")
 
         projects_client = Projects()
-        # it doesn't trough exception, because we catch all and log
+        # It doesn't throw exception because we catch all and log
         projects_client.list()
 
         with caplog.at_level(logging.WARNING):
@@ -103,11 +103,38 @@ class TestProjects:
         projects_client.share_project_with_user(project_id="123", user_id="456")
         mock_create_user_project_collaborators.assert_called_once_with(project_id="123", client=ANY, body=ANY)
 
+    @patch("galileo.projects.create_user_project_collaborators_projects_project_id_users_post.sync")
+    def test_share_project_with_user_error(
+        self, mock_create_user_project_collaborators, caplog, enable_galileo_logging
+    ):
+        mock_create_user_project_collaborators.return_value = None
+        projects_client = Projects()
+        with caplog.at_level(logging.WARNING):
+            projects_client.share_project_with_user(project_id="123", user_id="456")
+            assert (
+                "Error occurred during execution: share_project_with_user: Failed to share project 123 with user 456"
+                in caplog.text
+            )
+
     @patch("galileo.projects.delete_user_project_collaborator_projects_project_id_users_user_id_delete.sync")
     def test_unshare_project_with_user(self, mock_delete_user_project_collaborator):
+        mock_delete_user_project_collaborator.return_value = True
         projects_client = Projects()
         projects_client.unshare_project_with_user(project_id="123", user_id="456")
         mock_delete_user_project_collaborator.assert_called_once_with(project_id="123", user_id="456", client=ANY)
+
+    @patch("galileo.projects.delete_user_project_collaborator_projects_project_id_users_user_id_delete.sync")
+    def test_unshare_project_with_user_error(
+        self, mock_delete_user_project_collaborator, caplog, enable_galileo_logging
+    ):
+        mock_delete_user_project_collaborator.return_value = None
+        projects_client = Projects()
+        with caplog.at_level(logging.WARNING):
+            projects_client.unshare_project_with_user(project_id="123", user_id="456")
+            assert (
+                "Error occurred during execution: unshare_project_with_user: Failed to unshare project 123 with user 456"
+                in caplog.text
+            )
 
     @patch("galileo.projects.list_user_project_collaborators_projects_project_id_users_get.sync")
     def test_list_user_project_collaborators(self, mock_list_user_project_collaborators):
@@ -120,6 +147,19 @@ class TestProjects:
         assert len(collaborators) == 2
         assert mock_list_user_project_collaborators.call_count == 2
 
+    @patch("galileo.projects.list_user_project_collaborators_projects_project_id_users_get.sync")
+    def test_list_user_project_collaborators_error(
+        self, mock_list_user_project_collaborators, caplog, enable_galileo_logging
+    ):
+        mock_list_user_project_collaborators.return_value = None
+        projects_client = Projects()
+        with caplog.at_level(logging.WARNING):
+            projects_client.list_user_project_collaborators(project_id="123")
+            assert (
+                "Error occurred during execution: list_user_project_collaborators: Failed to list collaborators for project 123"
+                in caplog.text
+            )
+
     @patch("galileo.projects.update_user_project_collaborator_projects_project_id_users_user_id_patch.sync")
     def test_update_user_project_collaborator(self, mock_update_user_project_collaborator):
         projects_client = Projects()
@@ -127,3 +167,16 @@ class TestProjects:
         mock_update_user_project_collaborator.assert_called_once_with(
             project_id="123", user_id="456", client=ANY, body=ANY
         )
+
+    @patch("galileo.projects.update_user_project_collaborator_projects_project_id_users_user_id_patch.sync")
+    def test_update_user_project_collaborator_error(
+        self, mock_update_user_project_collaborator, caplog, enable_galileo_logging
+    ):
+        mock_update_user_project_collaborator.return_value = None
+        projects_client = Projects()
+        with caplog.at_level(logging.WARNING):
+            projects_client.update_user_project_collaborator(project_id="123", user_id="456")
+            assert (
+                "Error occurred during execution: update_user_project_collaborator: Failed to update collaborator for project 123"
+                in caplog.text
+            )

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -95,3 +95,35 @@ class TestProjects:
         with patch.dict("os.environ", {"GALILEO_PROJECT": "my_project"}):
             Projects().get_with_env_fallbacks()
             get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
+
+    @patch("galileo.projects.create_user_project_collaborators_projects_project_id_users_post.sync")
+    def test_share_project_with_user(self, mock_create_user_project_collaborators):
+        mock_create_user_project_collaborators.return_value = [Mock()]
+        projects_client = Projects()
+        projects_client.share_project_with_user(project_id="123", user_id="456")
+        mock_create_user_project_collaborators.assert_called_once_with(project_id="123", client=ANY, body=ANY)
+
+    @patch("galileo.projects.delete_user_project_collaborator_projects_project_id_users_user_id_delete.sync")
+    def test_unshare_project_with_user(self, mock_delete_user_project_collaborator):
+        projects_client = Projects()
+        projects_client.unshare_project_with_user(project_id="123", user_id="456")
+        mock_delete_user_project_collaborator.assert_called_once_with(project_id="123", user_id="456", client=ANY)
+
+    @patch("galileo.projects.list_user_project_collaborators_projects_project_id_users_get.sync")
+    def test_list_user_project_collaborators(self, mock_list_user_project_collaborators):
+        mock_list_user_project_collaborators.side_effect = [
+            Mock(collaborators=[Mock()], paginated=True, next_starting_token=1),
+            Mock(collaborators=[Mock()], paginated=False, next_starting_token=None),
+        ]
+        projects_client = Projects()
+        collaborators = projects_client.list_user_project_collaborators(project_id="123")
+        assert len(collaborators) == 2
+        assert mock_list_user_project_collaborators.call_count == 2
+
+    @patch("galileo.projects.update_user_project_collaborator_projects_project_id_users_user_id_patch.sync")
+    def test_update_user_project_collaborator(self, mock_update_user_project_collaborator):
+        projects_client = Projects()
+        projects_client.update_user_project_collaborator(project_id="123", user_id="456")
+        mock_update_user_project_collaborator.assert_called_once_with(
+            project_id="123", user_id="456", client=ANY, body=ANY
+        )


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/42295/verizon-2-0-workflow-for-updating-user-permissions-on-projects#activity-42428 [sc-42428]

**description:** Support workflow for updating user permissions on projects

Verizon has workflows that require listing out projects, viewing all users those projects are shared with, and updating those permissions based on their changing org structure and company.