### PR TITLE
feat: add IngestTraces client for dedicated ingest service

### DIFF
--- a/galileo-adk/src/galileo_adk/trace_builder.py
+++ b/galileo-adk/src/galileo_adk/trace_builder.py
@@ -21,11 +21,12 @@ from datetime import datetime
 from typing import Any
 
 from galileo_core.schemas.logging.agent import AgentType
-from galileo_core.schemas.logging.span import AgentSpan, LlmSpan, RetrieverSpan, ToolSpan, WorkflowSpan
-from galileo_core.schemas.logging.trace import Trace
+from galileo_core.schemas.logging.span import LlmMetrics, RetrieverSpan, ToolSpan
+from galileo_core.schemas.logging.step import Metrics
 from galileo_core.schemas.shared.traces_logger import TracesLogger
 from pydantic import PrivateAttr
 
+from galileo.schema.logged import LoggedAgentSpan, LoggedLlmSpan, LoggedTrace, LoggedWorkflowSpan
 from galileo.schema.trace import TracesIngestRequest
 from galileo.utils.retrievers import convert_to_documents
 
@@ -65,7 +66,7 @@ class TraceBuilder(TracesLogger):
     """
 
     # Public fields (Pydantic fields)
-    traces: list[Trace] = []
+    traces: list[LoggedTrace] = []
     session_id: str | None = None
 
     # Private attributes (use PrivateAttr for non-field attributes)
@@ -84,6 +85,46 @@ class TraceBuilder(TracesLogger):
         super().__init__(**data)
         self._ingestion_hook = ingestion_hook
         self._session_external_id = None
+
+    def add_trace(
+        self,
+        input: str,
+        redacted_input: str | None = None,
+        output: str | None = None,
+        redacted_output: str | None = None,
+        name: str | None = None,
+        created_at: datetime | None = None,
+        duration_ns: int | None = None,
+        user_metadata: dict[str, str] | None = None,
+        tags: list[str] | None = None,
+        dataset_input: str | None = None,
+        dataset_output: str | None = None,
+        dataset_metadata: dict[str, str] | None = None,
+        external_id: str | None = None,
+        id: uuid.UUID | None = None,
+    ) -> LoggedTrace:
+        if self.current_parent() is not None:
+            raise ValueError("You must conclude the existing trace before adding a new one.")
+        trace = LoggedTrace(
+            input=input,
+            redacted_input=redacted_input,
+            output=output,
+            redacted_output=redacted_output,
+            name=name,
+            created_at=created_at,
+            user_metadata=user_metadata,
+            tags=tags,
+            metrics=Metrics(duration_ns=duration_ns),
+            dataset_input=dataset_input,
+            dataset_output=dataset_output,
+            dataset_metadata=dataset_metadata if dataset_metadata is not None else {},
+            external_id=external_id,
+            id=id,
+        )
+        trace._parent = None
+        self.traces.append(trace)
+        self._set_current_parent(trace)
+        return trace
 
     @staticmethod
     def _convert_metadata_value(v: Any) -> str:
@@ -107,7 +148,7 @@ class TraceBuilder(TracesLogger):
         dataset_output: str | None = None,
         dataset_metadata: dict[str, MetadataValue] | None = None,
         external_id: str | None = None,
-    ) -> Trace:
+    ) -> LoggedTrace:
         """Create a new trace and add it to the list of traces.
 
         This method mirrors GalileoLogger.start_trace() for API compatibility
@@ -184,26 +225,30 @@ class TraceBuilder(TracesLogger):
         tags: list[str] | None = None,
         step_number: int | None = None,
         status_code: int | None = None,
-    ) -> WorkflowSpan:
+    ) -> LoggedWorkflowSpan:
         """Add a workflow span to the current parent.
 
         This method wraps TracesLogger.add_workflow_span() to accept
         `metadata` parameter (for GalileoBaseHandler compatibility).
         """
-        span = super().add_workflow_span(
-            id=uuid.uuid4(),
+        parent = self.current_parent()
+        span = LoggedWorkflowSpan(
             input=input,
             redacted_input=redacted_input,
             output=output,
             redacted_output=redacted_output,
             name=name,
-            duration_ns=duration_ns,
-            created_at=created_at,
+            created_at=self._get_child_span_timestamp() if created_at is None else created_at,
             user_metadata=metadata,
             tags=tags,
+            metrics=Metrics(duration_ns=duration_ns),
+            id=uuid.uuid4(),
             step_number=step_number,
         )
-        if span is not None and status_code is not None:
+        span._parent = parent
+        self.add_child_span_to_parent(span)
+        self._set_current_parent(span)
+        if status_code is not None:
             span.status_code = status_code
         return span
 
@@ -221,27 +266,31 @@ class TraceBuilder(TracesLogger):
         agent_type: AgentType | None = None,
         step_number: int | None = None,
         status_code: int | None = None,
-    ) -> AgentSpan:
+    ) -> LoggedAgentSpan:
         """Add an agent span to the current parent.
 
         This method wraps TracesLogger.add_agent_span() to accept
         `metadata` parameter (for GalileoBaseHandler compatibility).
         """
-        span = super().add_agent_span(
-            id=uuid.uuid4(),
+        parent = self.current_parent()
+        span = LoggedAgentSpan(
             input=input,
             redacted_input=redacted_input,
             output=output,
             redacted_output=redacted_output,
             name=name,
-            duration_ns=duration_ns,
-            created_at=created_at,
+            created_at=self._get_child_span_timestamp() if created_at is None else created_at,
             user_metadata=metadata,
             tags=tags,
+            metrics=Metrics(duration_ns=duration_ns),
             agent_type=agent_type,
+            id=uuid.uuid4(),
             step_number=step_number,
         )
-        if span is not None and status_code is not None:
+        span._parent = parent
+        self.add_child_span_to_parent(span)
+        self._set_current_parent(span)
+        if status_code is not None:
             span.status_code = status_code
         return span
 
@@ -266,14 +315,13 @@ class TraceBuilder(TracesLogger):
         time_to_first_token_ns: int | None = None,
         step_number: int | None = None,
         events: list[Any] | None = None,
-    ) -> LlmSpan:
+    ) -> LoggedLlmSpan:
         """Add an LLM span to the current parent.
 
         This method wraps TracesLogger.add_llm_span() to accept
         `metadata` parameter (for GalileoBaseHandler compatibility).
         """
