### PR TITLE
feat: Set default values for export_records

### DIFF
--- a/src/galileo/export.py
+++ b/src/galileo/export.py
@@ -34,6 +34,7 @@ class ExportClient:
     ) -> Iterator[dict[str, Any]]:
         if filters is None:
             filters = []
+
         response = export_records_stream(
             client=self.config.api_client,
             project_id=project_id,
@@ -89,6 +90,7 @@ def export_records(
     """
     if filters is None:
         filters = []
+
     if (log_stream_id is None) == (experiment_id is None):
         raise ValueError("Exactly one of log_stream_id or experiment_id must be provided.")
 

--- a/src/galileo/export.py
+++ b/src/galileo/export.py
@@ -23,7 +23,7 @@ class ExportClient:
     def records(
         self,
         project_id: str,
-        root_type: RootType = RootType.SESSION,
+        root_type: RootType = RootType.TRACE,
         filters: Optional[list[FilterType]] = None,
         sort: LogRecordsSortClause = LogRecordsSortClause(column_id="created_at", ascending=False),
         export_format: LLMExportFormat = LLMExportFormat.JSONL,
@@ -63,7 +63,7 @@ class ExportClient:
 
 def export_records(
     project_id: str,
-    root_type: RootType = RootType.SESSION,
+    root_type: RootType = RootType.TRACE,
     filters: Optional[list[FilterType]] = None,
     sort: LogRecordsSortClause = LogRecordsSortClause(column_id="created_at", ascending=False),
     export_format: LLMExportFormat = LLMExportFormat.JSONL,

--- a/src/galileo/export.py
+++ b/src/galileo/export.py
@@ -23,15 +23,17 @@ class ExportClient:
     def records(
         self,
         project_id: str,
-        root_type: RootType,
-        filters: list[FilterType],
-        sort: LogRecordsSortClause,
+        root_type: RootType = RootType.SESSION,
+        filters: Optional[list[FilterType]] = None,
+        sort: LogRecordsSortClause = LogRecordsSortClause(column_id="created_at", ascending=False),
         export_format: LLMExportFormat = LLMExportFormat.JSONL,
         log_stream_id: Optional[str] = None,
         experiment_id: Optional[str] = None,
         column_ids: Optional[list[str]] = None,
         redact: bool = True,
     ) -> Iterator[dict[str, Any]]:
+        if filters is None:
+            filters = []
         response = export_records_stream(
             client=self.config.api_client,
             project_id=project_id,
@@ -60,9 +62,9 @@ class ExportClient:
 
 def export_records(
     project_id: str,
-    root_type: RootType,
-    filters: list[FilterType],
-    sort: LogRecordsSortClause,
+    root_type: RootType = RootType.SESSION,
+    filters: Optional[list[FilterType]] = None,
+    sort: LogRecordsSortClause = LogRecordsSortClause(column_id="created_at", ascending=False),
     export_format: LLMExportFormat = LLMExportFormat.JSONL,
     log_stream_id: Optional[str] = None,
     experiment_id: Optional[str] = None,
@@ -85,6 +87,8 @@ def export_records(
     Returns:
         An iterator that yields each record as a dictionary.
     """
+    if filters is None:
+        filters = []
     if (log_stream_id is None) == (experiment_id is None):
         raise ValueError("Exactly one of log_stream_id or experiment_id must be provided.")
 

--- a/src/galileo/export.py
+++ b/src/galileo/export.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator
 from typing import Any, Optional
 
 from galileo.config import GalileoPythonConfig
+from galileo.log_streams import LogStreams
 from galileo.resources.api.trace.export_records_projects_project_id_export_records_post import (
     stream_detailed as export_records_stream,
 )
@@ -90,6 +91,11 @@ def export_records(
     """
     if filters is None:
         filters = []
+
+    if log_stream_id is None and experiment_id is None:
+        log_stream = LogStreams().get(name="default", project_id=project_id)
+        if log_stream:
+            log_stream_id = log_stream.id
 
     if (log_stream_id is None) == (experiment_id is None):
         raise ValueError("Exactly one of log_stream_id or experiment_id must be provided.")

--- a/src/galileo/export.py
+++ b/src/galileo/export.py
@@ -75,6 +75,8 @@ def export_records(
 ) -> Iterator[dict[str, Any]]:
     """Exports records from a Galileo project.
 
+    Defaults to the first logstream if `log_stream_id` and `experiment_id` are not provided.
+
     Args:
         project_id: The unique identifier of the project.
         root_type: The type of records to export.
@@ -93,9 +95,10 @@ def export_records(
         filters = []
 
     if log_stream_id is None and experiment_id is None:
-        log_stream = LogStreams().get(name="default", project_id=project_id)
-        if log_stream:
-            log_stream_id = log_stream.id
+        log_streams = LogStreams().list(project_id=project_id)
+        if log_streams:
+            sorted_log_streams = sorted(log_streams, key=lambda ls: ls.created_at)
+            log_stream_id = sorted_log_streams[0].id
 
     if (log_stream_id is None) == (experiment_id is None):
         raise ValueError("Exactly one of log_stream_id or experiment_id must be provided.")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -61,7 +61,7 @@ def test_export_records_with_defaults(mock_export_records_stream):
     mock_export_records_stream.assert_called_once()
     request_body = mock_export_records_stream.call_args.kwargs["body"]
     assert request_body.log_stream_id == log_stream_id
-    assert request_body.root_type == RootType.SESSION
+    assert request_body.root_type == RootType.TRACE
     assert request_body.filters == []
     assert request_body.sort == LogRecordsSortClause(column_id="created_at", ascending=False)
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -35,7 +35,6 @@ def test_export_records_basic(mock_export_records_stream):
             root_type=RootType.TRACE,
             column_ids=column_ids,
             sort=sort,
-            filters=[],
             log_stream_id=str(uuid4()),
         )
     )
@@ -51,25 +50,20 @@ def test_export_records_basic(mock_export_records_stream):
 
 
 @patch("galileo.export.export_records_stream")
-def test_export_records_with_log_stream_id(mock_export_records_stream):
+def test_export_records_with_defaults(mock_export_records_stream):
     project_id = str(uuid4())
     log_stream_id = str(uuid4())
     mock_response = httpx.Response(200, content=b"")
     mock_export_records_stream.return_value = mock_response
 
-    list(
-        export_records(
-            project_id=project_id,
-            root_type=RootType.TRACE,
-            log_stream_id=log_stream_id,
-            filters=[],
-            sort=LogRecordsSortClause(column_id="created_at", ascending=False),
-        )
-    )
+    list(export_records(project_id=project_id, log_stream_id=log_stream_id))
 
     mock_export_records_stream.assert_called_once()
     request_body = mock_export_records_stream.call_args.kwargs["body"]
     assert request_body.log_stream_id == log_stream_id
+    assert request_body.root_type == RootType.SESSION
+    assert request_body.filters == []
+    assert request_body.sort == LogRecordsSortClause(column_id="created_at", ascending=False)
 
 
 @patch("galileo.export.export_records_stream")


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/42678/update-the-export-library

**description:** Set default values for sort, filter and root_type for export_records. The API already sets default for sort and filter but for some reason the generated resources for these aren't optional and have no defaults so we set them to the server defaults. Additionally we set a default for root_type since it's required, and we default to the oldest logstream if no ids are provided.