### PR TITLE
docs(datasets): document asymmetric NotFoundError vs None behavior for get_dataset

### DIFF
--- a/src/galileo/__future__/dataset.py
+++ b/src/galileo/__future__/dataset.py
@@ -195,24 +195,33 @@ class Dataset(StateManagementMixin):
         """
         Get an existing dataset by ID or name.
 
+        .. note::
+            Lookup behavior differs depending on which parameter is used:
+
+            - **By ID**: the API performs a direct lookup. If no dataset with that ID exists,
+              a ``NotFoundError`` is raised.
+            - **By name**: the API performs a filtered list query. If no dataset with that name
+              exists, ``None`` is returned (no exception is raised).
+
         Args:
             id (Optional[str]): The dataset ID.
             name (Optional[str]): The dataset name.
 
         Returns
         -------
-            Optional[Dataset]: The dataset if found, None otherwise.
+            Optional[Dataset]: The dataset if found, or ``None`` if looked up by name and no match exists.
 
         Raises
         ------
+            NotFoundError: If looked up by ID and no dataset with that ID exists.
             ValueError: If neither or both id and name are provided.
 
         Examples
         --------
-            # Get by name
+            # Get by name — returns None if not found
             dataset = Dataset.get(name="geography-questions")
 
-            # Get by ID
+            # Get by ID — raises NotFoundError if not found
             dataset = Dataset.get(id="dataset-123")
         """
         datasets_service = Datasets()

--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -285,6 +285,14 @@ class Datasets:
 
         Optionally validates that the dataset is used in a specific project.
 
+        .. note::
+            Lookup behavior differs depending on which parameter is used:
+
+            - **By ID**: the API performs a direct lookup. If no dataset with that ID exists,
+              a ``NotFoundError`` is raised.
+            - **By name**: the API performs a filtered list query. If no dataset with that name
+              exists, ``None`` is returned (no exception is raised).
+
         Parameters
         ----------
         id : str
@@ -300,17 +308,17 @@ class Datasets:
 
         Returns
         -------
-        Dataset
-            The dataset.
+        Optional[Dataset]
+            The dataset if found, or ``None`` if looked up by name and no match exists.
 
         Raises
         ------
+        NotFoundError
+            If looked up by ID and no dataset with that ID exists.
         ValueError
             If neither or both `id` and `name` are provided, if both project_id and project_name
             are provided, or if the specified project does not exist, or if the dataset is not
             used in the specified project.
-        errors.UnexpectedStatus
-            If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException
             If the request takes longer than Client.timeout.
 
@@ -666,6 +674,14 @@ def get_dataset(
 
     Optionally validates that the dataset is used in a specific project.
 
+    .. note::
+        Lookup behavior differs depending on which parameter is used:
+
+        - **By ID**: the API performs a direct lookup. If no dataset with that ID exists,
+          a ``NotFoundError`` is raised.
+        - **By name**: the API performs a filtered list query. If no dataset with that name
+          exists, ``None`` is returned (no exception is raised).
+
     Parameters
     ----------
     id : str
@@ -679,17 +695,17 @@ def get_dataset(
 
     Returns
     -------
-    Dataset
-        The dataset.
+    Optional[Dataset]
+        The dataset if found, or ``None`` if looked up by name and no match exists.
 
     Raises
     ------
+    NotFoundError
+        If looked up by ID and no dataset with that ID exists.
     ValueError
         If neither or both `id` and `name` are provided, if both project_id and project_name
         are provided, or if the specified project does not exist, or if the dataset is not
         used in the specified project.
-    errors.UnexpectedStatus
-        If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
     httpx.TimeoutException
         If the request takes longer than Client.timeout.
 


### PR DESCRIPTION
# User description
**Shortcut:**
[get_dataset by ID throws NotFoundError but by name returns None](https://app.shortcut.com/galileo/story/55067/qa2-0-sdk-get-dataset-by-id-throws-notfounderror-but-by-name-returns-none)

**Description:**

   - Document the inconsistent lookup behavior of get_dataset / Datasets.get / Dataset.get
  across both the classic and __future__ SDK APIs:
   - By ID: the underlying API performs a direct GET /datasets/{id} request, which returns
  HTTP 404 when not found — causing a NotFoundError to be raised before the SDK can intercept
   it
   - By name: the underlying API performs a filtered list query, which returns an empty list
   when not found — causing the SDK to return None instead of raising

  Notes

  This is a documentation-only change. The behavior itself is not modified — this PR makes
  the asymmetry explicit so callers know what to expect and can handle both cases correctly:

```
  # By name — check for None
  dataset = get_dataset(name="my-dataset")
  if dataset is None:
      ...

  # By ID — catch NotFoundError
  from galileo.exceptions import NotFoundError
  try:
      dataset = get_dataset(id="dataset-123")
  except NotFoundError:
      ...
   ```

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify dataset lookup behavior in <code>Datasets.get</code> by documenting that ID queries raise <code>NotFoundError</code> while name queries return <code>None</code>, so callers know what to expect. Describe the same asymmetry in the __future__ <code>Dataset.get</code> method so future-API consumers can decide whether to catch the exception or handle a None return value.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bipin@galileo.ai</td><td>fix-normalize-ground_t...</td><td>February 18, 2026</td></tr>
<tr><td>vamaq@users.noreply.gi...</td><td>fix-dataset-204-respon...</td><td>February 07, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/495?tool=ast>(Baz)</a>.