### PR TITLE
feat: Update error handling to log with `warnings.warn()`

### DIFF
--- a/tests/test_logger_batch.py
+++ b/tests/test_logger_batch.py
@@ -1046,6 +1046,7 @@ def test_get_last_output() -> None:
         input="input",
         output="llm output",
         name="test-span",
+        model="test-model",
         created_at=datetime.datetime.now(),
         duration_ns=1_000_000,
         status_code=200,
@@ -1280,7 +1281,7 @@ def test_set_session_id(mock_traces_client: Mock, mock_projects_client: Mock, mo
 
     # Log a trace
     logger.start_trace(input="input", name="test-trace", created_at=datetime.datetime.now())
-    logger.add_llm_span(input="input", output="output")
+    logger.add_llm_span(input="input", output="output", model="test-model")
     logger.conclude("output", status_code=200)
     logger.flush()
 
@@ -1352,7 +1353,7 @@ def test_start_session_with_external_id(
 
     # Log a trace
     logger.start_trace(input="input", name="test-trace", created_at=datetime.datetime.now())
-    logger.add_llm_span(input="input", output="output")
+    logger.add_llm_span(input="input", output="output", model="test-model")
     logger.conclude("output", status_code=200)
     logger.flush()
 


### PR DESCRIPTION
# User description
**Shortcut:**

**Description:**
All SDK errors are caught by `catch_log.py` which takes the logs and logs them to a specific catch_log logger which required the developer to configure their code like this if they wanted to see logs:
```
import logging

# Get the exact logger that catch_log.py uses
galileo_logger = logging.getLogger('galileo.utils.catch_log')
galileo_logger.setLevel(logging.WARNING)
galileo_logger.addHandler(logging.StreamHandler())
```

There is little documentation on this, just [this](https://v2docs.galileo.ai/sdk-api/python/reference/utils/catch_log#catch-log) sdk method which isn't super helpful

This PR makes errors nosier by having them logged with `warnings.warn()` as opposed to having the user have to configure this unique catch_log.
**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhance the <code>galileo-python</code> SDK's error handling by modifying the <code>warn_catch_exception</code> and <code>async_warn_catch_exception</code> decorators in <code>catch_log.py</code> to emit visible warnings using <code>warnings.warn()</code>. This change ensures that exceptions caught within the SDK are more readily apparent to users without requiring specific logging configurations, improving the default observability experience.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/442?tool=ast&topic=LLM+Span+Test+Update>LLM Span Test Update</a>
        </td><td>Update <code>add_llm_span</code> calls in batch logger tests to include the <code>model</code> parameter, ensuring test compatibility and completeness.<details><summary>Modified files (1)</summary><ul><li>tests/test_logger_batch.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>pratyusha@galileo.ai</td><td>feat-Phase-1-Distribut...</td><td>December 12, 2025</td></tr>
<tr><td>jonathanrhone@rungalil...</td><td>fix-Redact-un-conclude...</td><td>November 03, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/442?tool=ast&topic=Error+Visibility>Error Visibility</a>
        </td><td>Improve error visibility by emitting warnings for exceptions caught within the SDK's <code>warn_catch_exception</code> and <code>async_warn_catch_exception</code> decorators, ensuring users are notified without requiring specific logging configurations.<details><summary>Modified files (1)</summary><ul><li>src/galileo/utils/catch_log.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>pratyusha@galileo.ai</td><td>feat-Phase-1-Distribut...</td><td>December 12, 2025</td></tr>
<tr><td>jimbobbennett@mac.com</td><td>fix-Fixing-docstrings-369</td><td>October 15, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/442?tool=ast>(Baz)</a>.