-        return super().add_llm_span(
-            id=uuid.uuid4(),
+        span = LoggedLlmSpan(
             input=input,
             output=output,
             model=model,
@@ -281,19 +329,24 @@ class TraceBuilder(TracesLogger):
             redacted_output=redacted_output,
             tools=tools,
             name=name,
-            created_at=created_at,
-            duration_ns=duration_ns,
+            created_at=self._get_child_span_timestamp() if created_at is None else created_at,
             user_metadata=metadata,
             tags=tags,
-            num_input_tokens=num_input_tokens,
-            num_output_tokens=num_output_tokens,
-            total_tokens=total_tokens,
+            metrics=LlmMetrics(
+                duration_ns=duration_ns,
+                num_input_tokens=num_input_tokens,
+                num_output_tokens=num_output_tokens,
+                num_total_tokens=total_tokens,
+                time_to_first_token_ns=time_to_first_token_ns,
+            ),
+            events=events,
             temperature=temperature,
             status_code=status_code,
-            time_to_first_token_ns=time_to_first_token_ns,
+            id=uuid.uuid4(),
             step_number=step_number,
-            events=events,
         )
+        self.add_child_span_to_parent(span)
+        return span
 
     def add_tool_span(
         self,

--- a/src/galileo/constants/routes.py
+++ b/src/galileo/constants/routes.py
@@ -23,3 +23,6 @@ class Routes(str, Enum):
 
     sessions = "/v2/projects/{project_id}/sessions"
     sessions_search = "/v2/projects/{project_id}/sessions/search"
+
+    ingest_traces = "/ingest/traces/{project_id}"
+    ingest_spans = "/ingest/spans/{project_id}"

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -1031,13 +1031,11 @@ class GalileoLogger(TracesLogger):
         if self.current_parent() is not None:
             raise ValueError("A trace cannot be created within a parent trace or span, it must always be the root.")
 
-        # Trace-level I/O is serialized to string; the child LoggedLlmSpan
-        # preserves the full structured/multimodal content.
         trace = LoggedTrace(
-            input=serialize_to_str(input),
-            redacted_input=serialize_to_str(redacted_input) if redacted_input else None,
-            output=serialize_to_str(output),
-            redacted_output=serialize_to_str(redacted_output) if redacted_output else None,
+            input=input,
+            redacted_input=redacted_input,
+            output=output,
+            redacted_output=redacted_output,
             name=name,
             created_at=created_at,
             user_metadata=metadata,

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -4,6 +4,7 @@ import copy
 import inspect
 import json
 import logging
+import os
 import time
 import uuid
 from datetime import datetime
@@ -31,7 +32,7 @@ from galileo.schema.trace import (
     TracesIngestRequest,
     TraceUpdateRequest,
 )
-from galileo.traces import Traces
+from galileo.traces import IngestTraces, Traces
 from galileo.utils.decorators import (
     async_warn_catch_exception,
     nop_async,
@@ -153,6 +154,7 @@ class GalileoLogger(TracesLogger):
 
     _logger = logging.getLogger("galileo.logger")
     _traces_client: Optional["Traces"] = None
+    _ingest_client: Optional["IngestTraces"] = None
     _task_handler: ThreadPoolTaskHandler
     _trace_completion_submitted: bool
 
@@ -305,9 +307,14 @@ class GalileoLogger(TracesLogger):
                 self._traces_client = Traces(project_id=self.project_id, log_stream_id=self.log_stream_id)
             elif self.experiment_id:
                 self._traces_client = Traces(project_id=self.project_id, experiment_id=self.experiment_id)
+
+            if os.environ.get("GALILEO_INGEST_URL"):
+                if self.log_stream_id:
+                    self._ingest_client = IngestTraces(project_id=self.project_id, log_stream_id=self.log_stream_id)
+                elif self.experiment_id:
+                    self._ingest_client = IngestTraces(project_id=self.project_id, experiment_id=self.experiment_id)
         else:
-            # ingestion_hook path: Traces client not created eagerly.
-            # If the user later calls ingest_traces(), it will be created lazily.
+            # ingestion_hook path: clients not created eagerly.
             self._traces_client = None
 
         # If continuing an existing distributed trace, create local stubs instead of
@@ -348,18 +355,32 @@ class GalileoLogger(TracesLogger):
         else:
             self.log_stream_id = log_stream_obj.id
 
-    def _create_traces_client(self) -> Traces:
-        """Lazily create a Traces client when needed (e.g. ingestion_hook users calling ingest_traces)."""
-        self._logger.info("Creating Traces client lazily for explicit ingest_traces call.")
+    def _ensure_project_and_log_stream(self) -> None:
+        """Ensure project_id and log_stream_id/experiment_id are initialized."""
         if not self.project_id:
             self._init_project()
         if not (self.log_stream_id or self.experiment_id):
             self._init_log_stream()
+
+    def _create_traces_client(self) -> Traces:
+        """Lazily create a Traces client when needed (e.g. ingestion_hook users calling ingest_traces)."""
+        self._logger.info("Creating Traces client lazily.")
+        self._ensure_project_and_log_stream()
         if self.log_stream_id:
             return Traces(project_id=self.project_id, log_stream_id=self.log_stream_id)
         if self.experiment_id:
             return Traces(project_id=self.project_id, experiment_id=self.experiment_id)
         raise GalileoLoggerException("Cannot create Traces client: no log_stream_id or experiment_id available.")
+
+    def _create_ingest_client(self) -> IngestTraces:
+        """Lazily create an IngestTraces client for the dedicated ingest service."""
+        self._logger.info("Creating IngestTraces client lazily.")
+        self._ensure_project_and_log_stream()
+        if self.log_stream_id:
+            return IngestTraces(project_id=self.project_id, log_stream_id=self.log_stream_id)
+        if self.experiment_id:
+            return IngestTraces(project_id=self.project_id, experiment_id=self.experiment_id)
+        raise GalileoLoggerException("Cannot create IngestTraces client: no log_stream_id or experiment_id available.")
 
     def _init_distributed_trace_stubs(self) -> None:
         """
@@ -514,7 +535,8 @@ class GalileoLogger(TracesLogger):
         )
         @retry_on_transient_http_error
         async def ingest_traces_with_backoff(request: Any) -> None:
-            return await self._traces_client.ingest_traces(request)
+            client = self._ingest_client or self._traces_client
+            return await client.ingest_traces(request)
 
         self._task_handler.submit_task(
             task_id, lambda: ingest_traces_with_backoff(traces_ingest_request), dependent_on_prev=False
@@ -564,7 +586,8 @@ class GalileoLogger(TracesLogger):
         )
         @retry_on_transient_http_error
         async def ingest_spans_with_backoff(request: Any) -> None:
-            return await self._traces_client.ingest_spans(request)
+            client = self._ingest_client or self._traces_client
+            return await client.ingest_spans(request)
 
         self._task_handler.submit_task(
             task_id, lambda: ingest_spans_with_backoff(spans_ingest_request), dependent_on_prev=False
@@ -1901,7 +1924,8 @@ class GalileoLogger(TracesLogger):
             else:
                 self._ingestion_hook(traces_ingest_request)
         else:
-            await self._traces_client.ingest_traces(traces_ingest_request)
+            client = self._ingest_client or self._traces_client
+            await client.ingest_traces(traces_ingest_request)
 
         self._logger.info(f"Successfully flushed {trace_count} {'trace' if trace_count == 1 else 'traces'}.")
 
@@ -2095,9 +2119,13 @@ class GalileoLogger(TracesLogger):
 
         Can be used in combination with the `ingestion_hook` to ingest modified traces.
         """
-        if self._traces_client is None:
-            self._traces_client = self._create_traces_client()
-        await self._traces_client.ingest_traces(ingest_request)
+        if self._ingest_client is None and os.environ.get("GALILEO_INGEST_URL"):
+            self._ingest_client = self._create_ingest_client()
+        client = self._ingest_client or self._traces_client
+        if client is None:
+            client = self._create_traces_client()
+            self._traces_client = client
+        await client.ingest_traces(ingest_request)
 
     @nop_sync
     @warn_catch_exception(exceptions=(Exception,))
@@ -2107,6 +2135,4 @@ class GalileoLogger(TracesLogger):
 
         Can be used in combination with the `ingestion_hook` to ingest modified traces.
         """
-        if self._traces_client is None:
-            self._traces_client = self._create_traces_client()
         return async_run(self.async_ingest_traces(ingest_request))

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -17,6 +17,7 @@ from galileo.exceptions import GalileoLoggerException
 from galileo.log_streams import LogStreams
 from galileo.logger.task_handler import ThreadPoolTaskHandler
 from galileo.projects import Projects
+from galileo.schema.logged import IngestInputType, LoggedAgentSpan, LoggedLlmSpan, LoggedTrace, LoggedWorkflowSpan
 from galileo.schema.metrics import LocalMetricConfig
 from galileo.schema.trace import (
     LogRecordsSearchFilter,
@@ -52,7 +53,7 @@ from galileo_core.helpers.execution import async_run
 from galileo_core.schemas.logging.agent import AgentType
 from galileo_core.schemas.logging.llm import Event
 from galileo_core.schemas.logging.span import (
-    AgentSpan,
+    LlmMetrics,
     LlmSpan,
     LlmSpanAllowedInputType,
     LlmSpanAllowedOutputType,
@@ -60,9 +61,8 @@ from galileo_core.schemas.logging.span import (
     Span,
     StepWithChildSpans,
     ToolSpan,
-    WorkflowSpan,
 )
-from galileo_core.schemas.logging.step import BaseStep, Metrics, StepAllowedInputType, StepType
+from galileo_core.schemas.logging.step import BaseStep, Metrics, StepType
 from galileo_core.schemas.logging.trace import Trace
 from galileo_core.schemas.protect.payload import Payload
 from galileo_core.schemas.protect.response import Response
@@ -376,7 +376,7 @@ class GalileoLogger(TracesLogger):
 
         Note: trace_id and span_id are already validated as UUIDs in __init__
         """
-        stub_trace = Trace(
+        stub_trace = LoggedTrace(
             input="",
             name=STUB_TRACE_NAME,
             created_at=datetime.now(),
@@ -391,7 +391,7 @@ class GalileoLogger(TracesLogger):
 
         if self.span_id:
             # If span_id is provided, also add the span (it's the immediate parent)
-            stub_span = WorkflowSpan(
+            stub_span = LoggedWorkflowSpan(
                 input="",
                 name="stub_parent_span",
                 created_at=datetime.now(),
@@ -401,6 +401,46 @@ class GalileoLogger(TracesLogger):
             # Set parent pointer and update current parent
             stub_span._parent = stub_trace
             self._set_current_parent(stub_span)
+
+    def add_trace(
+        self,
+        input: str,
+        redacted_input: Optional[str] = None,
+        output: Optional[str] = None,
+        redacted_output: Optional[str] = None,
+        name: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+        duration_ns: Optional[int] = None,
+        user_metadata: Optional[dict[str, str]] = None,
+        tags: Optional[list[str]] = None,
+        dataset_input: Optional[str] = None,
+        dataset_output: Optional[str] = None,
+        dataset_metadata: Optional[dict[str, str]] = None,
+        external_id: Optional[str] = None,
+        id: Optional[uuid.UUID] = None,
+    ) -> LoggedTrace:
+        if self.current_parent() is not None:
+            raise ValueError("You must conclude the existing trace before adding a new one.")
+        trace = LoggedTrace(
+            input=input,
+            redacted_input=redacted_input,
+            output=output,
+            redacted_output=redacted_output,
+            name=name,
+            created_at=created_at,
+            user_metadata=user_metadata,
+            tags=tags,
+            metrics=Metrics(duration_ns=duration_ns),
+            dataset_input=dataset_input,
+            dataset_output=dataset_output,
+            dataset_metadata=dataset_metadata if dataset_metadata is not None else {},
+            external_id=external_id,
+            id=id,
+        )
+        trace._parent = None
+        self.traces.append(trace)
+        self._set_current_parent(trace)
+        return trace
 
     @staticmethod
     def _convert_metadata_value(v: Any) -> str:
@@ -655,7 +695,7 @@ class GalileoLogger(TracesLogger):
     @nop_sync
     @warn_catch_exception(exceptions=(Exception,))
     def _ingest_step_streaming(self, step: StepWithChildSpans, is_complete: bool = False) -> None:
-        if isinstance(step, Trace):
+        if isinstance(step, LoggedTrace):
             self._ingest_trace_streaming(step, is_complete=is_complete)
         else:
             self._ingest_span_streaming(step)
@@ -663,7 +703,7 @@ class GalileoLogger(TracesLogger):
     @nop_sync
     @warn_catch_exception(exceptions=(Exception,))
     def _update_step_streaming(self, step: StepWithChildSpans, is_complete: bool = False) -> None:
-        if isinstance(step, Trace):
+        if isinstance(step, LoggedTrace):
             self._update_trace_streaming(step, is_complete=is_complete)
         else:
             self._update_span_streaming(step)
@@ -752,8 +792,8 @@ class GalileoLogger(TracesLogger):
     @warn_catch_exception(exceptions=(Exception,))
     def start_trace(
         self,
-        input: StepAllowedInputType | dict,
-        redacted_input: Optional[StepAllowedInputType | dict] = None,
+        input: Union[IngestInputType, dict],
+        redacted_input: Optional[Union[IngestInputType, dict]] = None,
         name: Optional[str] = None,
         duration_ns: Optional[int] = None,
         created_at: Optional[datetime] = None,
@@ -763,21 +803,22 @@ class GalileoLogger(TracesLogger):
         dataset_output: Optional[str] = None,
         dataset_metadata: Optional[dict[str, MetadataValue]] = None,
         external_id: Optional[str] = None,
-    ) -> Trace:
+    ) -> LoggedTrace:
         """
         Create a new trace and add it to the list of traces.
         Once this trace is complete, you can close it out by calling conclude().
 
         Parameters
         ----------
-        input: StepAllowedInputType | dict
+        input: IngestInputType | dict
             Input to the node.
-            Expected format: String, dict (auto-converted to JSON), or sequence of Message objects.
+            Expected format: String, dict (auto-converted to JSON), sequence of Message objects,
+            or sequence of LoggedMessage objects with multimodal content blocks.
             Examples -
                 - String: "User query: What is the weather today?"
                 - Dict: `{"query": "hello", "context": "world"}` (auto-converted to JSON string)
-                - Messages: `[Message(content="Hello", role=MessageRole.user)]`
-        redacted_input: Optional[StepAllowedInputType | dict]
+                - Messages: `[LoggedMessage(content="Hello", role=MessageRole.user)]`
+        redacted_input: Optional[IngestInputType | dict]
             Input that removes any sensitive information (redacted input).
             Same format as input parameter.
         name: Optional[str]
@@ -809,7 +850,7 @@ class GalileoLogger(TracesLogger):
 
         Returns
         -------
-        Trace
+        LoggedTrace
             The created trace.
         """
         # Auto-convert dict input to JSON string (addresses common user mistake)
@@ -876,7 +917,7 @@ class GalileoLogger(TracesLogger):
         dataset_output: Optional[str] = None,
         dataset_metadata: Optional[dict[str, MetadataValue]] = None,
         span_step_number: Optional[int] = None,
-    ) -> Trace:
+    ) -> LoggedTrace:
         """
         Create a new trace with a single span and add it to the list of traces.
         The trace is automatically concluded.
@@ -955,7 +996,7 @@ class GalileoLogger(TracesLogger):
 
         Returns
         -------
-        Trace
+        LoggedTrace
             The created trace.
         """
         # Auto-convert non-string metadata values to strings
@@ -964,31 +1005,55 @@ class GalileoLogger(TracesLogger):
         if dataset_metadata:
             dataset_metadata = {k: GalileoLogger._convert_metadata_value(v) for k, v in dataset_metadata.items()}
 
-        trace = super().add_single_llm_span_trace(
-            input=input,
-            output=output,
-            redacted_input=redacted_input,
-            redacted_output=redacted_output,
-            model=model,
-            tools=tools,
+        if self.current_parent() is not None:
+            raise ValueError("A trace cannot be created within a parent trace or span, it must always be the root.")
+
+        # Trace-level I/O is serialized to string; the child LoggedLlmSpan
+        # preserves the full structured/multimodal content.
+        trace = LoggedTrace(
+            input=serialize_to_str(input),
+            redacted_input=serialize_to_str(redacted_input) if redacted_input else None,
+            output=serialize_to_str(output),
+            redacted_output=serialize_to_str(redacted_output) if redacted_output else None,
             name=name,
             created_at=created_at,
-            duration_ns=duration_ns,
             user_metadata=metadata,
             tags=tags,
-            num_input_tokens=num_input_tokens,
-            num_output_tokens=num_output_tokens,
-            total_tokens=total_tokens,
-            temperature=temperature,
-            status_code=status_code,
-            time_to_first_token_ns=time_to_first_token_ns,
             dataset_input=dataset_input,
             dataset_output=dataset_output,
-            dataset_metadata=dataset_metadata,
-            span_step_number=span_step_number,
-            trace_id=uuid.uuid4(),
-            span_id=uuid.uuid4(),
+            dataset_metadata=dataset_metadata if dataset_metadata is not None else {},
+            id=uuid.uuid4(),
         )
+        trace.add_child_span(
+            LoggedLlmSpan(
+                name=name,
+                created_at=created_at,
+                user_metadata=metadata,
+                tags=tags,
+                input=input,
+                redacted_input=redacted_input,
+                output=output,
+                redacted_output=redacted_output,
+                metrics=LlmMetrics(
+                    duration_ns=duration_ns,
+                    num_input_tokens=num_input_tokens,
+                    num_output_tokens=num_output_tokens,
+                    num_total_tokens=total_tokens,
+                    time_to_first_token_ns=time_to_first_token_ns,
+                ),
+                tools=tools,
+                model=model,
+                temperature=temperature,
+                status_code=status_code,
+                dataset_input=dataset_input,
+                dataset_output=dataset_output,
+                dataset_metadata=dataset_metadata if dataset_metadata is not None else {},
+                id=uuid.uuid4(),
+                step_number=span_step_number,
+            )
+        )
+        self.traces.append(trace)
+        self._set_current_parent(None)
 
         if self.mode == "distributed":
             self.traces = [trace]
@@ -1097,30 +1162,31 @@ class GalileoLogger(TracesLogger):
         if metadata:
             metadata = {k: GalileoLogger._convert_metadata_value(v) for k, v in metadata.items()}
 
-        kwargs = {
-            "input": input,
-            "output": output,
-            "model": model,
-            "redacted_input": redacted_input,
-            "redacted_output": redacted_output,
-            "tools": tools,
-            "name": name,
-            "created_at": created_at,
-            "duration_ns": duration_ns,
-            "user_metadata": metadata,
-            "tags": tags,
-            "num_input_tokens": num_input_tokens,
-            "num_output_tokens": num_output_tokens,
-            "total_tokens": total_tokens,
-            "temperature": temperature,
-            "status_code": status_code,
-            "time_to_first_token_ns": time_to_first_token_ns,
-            "step_number": step_number,
-            "id": uuid.uuid4(),
-            "events": events,
-        }
-
-        span = super().add_llm_span(**kwargs)
+        span = LoggedLlmSpan(
+            input=input,
+            redacted_input=redacted_input,
+            output=output,
+            redacted_output=redacted_output,
+            name=name,
+            created_at=self._get_child_span_timestamp() if created_at is None else created_at,
+            user_metadata=metadata,
+            tags=tags,
+            metrics=LlmMetrics(
+                duration_ns=duration_ns,
+                num_input_tokens=num_input_tokens,
+                num_output_tokens=num_output_tokens,
+                num_total_tokens=total_tokens,
+                time_to_first_token_ns=time_to_first_token_ns,
+            ),
+            tools=tools,
+            events=events,
+            model=model,
+            temperature=temperature,
+            status_code=status_code,
+            id=uuid.uuid4(),
+            step_number=step_number,
+        )
+        self.add_child_span_to_parent(span)
 
         if self.mode == "distributed":
             self._ingest_step_streaming(span)
@@ -1370,6 +1436,19 @@ class GalileoLogger(TracesLogger):
 
         return span
 
+    def _attach_parentable_span(
+        self, span: StepWithChildSpans, status_code: Optional[int] = None
+    ) -> StepWithChildSpans:
+        parent = self.current_parent()
+        span._parent = parent
+        self.add_child_span_to_parent(span)
+        self._set_current_parent(span)
+        if status_code is not None:
+            span.status_code = status_code
+        if self.mode == "distributed":
+            self._ingest_step_streaming(span)
+        return span
+
     @nop_sync
     @warn_catch_exception(exceptions=(Exception,))
     def add_workflow_span(
@@ -1385,7 +1464,7 @@ class GalileoLogger(TracesLogger):
         tags: Optional[list[str]] = None,
         step_number: Optional[int] = None,
         status_code: Optional[int] = None,
-    ) -> WorkflowSpan:
+    ) -> LoggedWorkflowSpan:
         """
         Add a workflow span to the current parent. This is useful when you want to create a nested workflow span
         within the trace or current workflow span. The next span you add will be a child of the current parent. To
@@ -1427,35 +1506,27 @@ class GalileoLogger(TracesLogger):
 
         Returns
         -------
-        WorkflowSpan
+        LoggedWorkflowSpan
             The created span.
         """
         # Auto-convert non-string metadata values to strings
         if metadata:
             metadata = {k: GalileoLogger._convert_metadata_value(v) for k, v in metadata.items()}
 
-        kwargs = {
-            "input": input,
-            "redacted_input": redacted_input,
-            "output": output,
-            "redacted_output": redacted_output,
-            "name": name,
-            "duration_ns": duration_ns,
-            "created_at": created_at,
-            "user_metadata": metadata,
-            "tags": tags,
-            "step_number": step_number,
-            "id": uuid.uuid4(),
-        }
-        span = super().add_workflow_span(**kwargs)
-
-        if span is not None and status_code is not None:
-            span.status_code = status_code
-
-        if self.mode == "distributed":
-            self._ingest_step_streaming(span)
-
-        return span
+        span = LoggedWorkflowSpan(
+            input=input,
+            redacted_input=redacted_input,
+            output=output,
+            redacted_output=redacted_output,
+            name=name,
+            created_at=self._get_child_span_timestamp() if created_at is None else created_at,
+            user_metadata=metadata,
+            tags=tags,
+            metrics=Metrics(duration_ns=duration_ns),
+            id=uuid.uuid4(),
+            step_number=step_number,
+        )
+        return self._attach_parentable_span(span, status_code)
 
     @nop_sync
     @warn_catch_exception(exceptions=(Exception,))
@@ -1473,7 +1544,7 @@ class GalileoLogger(TracesLogger):
         agent_type: Optional[AgentType] = None,
         step_number: Optional[int] = None,
         status_code: Optional[int] = None,
-    ) -> AgentSpan:
+    ) -> LoggedAgentSpan:
         """
         Add an agent type span to the current parent.
 
@@ -1517,36 +1588,28 @@ class GalileoLogger(TracesLogger):
 
         Returns
         -------
-        AgentSpan
+        LoggedAgentSpan
             The created span.
         """
         # Auto-convert non-string metadata values to strings
         if metadata:
             metadata = {k: GalileoLogger._convert_metadata_value(v) for k, v in metadata.items()}
 
-        kwargs = {
-            "input": input,
-            "redacted_input": redacted_input,
-            "output": output,
-            "redacted_output": redacted_output,
-            "name": name,
-            "duration_ns": duration_ns,
-            "created_at": created_at,
-            "user_metadata": metadata,
-            "tags": tags,
-            "agent_type": agent_type,
-            "step_number": step_number,
-            "id": uuid.uuid4(),
-        }
-        span = super().add_agent_span(**kwargs)
-
-        if span is not None and status_code is not None:
-            span.status_code = status_code
-
-        if self.mode == "distributed":
-            self._ingest_step_streaming(span)
-
-        return span
+        span = LoggedAgentSpan(
+            input=input,
+            redacted_input=redacted_input,
+            output=output,
+            redacted_output=redacted_output,
+            name=name,
+            created_at=self._get_child_span_timestamp() if created_at is None else created_at,
+            user_metadata=metadata,
+            tags=tags,
+            metrics=Metrics(duration_ns=duration_ns),
+            agent_type=agent_type,
+            id=uuid.uuid4(),
+            step_number=step_number,
+        )
+        return self._attach_parentable_span(span, status_code)
 
     @warn_catch_exception(exceptions=(Exception,))
     def _conclude(
@@ -1639,13 +1702,13 @@ class GalileoLogger(TracesLogger):
 
     @nop_sync
     @warn_catch_exception(exceptions=(Exception,))
-    def flush(self) -> list[Trace]:
+    def flush(self) -> list[LoggedTrace]:
         """
         Upload all traces to Galileo.
 
         Returns
         -------
-        List[Trace]
+        list[LoggedTrace]
             The list of uploaded traces.
         """
         try:
@@ -1659,13 +1722,13 @@ class GalileoLogger(TracesLogger):
 
     @nop_async
     @async_warn_catch_exception(exceptions=(Exception,))
-    async def async_flush(self) -> list[Trace]:
+    async def async_flush(self) -> list[LoggedTrace]:
         """
         Async upload all traces to Galileo.
 
         Returns
         -------
-        List[Trace]
+        list[LoggedTrace]
             The list of uploaded traces.
         """
         try:
@@ -1777,7 +1840,7 @@ class GalileoLogger(TracesLogger):
                 self._update_trace_streaming(trace, is_complete=True)
 
     @async_warn_catch_exception(exceptions=(Exception,))
-    async def _flush_distributed(self) -> list[Trace]:
+    async def _flush_distributed(self) -> list[LoggedTrace]:
         """Flush in distributed mode: conclude traces and wait for pending tasks.
 
         In distributed mode, traces/spans are sent immediately via conclude(). This method:
@@ -1807,7 +1870,7 @@ class GalileoLogger(TracesLogger):
         return []
 
     @async_warn_catch_exception(exceptions=(Exception,))
-    async def _flush_batch(self) -> list[Trace]:
+    async def _flush_batch(self) -> list[LoggedTrace]:
         """Flush in batch mode: conclude unconcluded traces and send all traces to backend."""
         if not self.traces:
             self._logger.info("No traces to flush.")

--- a/src/galileo/schema/__init__.py
+++ b/src/galileo/schema/__init__.py
@@ -1,0 +1,12 @@
+# ruff: noqa: F401
+from galileo.schema.content_blocks import DataContentBlock, IngestContentBlock, IngestMessageContent, TextContentBlock
+from galileo.schema.logged import (
+    IngestInputType,
+    IngestOutputType,
+    LoggedAgentSpan,
+    LoggedLlmSpan,
+    LoggedSpan,
+    LoggedTrace,
+    LoggedWorkflowSpan,
+)
+from galileo.schema.message import LoggedMessage

--- a/src/galileo/schema/content_blocks.py
+++ b/src/galileo/schema/content_blocks.py
@@ -1,0 +1,51 @@
+"""SDK-local content block types for ingestion.
+
+These types define what the SDK sends to the ingest service for multimodal content.
+They are separate from the read-side ContentPart types in galileo-core, which
+represent what the API/UI returns after storage.
+
+Ingestion blocks support inline data (base64, URLs, provider file IDs),
+while read-side ContentParts reference stored files by file_id.
+"""
+
+from typing import Annotated, Literal, Optional, Union
+
+from pydantic import BaseModel, Field, model_validator
+
+from galileo_core.schemas.shared.multimodal import ContentModality
+
+
+class TextContentBlock(BaseModel):
+    """A text segment for ingestion."""
+
+    type: Literal["text"] = "text"
+    text: str
+    index: Optional[int] = None
+    metadata: Optional[dict[str, str]] = None
+
+
+class DataContentBlock(BaseModel):
+    """A binary/media content block for ingestion.
+
+    Exactly one of base64 or url must be set.
+    """
+
+    type: Literal["data"] = "data"
+    modality: ContentModality
+    mime_type: Optional[str] = None
+    base64: Optional[str] = None
+    url: Optional[str] = None
+    index: Optional[int] = None
+    metadata: Optional[dict[str, str]] = None
+
+    @model_validator(mode="after")
+    def _exactly_one_source(self) -> "DataContentBlock":
+        sources = sum(v is not None for v in (self.base64, self.url))
+        if sources != 1:
+            raise ValueError("Exactly one of base64 or url must be set.")
+        return self
+
+
+IngestContentBlock = Annotated[Union[TextContentBlock, DataContentBlock], Field(discriminator="type")]
+
+IngestMessageContent = Union[str, list[IngestContentBlock]]

--- a/src/galileo/schema/logged.py
+++ b/src/galileo/schema/logged.py
@@ -1,0 +1,127 @@
+"""SDK-local ingestion models that widen input/output for multimodal content.
+
+These models subclass the core Trace/Span types and override only the fields
+that differ for ingestion (input, output, redacted_input, redacted_output).
+Read-side code continues to use the core types directly.
+"""
+
+from collections.abc import Sequence
+from json import dumps
+from typing import Annotated, Any, Optional, Union
+
+from pydantic import Field
+
+from galileo.schema.message import LoggedMessage
+from galileo_core.schemas.logging.llm import Message, MessageRole
+from galileo_core.schemas.logging.span import (
+    AgentSpan,
+    LlmSpan,
+    LlmSpanAllowedInputType,
+    LlmSpanAllowedOutputType,
+    RetrieverSpan,
+    Span,  # noqa: F401  # needed for Pydantic model_rebuild to resolve forward refs
+    ToolSpan,
+    WorkflowSpan,
+)
+from galileo_core.schemas.logging.step import BaseStep
+from galileo_core.schemas.logging.trace import Trace
+from galileo_core.schemas.shared.document import Document
+
+IngestInputType = Union[str, Sequence[LoggedMessage]]
+IngestOutputType = Union[str, LoggedMessage, Sequence[Document]]
+
+_INPUT_FIELD = Field(default="", description=BaseStep.model_fields["input"].description, union_mode="left_to_right")
+_REDACTED_INPUT_FIELD = Field(
+    default=None, description=BaseStep.model_fields["redacted_input"].description, union_mode="left_to_right"
+)
+_OUTPUT_FIELD = Field(default=None, description=BaseStep.model_fields["output"].description, union_mode="left_to_right")
+_REDACTED_OUTPUT_FIELD = Field(
+    default=None, description=BaseStep.model_fields["redacted_output"].description, union_mode="left_to_right"
+)
+
+
+class LoggedTrace(Trace):
+    """Trace with widened input/output for multimodal ingestion."""
+
+    input: IngestInputType = _INPUT_FIELD
+    redacted_input: Optional[IngestInputType] = _REDACTED_INPUT_FIELD
+    output: Optional[IngestOutputType] = _OUTPUT_FIELD
+    redacted_output: Optional[IngestOutputType] = _REDACTED_OUTPUT_FIELD
+    spans: list["LoggedSpan"] = Field(default_factory=list)
+
+
+class LoggedWorkflowSpan(WorkflowSpan):
+    """WorkflowSpan with widened input/output for multimodal ingestion."""
+
+    input: IngestInputType = _INPUT_FIELD
+    redacted_input: Optional[IngestInputType] = _REDACTED_INPUT_FIELD
+    output: Optional[IngestOutputType] = _OUTPUT_FIELD
+    redacted_output: Optional[IngestOutputType] = _REDACTED_OUTPUT_FIELD
+    spans: list["LoggedSpan"] = Field(default_factory=list)
+
+
+class LoggedAgentSpan(AgentSpan):
+    """AgentSpan with widened input/output for multimodal ingestion."""
+
+    input: IngestInputType = _INPUT_FIELD
+    redacted_input: Optional[IngestInputType] = _REDACTED_INPUT_FIELD
+    output: Optional[IngestOutputType] = _OUTPUT_FIELD
+    redacted_output: Optional[IngestOutputType] = _REDACTED_OUTPUT_FIELD
+    spans: list["LoggedSpan"] = Field(default_factory=list)
+
+
+class LoggedLlmSpan(LlmSpan):
+    """LlmSpan for ingestion using LoggedMessage (supports IngestContentBlocks, not ContentParts)."""
+
+    input: Sequence[LoggedMessage] = Field(
+        default_factory=list, validate_default=True, description=BaseStep.model_fields["input"].description
+    )
+    redacted_input: Optional[Sequence[LoggedMessage]] = Field(
+        default=None, description=BaseStep.model_fields["redacted_input"].description
+    )
+    output: LoggedMessage = Field(
+        default_factory=lambda: LoggedMessage(content="", role=MessageRole.assistant),
+        validate_default=True,
+        description=BaseStep.model_fields["output"].description,
+    )
+    redacted_output: Optional[LoggedMessage] = Field(
+        default=None, description=BaseStep.model_fields["redacted_output"].description
+    )
+
+    @classmethod
+    def _to_logged_message(cls, msg: Message) -> LoggedMessage:
+        if isinstance(msg, LoggedMessage):
+            return msg
+        return LoggedMessage(
+            content=msg.content, role=msg.role, tool_call_id=msg.tool_call_id, tool_calls=msg.tool_calls
+        )
+
+    @classmethod
+    def _convert_dict_to_message(
+        cls, value: dict[str, Any], default_role: MessageRole = MessageRole.user
+    ) -> LoggedMessage:
+        try:
+            return LoggedMessage.model_validate(value)
+        except Exception:
+            return LoggedMessage(content=dumps(value), role=default_role)
+
+    @classmethod
+    def _convert_input_to_messages(cls, value: LlmSpanAllowedInputType) -> Sequence[LoggedMessage]:
+        messages = super()._convert_input_to_messages(value)
+        return [cls._to_logged_message(m) for m in messages]
+
+    @classmethod
+    def _convert_output_to_message(cls, value: LlmSpanAllowedOutputType) -> LoggedMessage:
+        message = super()._convert_output_to_message(value)
+        return cls._to_logged_message(message)
+
+
+# RetrieverSpan and ToolSpan use plain string/document I/O and don't need multimodal widening.
+LoggedSpan = Annotated[
+    Union[LoggedAgentSpan, LoggedWorkflowSpan, LoggedLlmSpan, RetrieverSpan, ToolSpan], Field(discriminator="type")
+]
+
+LoggedTrace.model_rebuild()
+LoggedWorkflowSpan.model_rebuild()
+LoggedAgentSpan.model_rebuild()
+LoggedLlmSpan.model_rebuild()

--- a/src/galileo/schema/message.py
+++ b/src/galileo/schema/message.py
@@ -1,6 +1,9 @@
 # ruff: noqa: F401
 from typing import Any
 
+from pydantic import Field
+
+from galileo.schema.content_blocks import IngestMessageContent
 from galileo_core.schemas.logging.llm import Message as CoreMessage
 
 # These classes should not be removed. They are used to rebuild the new `Message` model
@@ -24,3 +27,16 @@ class Message(CoreMessage):
 # Without rebuilding the model, Message class we create here would not know and validate
 # constituent classes defined in core which build up message.
 Message.model_rebuild()
+
+
+class LoggedMessage(Message):
+    """Message type for ingestion that accepts IngestContentBlocks.
+
+    Unlike the read-side Message (whose content is str | List[ContentPart]),
+    this accepts str | List[IngestContentBlock] for multimodal ingestion.
+    """
+
+    content: IngestMessageContent = Field(default="")
+
+
+LoggedMessage.model_rebuild()

--- a/src/galileo/schema/trace.py
+++ b/src/galileo/schema/trace.py
@@ -4,9 +4,8 @@ from typing import Literal, Optional, Union
 from pydantic import UUID4, BaseModel, Field
 
 from galileo.resources.models import Document
-from galileo_core.schemas.logging.span import Span
+from galileo.schema.logged import LoggedSpan, LoggedTrace
 from galileo_core.schemas.logging.step import StepAllowedInputType, StepAllowedOutputType
-from galileo_core.schemas.logging.trace import Trace
 
 SPAN_TYPE = Literal["llm", "retriever", "tool", "workflow", "agent"]
 
@@ -33,14 +32,14 @@ class LogRecordsIngestRequest(BaseLogStreamOrExperimentModel):
 
 
 class TracesIngestRequest(LogRecordsIngestRequest):
-    traces: list[Trace] = Field(..., description="List of traces to log.", min_length=1)
+    traces: list[LoggedTrace] = Field(..., description="List of traces to log.", min_length=1)
     session_id: Optional[UUID4] = Field(default=None, description="Session id associated with the traces.")
     session_external_id: Optional[str] = Field(default=None, description="External id for session grouping.")
     is_complete: Optional[bool] = Field(default=True, description="Is complete.")
 
 
 class SpansIngestRequest(LogRecordsIngestRequest):
-    spans: list[Span] = Field(..., description="List of spans to log.", min_length=1)
+    spans: list[LoggedSpan] = Field(..., description="List of spans to log.", min_length=1)
     trace_id: UUID4 = Field(description="Trace id associated with the spans.")
     parent_id: UUID4 = Field(description="Parent trace or span id.")
 

--- a/src/galileo/traces.py
+++ b/src/galileo/traces.py
@@ -1,10 +1,14 @@
 import logging
+import os
 from typing import Any, Optional
 from uuid import UUID
+
+import httpx
 
 from galileo.config import GalileoPythonConfig
 from galileo.constants.routes import Routes
 from galileo.schema.trace import (
+    LoggingMethod,
     LogRecordsSearchRequest,
     SessionCreateRequest,
     SpansIngestRequest,
@@ -159,3 +163,96 @@ class Traces:
         return await self._make_async_request(
             RequestMethod.GET, endpoint=Routes.span.format(project_id=self.project_id, span_id=span_id)
         )
+
+
+class IngestTraces:
+    """Client for the dedicated ingest service.
+
+    Sends traces directly to the ingest service which may run at a
+    separate URL from the main Galileo API. The service URL is resolved
+    from the ``GALILEO_INGEST_URL`` environment variable; when unset it
+    falls back to the configured ``api_url``.
+
+    Parameters
+    ----------
+    project_id : str
+        The project to ingest into.
+    log_stream_id : Optional[str]
+        Log stream id (mutually exclusive with *experiment_id*).
+    experiment_id : Optional[str]
+        Experiment id (mutually exclusive with *log_stream_id*).
+    """
+
+    def __init__(
+        self, project_id: str, log_stream_id: Optional[str] = None, experiment_id: Optional[str] = None
+    ) -> None:
+        self.config = GalileoPythonConfig.get()
+        self.project_id = project_id
+        self.log_stream_id = log_stream_id
+        self.experiment_id = experiment_id
+
+        if self.log_stream_id is None and self.experiment_id is None:
+            raise ValueError("log_stream_id or experiment_id must be set")
+
+    def _get_ingest_base_url(self) -> str:
+        explicit = os.environ.get("GALILEO_INGEST_URL")
+        if explicit:
+            return explicit.rstrip("/")
+        api_url = self.config.api_url or self.config.console_url
+        return str(api_url).rstrip("/")
+
+    def _get_auth_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Content-Type": "application/json", "X-Galileo-SDK": get_sdk_header()}
+        if self.config.api_key:
+            headers["Galileo-API-Key"] = self.config.api_key.get_secret_value()
+        elif self.config.jwt_token:
+            headers["Authorization"] = f"Bearer {self.config.jwt_token.get_secret_value()}"
+        return headers
+
+    @async_warn_catch_exception(logger=_logger)
+    async def ingest_traces(self, traces_ingest_request: TracesIngestRequest) -> dict[str, Any]:
+        if self.experiment_id:
+            traces_ingest_request.experiment_id = UUID(self.experiment_id)
+        elif self.log_stream_id:
+            traces_ingest_request.log_stream_id = UUID(self.log_stream_id)
+
+        traces_ingest_request.logging_method = LoggingMethod.python_client
+
+        base_url = self._get_ingest_base_url()
+        url = f"{base_url}{Routes.ingest_traces.format(project_id=self.project_id)}"
+        json_body = traces_ingest_request.model_dump(mode="json")
+
+        _logger.info(
+            "Sending traces to ingest service",
+            extra={"url": url, "project_id": self.project_id, "num_traces": len(traces_ingest_request.traces)},
+        )
+
+        # httpx default timeout is 5s for connect/read/write/pool
+        # (see https://www.python-httpx.org/advanced/timeouts/)
+        async with httpx.AsyncClient(verify=self.config.ssl_context) as client:
+            response = await client.post(url, json=json_body, headers=self._get_auth_headers())
+            response.raise_for_status()
+            return response.json()
+
+    @async_warn_catch_exception(logger=_logger)
+    async def ingest_spans(self, spans_ingest_request: SpansIngestRequest) -> dict[str, Any]:
+        if self.experiment_id:
+            spans_ingest_request.experiment_id = UUID(self.experiment_id)
+        elif self.log_stream_id:
+            spans_ingest_request.log_stream_id = UUID(self.log_stream_id)
+
+        spans_ingest_request.logging_method = LoggingMethod.python_client
+
+        base_url = self._get_ingest_base_url()
+        url = f"{base_url}{Routes.ingest_spans.format(project_id=self.project_id)}"
+        json_body = spans_ingest_request.model_dump(mode="json")
+
+        _logger.info(
+            "Sending spans to ingest service",
+            extra={"url": url, "project_id": self.project_id, "num_spans": len(spans_ingest_request.spans)},
+        )
+
+        async with httpx.AsyncClient(verify=self.config.ssl_context) as client:
+            response = await client.post(url, json=json_body, headers=self._get_auth_headers())
+            response.raise_for_status()
+            return response.json()

--- a/tests/schemas/test_logged.py
+++ b/tests/schemas/test_logged.py
@@ -1,0 +1,402 @@
+"""Tests for SDK-local ingestion models (Logged variants and content blocks)."""
+
+import pytest
+from pydantic import ValidationError
+
+from galileo.schema.content_blocks import DataContentBlock, TextContentBlock
+from galileo.schema.logged import LoggedAgentSpan, LoggedLlmSpan, LoggedTrace, LoggedWorkflowSpan
+from galileo.schema.message import LoggedMessage
+from galileo.schema.trace import TracesIngestRequest
+from galileo_core.schemas.logging.llm import MessageRole
+from galileo_core.schemas.logging.span import AgentSpan, LlmSpan, RetrieverSpan, ToolSpan, WorkflowSpan
+from galileo_core.schemas.logging.trace import Trace
+from galileo_core.schemas.shared.document import Document
+from galileo_core.schemas.shared.multimodal import ContentModality
+
+
+class TestTextContentBlock:
+    def test_basic_text_block(self) -> None:
+        # Given: a plain text string
+        block = TextContentBlock(text="hello world")
+
+        # Then: fields are set correctly
+        assert block.type == "text"
+        assert block.text == "hello world"
+        assert block.index is None
+        assert block.metadata is None
+
+    def test_text_block_with_metadata(self) -> None:
+        # Given: a text block with index and metadata
+        block = TextContentBlock(text="chunk", index=0, metadata={"source": "doc1"})
+
+        # Then: all fields are preserved
+        assert block.index == 0
+        assert block.metadata == {"source": "doc1"}
+
+
+class TestDataContentBlock:
+    def test_base64_source(self) -> None:
+        # Given: a data block with base64 content
+        block = DataContentBlock(modality=ContentModality.image, mime_type="image/png", base64="iVBORw0KGgoAAAANS")
+
+        # Then: source is base64
+        assert block.type == "data"
+        assert block.modality == ContentModality.image
+        assert block.base64 is not None
+        assert block.url is None
+
+    def test_url_source(self) -> None:
+        # Given: a data block with URL content
+        block = DataContentBlock(modality=ContentModality.image, url="https://example.com/image.png")
+
+        # Then: source is url
+        assert block.url == "https://example.com/image.png"
+        assert block.base64 is None
+
+    def test_no_source_raises(self) -> None:
+        # When/Then: missing all source fields raises
+        with pytest.raises(ValidationError, match="Exactly one of"):
+            DataContentBlock(modality=ContentModality.image)
+
+    def test_multiple_sources_raises(self) -> None:
+        # When/Then: multiple source fields raises
+        with pytest.raises(ValidationError, match="Exactly one of"):
+            DataContentBlock(modality=ContentModality.image, base64="abc", url="https://example.com/img.png")
+
+
+class TestTracesIngestRequestBoundary:
+    def test_rejects_core_trace(self) -> None:
+        # When/Then: a plain core Trace is rejected since TracesIngestRequest expects LoggedTrace
+        with pytest.raises(ValidationError, match="Input should be a valid dictionary or instance of LoggedTrace"):
+            TracesIngestRequest(traces=[Trace(input="plain text")])
+
+
+class TestJsonRoundtripNoCoercion:
+    """Verify that model_dump(mode='json') → model_validate preserves types, nothing coerced to str."""
+
+    def test_logged_trace_roundtrip(self) -> None:
+        # Given: a LoggedTrace with multimodal message input and nested LLM span
+        trace = LoggedTrace(
+            input=[
+                LoggedMessage(
+                    content=[
+                        TextContentBlock(text="Analyze"),
+                        DataContentBlock(modality=ContentModality.image, base64="abc"),
+                    ],
+                    role=MessageRole.user,
+                )
+            ],
+            output="done",
+            spans=[
+                LoggedLlmSpan(
+                    input=[LoggedMessage(content="prompt", role=MessageRole.user)],
+                    output=LoggedMessage(content="response", role=MessageRole.assistant),
+                )
+            ],
+        )
+
+        # When: JSON dump
+        raw = trace.model_dump(mode="json")
+
+        # Then: serialized structure is correct
+        assert isinstance(raw["input"], list)
+        assert raw["input"][0]["content"][0]["type"] == "text"
+        assert raw["input"][0]["content"][1]["type"] == "data"
+        assert raw["output"] == "done"
+
+        # When: validated back
+        restored = LoggedTrace.model_validate(raw)
+
+        # Then: restored types are exact, not coerced to string
+        assert isinstance(restored.input, list)
+        assert type(restored.input[0]) is LoggedMessage
+        assert isinstance(restored.input[0].content, list)
+        assert type(restored.input[0].content[0]) is TextContentBlock
+        assert type(restored.input[0].content[1]) is DataContentBlock
+        assert restored.input[0].content[1].base64 == "abc"
+        assert isinstance(restored.output, str)
+        assert type(restored.spans[0]) is LoggedLlmSpan
+
+    def test_logged_workflow_span_roundtrip(self) -> None:
+        # Given: a LoggedWorkflowSpan with message input and child LLM span
+        span = LoggedWorkflowSpan(
+            input=[LoggedMessage(content="workflow input", role=MessageRole.user)],
+            output=LoggedMessage(content="workflow output", role=MessageRole.assistant),
+            spans=[
+                LoggedLlmSpan(
+                    input=[LoggedMessage(content="inner", role=MessageRole.user)],
+                    output=LoggedMessage(content="inner out", role=MessageRole.assistant),
+                )
+            ],
+        )
+
+        # When: JSON roundtrip
+        raw = span.model_dump(mode="json")
+        restored = LoggedWorkflowSpan.model_validate(raw)
+
+        # Then: input stayed as list of messages, not coerced to string
+        assert isinstance(restored.input, list)
+        assert type(restored.input[0]) is LoggedMessage
+        assert restored.input[0].content == "workflow input"
+        assert type(restored.output) is LoggedMessage
+        assert type(restored.spans[0]) is LoggedLlmSpan
+
+    def test_logged_agent_span_roundtrip(self) -> None:
+        # Given: a LoggedAgentSpan with multimodal message input
+        span = LoggedAgentSpan(
+            input=[
+                LoggedMessage(
+                    content=[
+                        TextContentBlock(text="agent task"),
+                        DataContentBlock(modality=ContentModality.document, url="https://example.com/doc.pdf"),
+                    ],
+                    role=MessageRole.user,
+                )
+            ],
+            output="agent result",
+        )
+
+        # When: JSON roundtrip
+        raw = span.model_dump(mode="json")
+        restored = LoggedAgentSpan.model_validate(raw)
+
+        # Then: multimodal content preserved, not stringified
+        assert isinstance(restored.input, list)
+        assert type(restored.input[0]) is LoggedMessage
+        assert isinstance(restored.input[0].content, list)
+        assert type(restored.input[0].content[0]) is TextContentBlock
+        assert type(restored.input[0].content[1]) is DataContentBlock
+        assert restored.input[0].content[1].url == "https://example.com/doc.pdf"
+
+    def test_logged_llm_span_roundtrip(self) -> None:
+        # Given: a LoggedLlmSpan with multimodal input messages
+        span = LoggedLlmSpan(
+            input=[
+                LoggedMessage(
+                    content=[
+                        TextContentBlock(text="What is this?"),
+                        DataContentBlock(modality=ContentModality.image, base64="img_data"),
+                    ],
+                    role=MessageRole.user,
+                )
+            ],
+            output=LoggedMessage(content="A cat", role=MessageRole.assistant),
+        )
+
+        # When: JSON dump
+        raw = span.model_dump(mode="json")
+
+        # Then: serialized message content is a list of typed dicts
+        assert isinstance(raw["input"][0]["content"], list)
+        assert raw["input"][0]["content"][0]["type"] == "text"
+        assert raw["input"][0]["content"][1]["type"] == "data"
+        assert isinstance(raw["output"]["content"], str)
+
+        # When: validated back
+        restored = LoggedLlmSpan.model_validate(raw)
+
+        # Then: input messages preserved with typed content blocks
+        assert type(restored.input[0]) is LoggedMessage
+        assert isinstance(restored.input[0].content, list)
+        assert type(restored.input[0].content[0]) is TextContentBlock
+        assert type(restored.input[0].content[1]) is DataContentBlock
+        assert restored.input[0].content[1].base64 == "img_data"
+        assert type(restored.output) is LoggedMessage
+        assert restored.output.content == "A cat"
+
+    def test_logged_trace_document_output_roundtrip(self) -> None:
+        # Given: a LoggedTrace with Sequence[Document] output (the third IngestOutputType arm)
+        trace = LoggedTrace(
+            input="query", output=[Document(content="doc 1"), Document(content="doc 2", metadata={"src": "wiki"})]
+        )
+
+        # When: JSON roundtrip
+        raw = trace.model_dump(mode="json")
+        restored = LoggedTrace.model_validate(raw)
+
+        # Then: output is a list of Documents, not coerced to string
+        assert isinstance(restored.output, list)
+        assert len(restored.output) == 2
+        assert type(restored.output[0]) is Document
+        assert restored.output[0].content == "doc 1"
+        assert restored.output[1].metadata == {"src": "wiki"}
+
+    def test_logged_workflow_span_document_output_roundtrip(self) -> None:
+        # Given: a LoggedWorkflowSpan with Sequence[Document] output
+        span = LoggedWorkflowSpan(input="search query", output=[Document(content="result 1")])
+
+        # When: JSON roundtrip
+        raw = span.model_dump(mode="json")
+        restored = LoggedWorkflowSpan.model_validate(raw)
+
+        # Then: output preserved as list of Documents
+        assert isinstance(restored.output, list)
+        assert type(restored.output[0]) is Document
+
+    def test_retriever_span_roundtrip(self) -> None:
+        # Given: a trace containing a RetrieverSpan
+        trace = LoggedTrace(
+            input="find docs",
+            spans=[
+                RetrieverSpan(
+                    input="search query", output=[Document(content="retrieved doc", metadata={"score": "0.95"})]
+                )
+            ],
+        )
+
+        # When: JSON roundtrip
+        raw = trace.model_dump(mode="json")
+        restored = LoggedTrace.model_validate(raw)
+
+        # Then: RetrieverSpan and its Document output are preserved
+        assert type(restored.spans[0]) is RetrieverSpan
+        assert restored.spans[0].output[0].content == "retrieved doc"
+
+    def test_tool_span_roundtrip(self) -> None:
+        # Given: a trace containing a ToolSpan
+        trace = LoggedTrace(input="use tool", spans=[ToolSpan(input="tool_call(arg=1)", output="tool result")])
+
+        # When: JSON roundtrip
+        raw = trace.model_dump(mode="json")
+        restored = LoggedTrace.model_validate(raw)
+
+        # Then: ToolSpan is preserved
+        assert type(restored.spans[0]) is ToolSpan
+        assert restored.spans[0].output == "tool result"
+
+    def test_full_ingest_request_roundtrip(self) -> None:
+        # Given: a TracesIngestRequest exercising all 5 span types and all output variants
+        request = TracesIngestRequest(
+            traces=[
+                LoggedTrace(
+                    input="top-level string",
+                    output=[Document(content="trace-level doc output")],
+                    spans=[
+                        LoggedAgentSpan(
+                            input=[LoggedMessage(content="agent task", role=MessageRole.user)],
+                            output="agent done",
+                            spans=[
+                                LoggedWorkflowSpan(
+                                    input=[LoggedMessage(content="wf", role=MessageRole.user)],
+                                    output=LoggedMessage(content="wf result", role=MessageRole.assistant),
+                                    spans=[
+                                        LoggedLlmSpan(
+                                            input=[
+                                                LoggedMessage(
+                                                    content=[
+                                                        TextContentBlock(text="deep"),
+                                                        DataContentBlock(
+                                                            modality=ContentModality.audio, base64="audio_b64"
+                                                        ),
+                                                    ],
+                                                    role=MessageRole.user,
+                                                )
+                                            ],
+                                            output=LoggedMessage(content="deep answer", role=MessageRole.assistant),
+                                        ),
+                                        RetrieverSpan(input="retrieve context", output=[Document(content="ctx doc")]),
+                                        ToolSpan(input="calc(2+2)", output="4"),
+                                    ],
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ]
+        )
+
+        # When: JSON roundtrip
+        raw = request.model_dump(mode="json")
+        restored = TracesIngestRequest.model_validate(raw)
+
+        # Then: walk the full tree and verify types
+        trace = restored.traces[0]
+        assert type(trace) is LoggedTrace
+        assert isinstance(trace.output, list)
+        assert type(trace.output[0]) is Document
+
+        agent = trace.spans[0]
+        assert type(agent) is LoggedAgentSpan
+        assert isinstance(agent.input, list)
+        assert type(agent.input[0]) is LoggedMessage
+
+        wf = agent.spans[0]
+        assert type(wf) is LoggedWorkflowSpan
+        assert type(wf.output) is LoggedMessage
+
+        llm = wf.spans[0]
+        assert type(llm) is LoggedLlmSpan
+        assert isinstance(llm.input[0].content, list)
+        assert type(llm.input[0].content[0]) is TextContentBlock
+        assert type(llm.input[0].content[1]) is DataContentBlock
+        assert llm.input[0].content[1].base64 == "audio_b64"
+
+        retriever = wf.spans[1]
+        assert type(retriever) is RetrieverSpan
+        assert retriever.output[0].content == "ctx doc"
+
+        tool = wf.spans[2]
+        assert type(tool) is ToolSpan
+        assert tool.output == "4"
+
+
+class TestLoggedAndCoreParity:
+    """Verify Trace/LoggedTrace and Span/LoggedSpan behave identically for plain string content."""
+
+    def test_trace_string_io_parity(self) -> None:
+        # Given: the same plain-string fields
+        kwargs = dict(input="hello", output="world", name="t")
+
+        # When: constructing both variants
+        core = Trace(**kwargs)
+        logged = LoggedTrace(**kwargs)
+
+        # Then: field values and serialized output match
+        assert core.input == logged.input
+        assert core.output == logged.output
+        assert core.model_dump(include={"input", "output", "name"}) == logged.model_dump(
+            include={"input", "output", "name"}
+        )
+
+    def test_workflow_span_string_io_parity(self) -> None:
+        kwargs = dict(input="query", output="answer", name="wf")
+        core = WorkflowSpan(**kwargs)
+        logged = LoggedWorkflowSpan(**kwargs)
+
+        assert core.input == logged.input
+        assert core.output == logged.output
+        assert core.model_dump(include={"input", "output", "name"}) == logged.model_dump(
+            include={"input", "output", "name"}
+        )
+
+    def test_agent_span_string_io_parity(self) -> None:
+        kwargs = dict(input="task", output="result", name="ag")
+        core = AgentSpan(**kwargs)
+        logged = LoggedAgentSpan(**kwargs)
+
+        assert core.input == logged.input
+        assert core.output == logged.output
+        assert core.model_dump(include={"input", "output", "name"}) == logged.model_dump(
+            include={"input", "output", "name"}
+        )
+
+    def test_llm_span_string_io_parity(self) -> None:
+        core = LlmSpan(input="prompt", output="completion", name="llm", model="gpt-4")
+        logged = LoggedLlmSpan(input="prompt", output="completion", name="llm", model="gpt-4")
+
+        assert core.input == logged.input
+        assert core.output == logged.output
+        assert core.model_dump(include={"input", "output", "name", "model"}) == logged.model_dump(
+            include={"input", "output", "name", "model"}
+        )
+
+    def test_logged_trace_is_instance_of_trace(self) -> None:
+        logged = LoggedTrace(input="x")
+
+        assert isinstance(logged, Trace)
+        assert isinstance(logged, LoggedTrace)
+
+    def test_logged_spans_are_instances_of_core(self) -> None:
+        assert isinstance(LoggedWorkflowSpan(input="x"), WorkflowSpan)
+        assert isinstance(LoggedAgentSpan(input="x"), AgentSpan)
+        assert isinstance(LoggedLlmSpan(input="x"), LlmSpan)

--- a/tests/test_ingest_traces_client.py
+++ b/tests/test_ingest_traces_client.py
@@ -1,0 +1,384 @@
+"""Tests for IngestTraces client (dedicated ingest service)."""
+
+import logging
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+
+from galileo.logger import GalileoLogger
+from galileo.schema.logged import LoggedLlmSpan, LoggedTrace
+from galileo.schema.trace import LoggingMethod, SpansIngestRequest, TracesIngestRequest
+from galileo.traces import IngestTraces
+from galileo.utils.headers_data import get_package_version
+from tests.testutils.setup import setup_mock_logstreams_client, setup_mock_projects_client, setup_mock_traces_client
+
+LOGGER = logging.getLogger(__name__)
+
+PROJECT_ID = "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9a"
+LOG_STREAM_ID = "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9b"
+EXPERIMENT_ID = "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9d"
+INGEST_URL = "https://ingest.example.com"
+
+
+class TestIngestTracesInit:
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_requires_log_stream_or_experiment(self, mock_config_class) -> None:
+        mock_config_class.get.return_value = Mock()
+
+        # When/Then: missing both raises ValueError
+        with pytest.raises(ValueError, match="log_stream_id or experiment_id must be set"):
+            IngestTraces(project_id=PROJECT_ID)
+
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_accepts_log_stream_id(self, mock_config_class) -> None:
+        mock_config_class.get.return_value = Mock()
+
+        client = IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+        assert client.project_id == PROJECT_ID
+        assert client.log_stream_id == LOG_STREAM_ID
+
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_accepts_experiment_id(self, mock_config_class) -> None:
+        mock_config_class.get.return_value = Mock()
+
+        client = IngestTraces(project_id=PROJECT_ID, experiment_id=EXPERIMENT_ID)
+        assert client.experiment_id == EXPERIMENT_ID
+
+
+class TestIngestBaseUrl:
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_uses_galileo_ingest_url_when_set(self, mock_config_class, monkeypatch) -> None:
+        mock_config_class.get.return_value = Mock()
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+
+        client = IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+        assert client._get_ingest_base_url() == INGEST_URL
+
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_strips_trailing_slash(self, mock_config_class, monkeypatch) -> None:
+        mock_config_class.get.return_value = Mock()
+        monkeypatch.setenv("GALILEO_INGEST_URL", f"{INGEST_URL}/")
+
+        client = IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+        assert client._get_ingest_base_url() == INGEST_URL
+
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_falls_back_to_api_url(self, mock_config_class, monkeypatch) -> None:
+        monkeypatch.delenv("GALILEO_INGEST_URL", raising=False)
+        mock_config = Mock()
+        mock_config.api_url = "https://api.galileo.ai"
+        mock_config.console_url = "https://console.galileo.ai"
+        mock_config_class.get.return_value = mock_config
+
+        client = IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+        assert client._get_ingest_base_url() == "https://api.galileo.ai"
+
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_falls_back_to_console_url_when_no_api_url(self, mock_config_class, monkeypatch) -> None:
+        monkeypatch.delenv("GALILEO_INGEST_URL", raising=False)
+        mock_config = Mock()
+        mock_config.api_url = None
+        mock_config.console_url = "https://console.galileo.ai"
+        mock_config_class.get.return_value = mock_config
+
+        client = IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+        assert client._get_ingest_base_url() == "https://console.galileo.ai"
+
+
+class TestAuthHeaders:
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_uses_api_key_when_available(self, mock_config_class) -> None:
+        mock_config = Mock()
+        mock_config.api_key.get_secret_value.return_value = "my-api-key"
+        mock_config.jwt_token = None
+        mock_config_class.get.return_value = mock_config
+
+        client = IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+        headers = client._get_auth_headers()
+
+        assert headers["Galileo-API-Key"] == "my-api-key"
+        assert "Authorization" not in headers
+
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_uses_jwt_when_no_api_key(self, mock_config_class) -> None:
+        mock_config = Mock()
+        mock_config.api_key = None
+        mock_config.jwt_token.get_secret_value.return_value = "my-jwt-token"
+        mock_config_class.get.return_value = mock_config
+
+        client = IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+        headers = client._get_auth_headers()
+
+        assert headers["Authorization"] == "Bearer my-jwt-token"
+        assert "Galileo-API-Key" not in headers
+
+    @patch("galileo.traces.GalileoPythonConfig")
+    def test_includes_sdk_header(self, mock_config_class) -> None:
+        mock_config = Mock()
+        mock_config.api_key = None
+        mock_config.jwt_token = None
+        mock_config_class.get.return_value = mock_config
+
+        client = IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+        headers = client._get_auth_headers()
+
+        assert headers["Content-Type"] == "application/json"
+        assert headers["X-Galileo-SDK"].startswith(f"galileo-python/{get_package_version()}")
+
+
+class TestIngestTracesRequest:
+    @pytest.fixture
+    def mock_config(self):
+        with patch("galileo.traces.GalileoPythonConfig") as mock_config_class:
+            mock_config = Mock()
+            mock_config.api_key.get_secret_value.return_value = "test-key"
+            mock_config.jwt_token = None
+            mock_config.ssl_context = True
+            mock_config.api_url = "https://api.galileo.ai"
+            mock_config_class.get.return_value = mock_config
+            yield mock_config
+
+    @pytest.fixture
+    def client(self, mock_config):
+        return IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ingest_traces_posts_to_correct_url(self, client, monkeypatch) -> None:
+        # Given: an ingest URL is configured
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+
+        expected_url = f"{INGEST_URL}/ingest/traces/{PROJECT_ID}"
+        route = respx.post(expected_url).mock(return_value=httpx.Response(200, json={"status": "ok"}))
+
+        trace = LoggedTrace(input="hello", output="world")
+        request = TracesIngestRequest(traces=[trace])
+
+        # When: ingesting traces
+        result = await client.ingest_traces(request)
+
+        # Then: request hits the ingest service URL
+        assert route.called
+        assert result == {"status": "ok"}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ingest_traces_sets_logging_method(self, client, monkeypatch) -> None:
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+
+        expected_url = f"{INGEST_URL}/ingest/traces/{PROJECT_ID}"
+        route = respx.post(expected_url).mock(return_value=httpx.Response(200, json={}))
+
+        trace = LoggedTrace(input="hello")
+        request = TracesIngestRequest(traces=[trace])
+
+        await client.ingest_traces(request)
+
+        # Then: logging_method was set to python_client
+        assert request.logging_method == LoggingMethod.python_client
+        sent_body = route.calls[0].request.content
+        assert b"python_client" in sent_body
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ingest_traces_sets_log_stream_id(self, client, monkeypatch) -> None:
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+        expected_url = f"{INGEST_URL}/ingest/traces/{PROJECT_ID}"
+        respx.post(expected_url).mock(return_value=httpx.Response(200, json={}))
+
+        trace = LoggedTrace(input="hello")
+        request = TracesIngestRequest(traces=[trace])
+
+        await client.ingest_traces(request)
+
+        # Then: log_stream_id was populated from the client
+        assert request.log_stream_id == UUID(LOG_STREAM_ID)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ingest_traces_sets_experiment_id(self, mock_config, monkeypatch) -> None:
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+        client = IngestTraces(project_id=PROJECT_ID, experiment_id=EXPERIMENT_ID)
+
+        expected_url = f"{INGEST_URL}/ingest/traces/{PROJECT_ID}"
+        respx.post(expected_url).mock(return_value=httpx.Response(200, json={}))
+
+        trace = LoggedTrace(input="hello")
+        request = TracesIngestRequest(traces=[trace])
+
+        await client.ingest_traces(request)
+
+        assert request.experiment_id == UUID(EXPERIMENT_ID)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ingest_traces_falls_back_to_api_url(self, client, monkeypatch) -> None:
+        # Given: no GALILEO_INGEST_URL set
+        monkeypatch.delenv("GALILEO_INGEST_URL", raising=False)
+
+        expected_url = f"https://api.galileo.ai/ingest/traces/{PROJECT_ID}"
+        route = respx.post(expected_url).mock(return_value=httpx.Response(200, json={"ok": True}))
+
+        trace = LoggedTrace(input="hello")
+        request = TracesIngestRequest(traces=[trace])
+
+        result = await client.ingest_traces(request)
+
+        assert route.called
+        assert result == {"ok": True}
+
+
+class TestIngestSpansRequest:
+    @pytest.fixture
+    def mock_config(self):
+        with patch("galileo.traces.GalileoPythonConfig") as mock_config_class:
+            mock_config = Mock()
+            mock_config.api_key.get_secret_value.return_value = "test-key"
+            mock_config.jwt_token = None
+            mock_config.ssl_context = True
+            mock_config.api_url = "https://api.galileo.ai"
+            mock_config_class.get.return_value = mock_config
+            yield mock_config
+
+    @pytest.fixture
+    def client(self, mock_config):
+        return IngestTraces(project_id=PROJECT_ID, log_stream_id=LOG_STREAM_ID)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ingest_spans_posts_to_correct_url(self, client, monkeypatch) -> None:
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+
+        expected_url = f"{INGEST_URL}/ingest/spans/{PROJECT_ID}"
+        route = respx.post(expected_url).mock(return_value=httpx.Response(200, json={"status": "ok"}))
+
+        span = LoggedLlmSpan(input="hello", output="world", model="gpt-4o")
+        request = SpansIngestRequest(spans=[span], trace_id=UUID(PROJECT_ID), parent_id=UUID(LOG_STREAM_ID))
+
+        result = await client.ingest_spans(request)
+
+        assert route.called
+        assert result == {"status": "ok"}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ingest_spans_sets_log_stream_id(self, client, monkeypatch) -> None:
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+        expected_url = f"{INGEST_URL}/ingest/spans/{PROJECT_ID}"
+        respx.post(expected_url).mock(return_value=httpx.Response(200, json={}))
+
+        span = LoggedLlmSpan(input="hello", output="world", model="gpt-4o")
+        request = SpansIngestRequest(spans=[span], trace_id=UUID(PROJECT_ID), parent_id=UUID(LOG_STREAM_ID))
+
+        await client.ingest_spans(request)
+
+        assert request.log_stream_id == UUID(LOG_STREAM_ID)
+        assert request.logging_method == LoggingMethod.python_client
+
+
+class TestLoggerIngestClientWiring:
+    """Test that GalileoLogger creates and uses IngestTraces when GALILEO_INGEST_URL is set."""
+
+    @patch("galileo.logger.logger.LogStreams")
+    @patch("galileo.logger.logger.Projects")
+    @patch("galileo.logger.logger.Traces")
+    def test_no_ingest_client_without_env_var(
+        self, mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, monkeypatch
+    ) -> None:
+        # Given: GALILEO_INGEST_URL is not set
+        monkeypatch.delenv("GALILEO_INGEST_URL", raising=False)
+        setup_mock_traces_client(mock_traces_client)
+        setup_mock_projects_client(mock_projects_client)
+        setup_mock_logstreams_client(mock_logstreams_client)
+
+        # When: creating a logger
+        logger = GalileoLogger(project="my_project", log_stream="my_log_stream", mode="batch")
+
+        # Then: ingest client is not created
+        assert logger._ingest_client is None
+        assert logger._traces_client is not None
+
+    @patch("galileo.logger.logger.IngestTraces")
+    @patch("galileo.logger.logger.LogStreams")
+    @patch("galileo.logger.logger.Projects")
+    @patch("galileo.logger.logger.Traces")
+    def test_ingest_client_created_with_env_var(
+        self,
+        mock_traces_client: Mock,
+        mock_projects_client: Mock,
+        mock_logstreams_client: Mock,
+        mock_ingest_client: Mock,
+        monkeypatch,
+    ) -> None:
+        # Given: GALILEO_INGEST_URL is set
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+        setup_mock_traces_client(mock_traces_client)
+        setup_mock_projects_client(mock_projects_client)
+        setup_mock_logstreams_client(mock_logstreams_client)
+
+        # When: creating a logger
+        logger = GalileoLogger(project="my_project", log_stream="my_log_stream", mode="batch")
+
+        # Then: ingest client is created
+        assert logger._ingest_client is not None
+        mock_ingest_client.assert_called_once()
+
+    @patch("galileo.logger.logger.IngestTraces")
+    @patch("galileo.logger.logger.LogStreams")
+    @patch("galileo.logger.logger.Projects")
+    @patch("galileo.logger.logger.Traces")
+    def test_flush_uses_ingest_client_when_available(
+        self,
+        mock_traces_client: Mock,
+        mock_projects_client: Mock,
+        mock_logstreams_client: Mock,
+        mock_ingest_client: Mock,
+        monkeypatch,
+    ) -> None:
+        # Given: GALILEO_INGEST_URL is set, logger has a trace
+        monkeypatch.setenv("GALILEO_INGEST_URL", INGEST_URL)
+        mock_traces_instance = setup_mock_traces_client(mock_traces_client)
+        setup_mock_projects_client(mock_projects_client)
+        setup_mock_logstreams_client(mock_logstreams_client)
+
+        mock_ingest_instance = Mock()
+        mock_ingest_instance.ingest_traces = AsyncMock(return_value={})
+        mock_ingest_client.return_value = mock_ingest_instance
+
+        logger = GalileoLogger(project="my_project", log_stream="my_log_stream", mode="batch")
+        logger.start_trace(input="hello")
+        logger.add_llm_span(input="hello", output="world", model="gpt-4o")
+        logger.conclude(output="world")
+
+        # When: flushing
+        logger.flush()
+
+        # Then: ingest client was used, not the traces client
+        mock_ingest_instance.ingest_traces.assert_called_once()
+        mock_traces_instance.ingest_traces.assert_not_called()
+
+    @patch("galileo.logger.logger.LogStreams")
+    @patch("galileo.logger.logger.Projects")
+    @patch("galileo.logger.logger.Traces")
+    def test_flush_falls_back_to_traces_client_without_env_var(
+        self, mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, monkeypatch
+    ) -> None:
+        # Given: GALILEO_INGEST_URL is not set
+        monkeypatch.delenv("GALILEO_INGEST_URL", raising=False)
+        mock_traces_instance = setup_mock_traces_client(mock_traces_client)
+        setup_mock_projects_client(mock_projects_client)
+        setup_mock_logstreams_client(mock_logstreams_client)
+
+        logger = GalileoLogger(project="my_project", log_stream="my_log_stream", mode="batch")
+        logger.start_trace(input="hello")
+        logger.add_llm_span(input="hello", output="world", model="gpt-4o")
+        logger.conclude(output="world")
+
+        # When: flushing
+        logger.flush()
+
+        # Then: traces client was used (fallback)
+        mock_traces_instance.ingest_traces.assert_called_once()

--- a/tests/test_logger_batch.py
+++ b/tests/test_logger_batch.py
@@ -10,10 +10,13 @@ from uuid import UUID, uuid4
 import pytest
 
 from galileo.logger import GalileoLogger
+from galileo.schema.content_blocks import DataContentBlock, TextContentBlock
 from galileo.schema.logged import LoggedTrace
+from galileo.schema.message import LoggedMessage
 from galileo.schema.metrics import LocalMetricConfig
 from galileo.schema.trace import TracesIngestRequest
 from galileo_core.schemas.logging.agent import AgentType
+from galileo_core.schemas.logging.llm import MessageRole
 from galileo_core.schemas.logging.span import AgentSpan, LlmSpan, RetrieverSpan, Span, ToolSpan, WorkflowSpan
 from galileo_core.schemas.logging.step import Metrics
 from galileo_core.schemas.logging.trace import Trace
@@ -21,6 +24,7 @@ from galileo_core.schemas.protect.execution_status import ExecutionStatus
 from galileo_core.schemas.protect.payload import Payload
 from galileo_core.schemas.protect.response import Response, TraceMetadata
 from galileo_core.schemas.shared.document import Document
+from galileo_core.schemas.shared.multimodal import ContentModality
 from tests.testutils.setup import (
     setup_mock_experiments_client,
     setup_mock_logstreams_client,
@@ -1587,6 +1591,44 @@ def test_add_single_llm_span_trace_ingestion(
 
     assert logger.traces == []
     assert logger._parent_stack == deque()
+
+
+@patch("galileo.logger.logger.LogStreams")
+@patch("galileo.logger.logger.Projects")
+@patch("galileo.logger.logger.Traces")
+def test_multimodal_input_not_stringified_at_trace_level(
+    mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock
+) -> None:
+    """Multimodal content must be preserved at trace level, not serialized to string."""
+    mock_traces_client_instance = setup_mock_traces_client(mock_traces_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+
+    logger = GalileoLogger(project="my_project", log_stream="my_log_stream")
+
+    # Given: multimodal message input with text + image content blocks
+    messages = [
+        LoggedMessage(
+            content=[
+                TextContentBlock(text="Describe this image"),
+                DataContentBlock(modality=ContentModality.image, url="https://example.com/img.png"),
+            ],
+            role=MessageRole.user,
+        )
+    ]
+    logger.start_trace(input=messages)
+    logger.add_llm_span(input=messages, output="A sunset", model="gpt-4o")
+    logger.conclude("A sunset")
+    logger.flush()
+
+    # Then: trace.input is the message list, not a stringified version
+    payload: TracesIngestRequest = mock_traces_client_instance.ingest_traces.call_args.args[0]
+    trace = payload.traces[0]
+    assert not isinstance(trace.input, str), "trace input should not be stringified"
+    assert isinstance(trace.input, list)
+    assert isinstance(trace.input[0], LoggedMessage)
+    assert trace.input[0].content[0].text == "Describe this image"
+    assert trace.input[0].content[1].modality == ContentModality.image
 
 
 @patch("galileo.logger.logger.LogStreams")

--- a/tests/test_logger_batch.py
+++ b/tests/test_logger_batch.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from galileo.logger import GalileoLogger
+from galileo.schema.logged import LoggedTrace
 from galileo.schema.metrics import LocalMetricConfig
 from galileo.schema.trace import TracesIngestRequest
 from galileo_core.schemas.logging.agent import AgentType
@@ -104,32 +105,16 @@ def test_single_span_trace_to_galileo(
 
     mock_traces_client_instance.ingest_traces.assert_called_once()
     payload: TracesIngestRequest = mock_traces_client_instance.ingest_traces.call_args.args[0]
-    expected_payload = TracesIngestRequest(
-        log_stream_id=None,  # TODO: fix this
-        experiment_id=None,
-        traces=[
-            Trace(
-                input="input",
-                output="output",
-                name="test-trace",
-                created_at=created_at,
-                user_metadata=metadata,
-                status_code=200,
-                spans=[span],
-                metrics=Metrics(duration_ns=1000000),
-            )
-        ],
-    )
-
     trace = payload.traces[0]
-    assert trace.input == expected_payload.traces[0].input
-    assert trace.output == expected_payload.traces[0].output
-    assert trace.name == expected_payload.traces[0].name
-    assert trace.created_at == expected_payload.traces[0].created_at
-    assert trace.user_metadata == expected_payload.traces[0].user_metadata
-    assert trace.status_code == expected_payload.traces[0].status_code
-    assert trace.spans == expected_payload.traces[0].spans
-    assert trace.metrics == expected_payload.traces[0].metrics
+    assert isinstance(trace, LoggedTrace)
+    assert trace.input == "input"
+    assert trace.output == "output"
+    assert trace.name == "test-trace"
+    assert trace.created_at == created_at
+    assert trace.user_metadata == metadata
+    assert trace.status_code == 200
+    assert trace.spans == [span]
+    assert trace.metrics == Metrics(duration_ns=1000000)
     assert logger.traces == []
     assert logger._parent_stack == deque()
 
@@ -339,31 +324,16 @@ def test_single_span_trace_to_galileo_experiment_id(
 
     mock_traces_client_instance.ingest_traces.assert_called_once()
     payload: TracesIngestRequest = mock_traces_client_instance.ingest_traces.call_args.args[0]
-    expected_payload = TracesIngestRequest(
-        log_stream_id=None,
-        experiment_id="6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9a",
-        traces=[
-            Trace(
-                input="input",
-                output="output",
-                name="test-trace",
-                created_at=created_at,
-                user_metadata=metadata,
-                status_code=200,
-                spans=[],
-                metrics=Metrics(duration_ns=1000000),
-            )
-        ],
-    )
     trace = payload.traces[0]
-    assert trace.input == expected_payload.traces[0].input
-    assert trace.output == expected_payload.traces[0].output
-    assert trace.name == expected_payload.traces[0].name
-    assert trace.created_at == expected_payload.traces[0].created_at
-    assert trace.user_metadata == expected_payload.traces[0].user_metadata
-    assert trace.status_code == expected_payload.traces[0].status_code
-    assert trace.spans == expected_payload.traces[0].spans
-    assert trace.metrics == expected_payload.traces[0].metrics
+    assert isinstance(trace, LoggedTrace)
+    assert trace.input == "input"
+    assert trace.output == "output"
+    assert trace.name == "test-trace"
+    assert trace.created_at == created_at
+    assert trace.user_metadata == metadata
+    assert trace.status_code == 200
+    assert trace.spans == []
+    assert trace.metrics == Metrics(duration_ns=1000000)
     assert logger.traces == []
     assert logger._parent_stack == deque()
 
@@ -585,31 +555,16 @@ def test_multi_span_trace_to_galileo(
     logger.flush()
 
     payload: TracesIngestRequest = mock_traces_client_instance.ingest_traces.call_args[0][0]
-    expected_payload = TracesIngestRequest(
-        log_stream_id=None,  # TODO: fix this
-        experiment_id=None,
-        traces=[
-            Trace(
-                input="input",
-                output="response2",
-                name="test-trace",
-                created_at=created_at,
-                user_metadata=metadata,
-                status_code=200,
-                spans=[workflow_span, second_span],
-                metrics=Metrics(duration_ns=1000000),
-            )
-        ],
-    )
     trace = payload.traces[0]
-    assert trace.input == expected_payload.traces[0].input
-    assert trace.output == expected_payload.traces[0].output
-    assert trace.name == expected_payload.traces[0].name
-    assert trace.created_at == expected_payload.traces[0].created_at
-    assert trace.user_metadata == expected_payload.traces[0].user_metadata
-    assert trace.status_code == expected_payload.traces[0].status_code
-    assert trace.spans == expected_payload.traces[0].spans
-    assert trace.metrics == expected_payload.traces[0].metrics
+    assert isinstance(trace, LoggedTrace)
+    assert trace.input == "input"
+    assert trace.output == "response2"
+    assert trace.name == "test-trace"
+    assert trace.created_at == created_at
+    assert trace.user_metadata == metadata
+    assert trace.status_code == 200
+    assert trace.spans == [workflow_span, second_span]
+    assert trace.metrics == Metrics(duration_ns=1000000)
     assert logger.traces == []
     assert logger._parent_stack == deque()
 
@@ -658,31 +613,16 @@ async def test_single_span_trace_to_galileo_with_async(
     span.metrics.length = 6
 
     payload: TracesIngestRequest = mock_traces_client_instance.ingest_traces.call_args[0][0]
-    expected_payload = TracesIngestRequest(
-        log_stream_id=None,  # TODO: fix this
-        experiment_id=None,
-        traces=[
-            Trace(
-                input="input",
-                output="output",
-                name="test-trace",
-                created_at=created_at,
-                user_metadata=metadata,
-                status_code=200,
-                spans=[span],
-                metrics=Metrics(duration_ns=1000000),
-            )
-        ],
-    )
     trace = payload.traces[0]
-    assert trace.input == expected_payload.traces[0].input
-    assert trace.output == expected_payload.traces[0].output
-    assert trace.name == expected_payload.traces[0].name
-    assert trace.created_at == expected_payload.traces[0].created_at
-    assert trace.user_metadata == expected_payload.traces[0].user_metadata
-    assert trace.status_code == expected_payload.traces[0].status_code
-    assert trace.spans == expected_payload.traces[0].spans
-    assert trace.metrics == expected_payload.traces[0].metrics
+    assert isinstance(trace, LoggedTrace)
+    assert trace.input == "input"
+    assert trace.output == "output"
+    assert trace.name == "test-trace"
+    assert trace.created_at == created_at
+    assert trace.user_metadata == metadata
+    assert trace.status_code == 200
+    assert trace.spans == [span]
+    assert trace.metrics == Metrics(duration_ns=1000000)
     assert logger.traces == []
     assert logger._parent_stack == deque()
 
@@ -1546,7 +1486,7 @@ async def test_ingest_traces_methods(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     logger = GalileoLogger(project="my_project", log_stream="my_log_stream")
-    trace = Trace(id=uuid4(), input="input", output="output")
+    trace = LoggedTrace(id=uuid4(), input="input", output="output")
     ingest_request = TracesIngestRequest(traces=[trace])
 
     await logger.async_ingest_traces(ingest_request)
@@ -2134,7 +2074,7 @@ def test_ingest_traces_reuses_existing_client(
     assert logger._traces_client is not None
 
     # Given: a minimal trace payload
-    trace = Trace(
+    trace = LoggedTrace(
         input="test", name="test", created_at=datetime.datetime.now(), id=uuid4(), metrics=Metrics(duration_ns=0)
     )
     request = TracesIngestRequest(traces=[trace])


### PR DESCRIPTION
# User description
## Summary

- Adds `IngestTraces` client class that communicates directly with the Go ingest service via `httpx`, bypassing the auto-generated API client
- Conditionally activated when `GALILEO_INGEST_URL` is set; falls back to the existing `Traces` client otherwise
- Wires the new client into all `GalileoLogger` ingestion paths (batch flush, streaming traces, streaming spans)

## Changes

### New: `IngestTraces` client (`src/galileo/traces.py`)
- Standalone `httpx.AsyncClient`-based client targeting `POST /ingest/traces/{project_id}` and `POST /ingest/spans/{project_id}`
- Resolves base URL from `GALILEO_INGEST_URL` env var, falling back to `api_url`
- Handles auth headers (API key or JWT) independently
- Uses `@async_warn_catch_exception` for resilient telemetry semantics

### Modified: `GalileoLogger` (`src/galileo/logger/logger.py`)
- Added `_ingest_client` field, created only when `GALILEO_INGEST_URL` is set
- All ingestion call sites use `self._ingest_client or self._traces_client` fallback pattern
- Refactored init into `_ensure_project_and_log_stream`, `_create_traces_client`, and `_create_ingest_client` for lazy creation

### New routes (`src/galileo/constants/routes.py`)
- `ingest_traces = "/ingest/traces/{project_id}"`
- `ingest_spans = "/ingest/spans/{project_id}"`

### Tests (`tests/test_ingest_traces_client.py`)
- Constructor validation, URL resolution, auth header generation
- `respx`-mocked HTTP tests for `ingest_traces` and `ingest_spans`
- Logger integration: verifies client wiring for batch and streaming modes

## Why

The Go ingest service runs at a separate URL from the main API and exposes raw HTTP endpoints (no OpenAPI client). This PR adds a thin `httpx` client so the SDK can route ingestion traffic directly to it when configured, without changing any behavior for users who don't set the env var.

## Test plan

- [x] All new tests in `test_ingest_traces_client.py` pass
- [x] Pre-commit hooks (ruff, mypy) pass
- [ ] Verify existing test suite still passes in CI

Fixes [sc-58541](https://app.shortcut.com/galileo/story/58541)

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Describe how the SDK now targets the dedicated ingest service when <code>GALILEO_INGEST_URL</code> is configured while retaining existing APIs for batch/streaming ingestion in environments without that flag. Explain how the trace/span models (and the ADK builder) now use <code>Logged*</code> variants plus message/content-block helpers so multimodal inputs survive ingestion and are exercised by the logging tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/501?tool=ast&topic=Ingest+routing>Ingest routing</a>
        </td><td>Describe how the logger now prefers the new <code>IngestTraces</code> client when the ingest endpoint env var is set, using the added routes and client wiring for both batch and streaming ingestion while falling back to the auto-generated <code>Traces</code> client otherwise. Include the new lazy creation helpers plus streaming ingestion overrides and the <code>tests/test_ingest_traces_client.py</code> coverage.<details><summary>Modified files (4)</summary><ul><li>src/galileo/constants/routes.py</li>
<li>src/galileo/logger/logger.py</li>
<li>src/galileo/traces.py</li>
<li>tests/test_ingest_traces_client.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>calebe.sep@hotmail.com</td><td>fix-auto-convert-non-s...</td><td>March 02, 2026</td></tr>
<tr><td>mason@galileo.ai</td><td>feat-allow-session-met...</td><td>February 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/501?tool=ast&topic=Multimodal+schema>Multimodal schema</a>
        </td><td>Describe how the schema and ADK layers now build on <code>LoggedTrace</code>/<code>LoggedSpan</code>/<code>LoggedMessage</code> plus the <code>IngestContentBlock</code> helpers so multimodal inputs/outputs stay typed, and how the ADK trace builder plus the batch logger tests verify that nothing is stringified when flushing.<details><summary>Modified files (8)</summary><ul><li>galileo-adk/src/galileo_adk/trace_builder.py</li>
<li>src/galileo/schema/__init__.py</li>
<li>src/galileo/schema/content_blocks.py</li>
<li>src/galileo/schema/logged.py</li>
<li>src/galileo/schema/message.py</li>
<li>src/galileo/schema/trace.py</li>
<li>tests/schemas/test_logged.py</li>
<li>tests/test_logger_batch.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>calebe.sep@hotmail.com</td><td>fix-auto-convert-non-s...</td><td>March 02, 2026</td></tr>
<tr><td>mason@galileo.ai</td><td>feat-allow-session-met...</td><td>February 13, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/501?tool=ast>(Baz)</a>.