### PR TITLE
feat: add experimental A2A tracing middleware

### DIFF
--- a/src/galileo/__future__/a2a/__init__.py
+++ b/src/galileo/__future__/a2a/__init__.py
@@ -1,0 +1,23 @@
+"""Experimental A2A (Agent-to-Agent) tracing support for Galileo.
+
+This module provides OpenTelemetry-based tracing for A2A protocol endpoints,
+creating spans with gen_ai semantic convention attributes compatible with
+Galileo's trace viewer.
+
+Usage::
+
+    from galileo.__future__.a2a import A2ASpanMiddleware, inject_trace_context
+
+    # Server side: add middleware to capture A2A request/response data
+    app.add_middleware(A2ASpanMiddleware)
+
+    # Client side: propagate trace context across A2A service boundaries
+    httpx_client = httpx.AsyncClient(
+        event_hooks={"request": [inject_trace_context]}
+    )
+"""
+
+from galileo.__future__.a2a.asgi_middleware import A2ASpanMiddleware
+from galileo.__future__.a2a.propagation import inject_trace_context
+
+__all__ = ["A2ASpanMiddleware", "inject_trace_context"]

--- a/src/galileo/__future__/a2a/asgi_middleware.py
+++ b/src/galileo/__future__/a2a/asgi_middleware.py
@@ -156,7 +156,7 @@ class A2ASpanMiddleware:
         request_body, receive_wrapper = _wrap_receive(receive)
         response_body, status_code, send_wrapper = _wrap_send(send)
 
-        tool_name = "get_task" if "tasks:get" in path else "cancel_task"
+        tool_name = _derive_task_tool_name(path)
 
         with _tracer.start_as_current_span(f"A2A {tool_name}", context=ctx, kind=trace.SpanKind.SERVER) as span:
             _set_tool_attrs(span, tool_name, None)
@@ -187,7 +187,7 @@ class A2ASpanMiddleware:
                 span.set_attribute("gen_ai.output.messages", json.dumps([{"role": "tool", "content": result_str}]))
                 if state := result.get("status", {}).get("state"):
                     span.set_attribute("a2a.task.state", state)
-            elif status_code() >= 400:
+            if status_code() >= 400:
                 span.set_attribute("error.type", str(status_code()))
 
 
@@ -236,6 +236,15 @@ def _extract_context(scope: dict) -> Any:
 # ---------------------------------------------------------------------------
 
 
+def _derive_task_tool_name(path: str) -> str:
+    """Derive tool name from A2A task path (e.g. ``/tasks:get`` → ``get_task``)."""
+    for segment in path.split("/"):
+        if segment.startswith("tasks:"):
+            operation = segment.split(":", 1)[1]
+            return f"{operation}_task"
+    return "task_operation"
+
+
 def _set_tool_attrs(span: Any, tool_name: str, status_code: int | None) -> None:
     """Set ``gen_ai.tool.*`` semantic convention attributes on a span."""
     span.set_attribute("gen_ai.operation.name", "execute_tool")
@@ -272,9 +281,10 @@ def _get_user_text(data: dict[str, Any] | None) -> str | None:
 
 
 def _get_agent_text(data: dict[str, Any] | None) -> str | None:
-    """Extract agent response text from an A2A JSON-RPC response body."""
+    """Extract the last agent response text from an A2A JSON-RPC response body."""
     if not data:
         return None
+    last_agent_text: str | None = None
     for msg in data.get("result", {}).get("history", []):
         if msg.get("role") == "agent":
             texts: list[str] = []
@@ -283,5 +293,5 @@ def _get_agent_text(data: dict[str, Any] | None) -> str | None:
                 if "text" in root:
                     texts.append(root["text"])
             if texts:
-                return " ".join(texts)
-    return None
+                last_agent_text = " ".join(texts)
+    return last_agent_text

--- a/src/galileo/__future__/a2a/asgi_middleware.py
+++ b/src/galileo/__future__/a2a/asgi_middleware.py
@@ -1,0 +1,287 @@
+"""ASGI middleware for tracing A2A protocol endpoints with OpenTelemetry.
+
+Creates spans with gen_ai semantic convention attributes
+(``gen_ai.input.messages``, ``gen_ai.output.messages``, ``gen_ai.tool.*``)
+compatible with Galileo's trace viewer.
+
+The middleware handles three types of A2A endpoints:
+
+- **Agent card** (``/.well-known/agent-card.json``): traced as ``execute_tool`` spans
+- **Message send/stream** (``/message:send``, ``/message:stream``): traced with
+  ``gen_ai.input.messages`` / ``gen_ai.output.messages``
+- **Task operations** (``/tasks:get``, ``/tasks:cancel``): traced as ``execute_tool`` spans
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+_OTEL_ERR_MSG = (
+    "OpenTelemetry packages are required for A2A tracing middleware. Install with: pip install galileo[otel]"
+)
+
+try:
+    from opentelemetry import context, trace
+    from opentelemetry.propagate import extract
+
+    _tracer = trace.get_tracer("galileo.a2a")
+    _OTEL_AVAILABLE = True
+except ImportError:
+    _OTEL_AVAILABLE = False
+    _tracer = None
+
+
+class A2ASpanMiddleware:
+    """ASGI middleware that creates OpenTelemetry spans for A2A endpoints.
+
+    This middleware intercepts A2A JSON-RPC requests and responses, creating
+    enriched spans with gen_ai semantic convention attributes that Galileo
+    reads natively.
+
+    It replaces ``FastAPIInstrumentor`` for A2A endpoints — creating its own
+    spans gives full control over the lifecycle and allows setting attributes
+    before the span ends.
+
+    Parameters
+    ----------
+    app : ASGI application
+        The ASGI application to wrap.
+
+    Examples
+    --------
+    With FastAPI/Starlette::
+
+        from galileo.__future__.a2a import A2ASpanMiddleware
+
+        app = FastAPI()
+        app.add_middleware(A2ASpanMiddleware)
+
+    With Agno AgentOS::
+
+        from agno.os import AgentOS
+        from galileo.__future__.a2a import A2ASpanMiddleware
+
+        agent_os = AgentOS(agents=[agent], a2a_interface=True)
+        app = agent_os.get_app()
+        app.add_middleware(A2ASpanMiddleware)
+    """
+
+    def __init__(self, app: Any) -> None:
+        if not _OTEL_AVAILABLE:
+            raise ImportError(_OTEL_ERR_MSG)
+        self.app = app
+
+    async def __call__(self, scope: dict, receive: Callable, send: Callable) -> None:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        path: str = scope.get("path", "")
+        method: str = scope.get("method", "")
+        ctx = _extract_context(scope)
+
+        if ".well-known/agent-card.json" in path:
+            return await self._handle_agent_card(scope, receive, send, path, ctx)
+        if "message:" in path:
+            return await self._handle_message(scope, receive, send, method, path, ctx)
+        if "tasks:" in path:
+            return await self._handle_task(scope, receive, send, method, path, ctx)
+
+        return await self.app(scope, receive, send)
+
+    async def _handle_agent_card(self, scope: dict, receive: Callable, send: Callable, path: str, ctx: Any) -> None:
+        response_body, status_code, send_wrapper = _wrap_send(send)
+
+        with _tracer.start_as_current_span("A2A fetch_agent_card", context=ctx, kind=trace.SpanKind.SERVER) as span:
+            await self.app(scope, receive, send_wrapper)
+
+            _set_tool_attrs(span, "fetch_agent_card", status_code())
+            span.set_attribute("gen_ai.tool.call.arguments", json.dumps({"url": path}))
+            span.set_attribute(
+                "gen_ai.input.messages", json.dumps([{"role": "tool", "content": json.dumps({"url": path})}])
+            )
+
+            card = _parse_json(response_body())
+            if card:
+                if name := card.get("name"):
+                    span.set_attribute("a2a.agent.name", name)
+                if desc := card.get("description"):
+                    span.set_attribute("a2a.agent.description", desc)
+                card_str = json.dumps(card)
+                span.set_attribute("gen_ai.tool.call.result", card_str)
+                span.set_attribute("gen_ai.output.messages", json.dumps([{"role": "tool", "content": card_str}]))
+
+    async def _handle_message(
+        self, scope: dict, receive: Callable, send: Callable, method: str, path: str, ctx: Any
+    ) -> None:
+        request_body, receive_wrapper = _wrap_receive(receive)
+        response_body, status_code, send_wrapper = _wrap_send(send)
+
+        with _tracer.start_as_current_span("A2A message", context=ctx, kind=trace.SpanKind.SERVER) as span:
+            span.set_attribute("http.method", method)
+            span.set_attribute("http.target", path)
+
+            token = context.attach(trace.set_span_in_context(span))
+            try:
+                await self.app(scope, receive_wrapper, send_wrapper)
+            finally:
+                context.detach(token)
+
+            span.set_attribute("http.status_code", status_code())
+
+            req = _parse_json(request_body())
+            resp = _parse_json(response_body())
+
+            if input_text := _get_user_text(req):
+                span.set_attribute("gen_ai.input.messages", json.dumps([{"role": "user", "content": input_text}]))
+            if output_text := _get_agent_text(resp):
+                span.set_attribute(
+                    "gen_ai.output.messages", json.dumps([{"role": "assistant", "content": output_text}])
+                )
+            if req and (rpc_method := req.get("method")):
+                span.set_attribute("a2a.rpc.method", rpc_method)
+            if resp:
+                result = resp.get("result", {})
+                if state := result.get("status", {}).get("state"):
+                    span.set_attribute("a2a.task.state", state)
+                if task_id := result.get("id"):
+                    span.set_attribute("a2a.task.id", task_id)
+
+    async def _handle_task(
+        self, scope: dict, receive: Callable, send: Callable, method: str, path: str, ctx: Any
+    ) -> None:
+        request_body, receive_wrapper = _wrap_receive(receive)
+        response_body, status_code, send_wrapper = _wrap_send(send)
+
+        tool_name = "get_task" if "tasks:get" in path else "cancel_task"
+
+        with _tracer.start_as_current_span(f"A2A {tool_name}", context=ctx, kind=trace.SpanKind.SERVER) as span:
+            _set_tool_attrs(span, tool_name, None)
+            span.set_attribute("http.method", method)
+
+            token = context.attach(trace.set_span_in_context(span))
+            try:
+                await self.app(scope, receive_wrapper, send_wrapper)
+            finally:
+                context.detach(token)
+
+            span.set_attribute("http.status_code", status_code())
+
+            req = _parse_json(request_body())
+            if req:
+                task_id = req.get("params", {}).get("id")
+                if task_id:
+                    span.set_attribute("a2a.task.id", task_id)
+                    args = json.dumps({"task_id": task_id})
+                    span.set_attribute("gen_ai.tool.call.arguments", args)
+                    span.set_attribute("gen_ai.input.messages", json.dumps([{"role": "tool", "content": args}]))
+
+            resp = _parse_json(response_body())
+            if resp:
+                result = resp.get("result", {})
+                result_str = json.dumps(result)
+                span.set_attribute("gen_ai.tool.call.result", result_str)
+                span.set_attribute("gen_ai.output.messages", json.dumps([{"role": "tool", "content": result_str}]))
+                if state := result.get("status", {}).get("state"):
+                    span.set_attribute("a2a.task.state", state)
+            elif status_code() >= 400:
+                span.set_attribute("error.type", str(status_code()))
+
+
+# ---------------------------------------------------------------------------
+# ASGI wrappers
+# ---------------------------------------------------------------------------
+
+
+def _wrap_receive(receive: Callable) -> tuple[Callable[[], bytes], Callable]:
+    """Wrap ASGI ``receive`` to capture request body while passing it through."""
+    body_parts: list[bytes] = []
+
+    async def wrapper() -> dict:
+        message = await receive()
+        if message["type"] == "http.request":
+            body_parts.append(message.get("body", b""))
+        return message
+
+    return lambda: b"".join(body_parts), wrapper
+
+
+def _wrap_send(send: Callable) -> tuple[Callable[[], bytes], Callable[[], int], Callable]:
+    """Wrap ASGI ``send`` to capture response body and status code."""
+    body_parts: list[bytes] = []
+    code: list[int] = [200]
+
+    async def wrapper(message: dict) -> None:
+        if message["type"] == "http.response.start":
+            code[0] = message.get("status", 200)
+        elif message["type"] == "http.response.body":
+            body_parts.append(message.get("body", b""))
+        return await send(message)
+
+    return lambda: b"".join(body_parts), lambda: code[0], wrapper
+
+
+def _extract_context(scope: dict) -> Any:
+    """Extract W3C trace context from ASGI scope headers."""
+    headers = dict(scope.get("headers", []))
+    carrier = {k.decode("utf-8"): v.decode("utf-8") for k, v in headers.items()}
+    return extract(carrier)
+
+
+# ---------------------------------------------------------------------------
+# Span helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_tool_attrs(span: Any, tool_name: str, status_code: int | None) -> None:
+    """Set ``gen_ai.tool.*`` semantic convention attributes on a span."""
+    span.set_attribute("gen_ai.operation.name", "execute_tool")
+    span.set_attribute("gen_ai.tool.name", tool_name)
+    span.set_attribute("gen_ai.tool.type", "function")
+    if status_code is not None:
+        span.set_attribute("http.status_code", status_code)
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_json(body: bytes) -> dict[str, Any] | None:
+    """Parse JSON from bytes, returning ``None`` on failure."""
+    try:
+        return json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _get_user_text(data: dict[str, Any] | None) -> str | None:
+    """Extract user message text from an A2A JSON-RPC request body."""
+    if not data:
+        return None
+    message = data.get("params", {}).get("message", {})
+    texts: list[str] = []
+    for part in message.get("parts", []):
+        root = part.get("root", part)
+        if "text" in root:
+            texts.append(root["text"])
+    return " ".join(texts) if texts else None
+
+
+def _get_agent_text(data: dict[str, Any] | None) -> str | None:
+    """Extract agent response text from an A2A JSON-RPC response body."""
+    if not data:
+        return None
+    for msg in data.get("result", {}).get("history", []):
+        if msg.get("role") == "agent":
+            texts: list[str] = []
+            for part in msg.get("parts", []):
+                root = part.get("root", part)
+                if "text" in root:
+                    texts.append(root["text"])
+            if texts:
+                return " ".join(texts)
+    return None

--- a/src/galileo/__future__/a2a/asgi_middleware.py
+++ b/src/galileo/__future__/a2a/asgi_middleware.py
@@ -35,6 +35,10 @@ except ImportError:
     _tracer = None
 
 
+_MESSAGE_SEGMENTS = {"message:send", "message:stream"}
+_TASK_SEGMENTS = {"tasks:get", "tasks:cancel", "tasks:subscribe"}
+
+
 class A2ASpanMiddleware:
     """ASGI middleware that creates OpenTelemetry spans for A2A endpoints.
 
@@ -83,11 +87,12 @@ class A2ASpanMiddleware:
         method: str = scope.get("method", "")
         ctx = _extract_context(scope)
 
-        if ".well-known/agent-card.json" in path:
+        segment = path.rsplit("/", 1)[-1]
+        if segment == "agent-card.json":
             return await self._handle_agent_card(scope, receive, send, path, ctx)
-        if "message:" in path:
+        if segment in _MESSAGE_SEGMENTS:
             return await self._handle_message(scope, receive, send, method, path, ctx)
-        if "tasks:" in path:
+        if segment in _TASK_SEGMENTS:
             return await self._handle_task(scope, receive, send, method, path, ctx)
 
         return await self.app(scope, receive, send)
@@ -95,8 +100,15 @@ class A2ASpanMiddleware:
     async def _handle_agent_card(self, scope: dict, receive: Callable, send: Callable, path: str, ctx: Any) -> None:
         response_body, status_code, send_wrapper = _wrap_send(send)
 
+        if not _tracer:
+            return await self.app(scope, receive, send_wrapper)
+
         with _tracer.start_as_current_span("A2A fetch_agent_card", context=ctx, kind=trace.SpanKind.SERVER) as span:
-            await self.app(scope, receive, send_wrapper)
+            token = context.attach(trace.set_span_in_context(span))
+            try:
+                await self.app(scope, receive, send_wrapper)
+            finally:
+                context.detach(token)
 
             _set_tool_attrs(span, "fetch_agent_card", status_code())
             span.set_attribute("gen_ai.tool.call.arguments", json.dumps({"url": path}))
@@ -113,15 +125,18 @@ class A2ASpanMiddleware:
                 card_str = json.dumps(card)
                 span.set_attribute("gen_ai.tool.call.result", card_str)
                 span.set_attribute("gen_ai.output.messages", json.dumps([{"role": "tool", "content": card_str}]))
+        return None
 
     async def _handle_message(
         self, scope: dict, receive: Callable, send: Callable, method: str, path: str, ctx: Any
     ) -> None:
         request_body, receive_wrapper = _wrap_receive(receive)
         response_body, status_code, send_wrapper = _wrap_send(send)
+        if not _tracer:
+            return await self.app(scope, receive_wrapper, send_wrapper)
 
         with _tracer.start_as_current_span("A2A message", context=ctx, kind=trace.SpanKind.SERVER) as span:
-            span.set_attribute("http.method", method)
+            span.set_attribute("http.request.method", method)
             span.set_attribute("http.target", path)
 
             token = context.attach(trace.set_span_in_context(span))
@@ -130,7 +145,10 @@ class A2ASpanMiddleware:
             finally:
                 context.detach(token)
 
-            span.set_attribute("http.status_code", status_code())
+            span.set_attribute("http.response.status_code", status_code())
+
+            if status_code() >= 400:
+                span.set_attribute("error.type", str(status_code()))
 
             req = _parse_json(request_body())
             resp = _parse_json(response_body())
@@ -149,6 +167,7 @@ class A2ASpanMiddleware:
                     span.set_attribute("a2a.task.state", state)
                 if task_id := result.get("id"):
                     span.set_attribute("a2a.task.id", task_id)
+        return None
 
     async def _handle_task(
         self, scope: dict, receive: Callable, send: Callable, method: str, path: str, ctx: Any
@@ -157,10 +176,12 @@ class A2ASpanMiddleware:
         response_body, status_code, send_wrapper = _wrap_send(send)
 
         tool_name = _derive_task_tool_name(path)
+        if not _tracer:
+            return await self.app(scope, receive_wrapper, send_wrapper)
 
         with _tracer.start_as_current_span(f"A2A {tool_name}", context=ctx, kind=trace.SpanKind.SERVER) as span:
             _set_tool_attrs(span, tool_name, None)
-            span.set_attribute("http.method", method)
+            span.set_attribute("http.request.method", method)
 
             token = context.attach(trace.set_span_in_context(span))
             try:
@@ -168,7 +189,7 @@ class A2ASpanMiddleware:
             finally:
                 context.detach(token)
 
-            span.set_attribute("http.status_code", status_code())
+            span.set_attribute("http.response.status_code", status_code())
 
             req = _parse_json(request_body())
             if req:
@@ -189,6 +210,7 @@ class A2ASpanMiddleware:
                     span.set_attribute("a2a.task.state", state)
             if status_code() >= 400:
                 span.set_attribute("error.type", str(status_code()))
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -214,7 +236,7 @@ def _wrap_send(send: Callable) -> tuple[Callable[[], bytes], Callable[[], int], 
     body_parts: list[bytes] = []
     code: list[int] = [200]
 
-    async def wrapper(message: dict) -> None:
+    async def wrapper(message: dict) -> Any:
         if message["type"] == "http.response.start":
             code[0] = message.get("status", 200)
         elif message["type"] == "http.response.body":
@@ -226,8 +248,13 @@ def _wrap_send(send: Callable) -> tuple[Callable[[], bytes], Callable[[], int], 
 
 def _extract_context(scope: dict) -> Any:
     """Extract W3C trace context from ASGI scope headers."""
-    headers = dict(scope.get("headers", []))
-    carrier = {k.decode("utf-8"): v.decode("utf-8") for k, v in headers.items()}
+    headers = scope.get("headers", [])
+    carrier: dict[str, str] = {}
+    for k, v in headers:
+        try:
+            carrier[k.decode("utf-8")] = v.decode("utf-8")
+        except (AttributeError, UnicodeDecodeError):
+            continue
     return extract(carrier)
 
 
@@ -251,7 +278,7 @@ def _set_tool_attrs(span: Any, tool_name: str, status_code: int | None) -> None:
     span.set_attribute("gen_ai.tool.name", tool_name)
     span.set_attribute("gen_ai.tool.type", "function")
     if status_code is not None:
-        span.set_attribute("http.status_code", status_code)
+        span.set_attribute("http.response.status_code", status_code)
 
 
 # ---------------------------------------------------------------------------

--- a/src/galileo/__future__/a2a/propagation.py
+++ b/src/galileo/__future__/a2a/propagation.py
@@ -29,15 +29,13 @@ async def inject_trace_context(request: httpx.Request) -> None:
             event_hooks={"request": [inject_trace_context]}
         )
 
+    If OpenTelemetry is not installed, a warning is logged and the request
+    is left unchanged.
+
     Parameters
     ----------
     request : httpx.Request
         The outgoing httpx request to inject headers into.
-
-    Raises
-    ------
-    ImportError
-        If OpenTelemetry packages are not installed.
     """
     try:
         from opentelemetry.propagate import inject

--- a/src/galileo/__future__/a2a/propagation.py
+++ b/src/galileo/__future__/a2a/propagation.py
@@ -1,0 +1,48 @@
+"""Trace context propagation for A2A client calls.
+
+Provides an httpx event hook that injects the W3C traceparent header into
+outgoing requests, enabling distributed tracing across A2A service boundaries.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import httpx
+
+logger = logging.getLogger(__name__)
+
+_INJECT_ERR_MSG = (
+    "OpenTelemetry packages are required for trace context propagation. Install with: pip install galileo[otel]"
+)
+
+
+async def inject_trace_context(request: httpx.Request) -> None:
+    """Inject W3C trace context headers into an outgoing httpx request.
+
+    Use as an httpx event hook to propagate trace context (``traceparent``)
+    across A2A service boundaries without creating additional HTTPX spans::
+
+        httpx_client = httpx.AsyncClient(
+            event_hooks={"request": [inject_trace_context]}
+        )
+
+    Parameters
+    ----------
+    request : httpx.Request
+        The outgoing httpx request to inject headers into.
+
+    Raises
+    ------
+    ImportError
+        If OpenTelemetry packages are not installed.
+    """
+    try:
+        from opentelemetry.propagate import inject
+    except ImportError:
+        logger.warning(_INJECT_ERR_MSG)
+        return
+
+    inject(request.headers)

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -30,17 +29,34 @@ from galileo.__future__.a2a.propagation import inject_trace_context
 
 
 @pytest.fixture()
-def span_exporter():
-    """Set up an in-memory OTel exporter so we can inspect finished spans."""
+def _otel_provider():
+    """Create an isolated TracerProvider that does not touch the global singleton.
+
+    ``trace.set_tracer_provider()`` can only be called once per process; subsequent
+    calls are silently ignored.  Using a local provider avoids conflicts when
+    multiple test files run in the same CI worker.
+    """
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    trace.set_tracer_provider(provider)
-    # Re-create the module-level tracer so it uses the new provider
-    _a2a_mw._tracer = trace.get_tracer("galileo.a2a")
-    yield exporter
+    _a2a_mw._tracer = provider.get_tracer("galileo.a2a")
+    yield provider, exporter
     exporter.shutdown()
     provider.shutdown()
+
+
+@pytest.fixture()
+def span_exporter(_otel_provider):
+    """Convenience fixture that yields only the exporter."""
+    _, exporter = _otel_provider
+    return exporter
+
+
+@pytest.fixture()
+def otel_provider(_otel_provider):
+    """Convenience fixture that yields only the provider."""
+    provider, _ = _otel_provider
+    return provider
 
 
 @pytest.fixture()
@@ -208,6 +224,24 @@ class TestGetAgentText:
 
         # When/Then: returns None
         assert _get_agent_text(data) is None
+
+    def test_returns_last_agent_message(self):
+        # Given: a response with multiple agent messages in history
+        data = {
+            "result": {
+                "history": [
+                    {"role": "agent", "parts": [{"text": "first reply"}]},
+                    {"role": "user", "parts": [{"text": "follow-up question"}]},
+                    {"role": "agent", "parts": [{"text": "final reply"}]},
+                ]
+            }
+        }
+
+        # When: extracting agent text
+        result = _get_agent_text(data)
+
+        # Then: the last agent message is returned
+        assert result == "final reply"
 
 
 # ---------------------------------------------------------------------------
@@ -580,6 +614,56 @@ class TestA2ASpanMiddlewareTask:
         assert attrs["error.type"] == "500"
         assert attrs["http.status_code"] == 500
 
+    @pytest.mark.asyncio
+    async def test_sets_error_type_on_json_error_response(self, make_scope, span_exporter):
+        # Given: a tasks:get request that returns 500 with a JSON error body
+        request_body = {"jsonrpc": "2.0", "method": "tasks/get", "params": {"id": "task-fail"}}
+        error_response = {"jsonrpc": "2.0", "error": {"code": -32000, "message": "Internal error"}}
+
+        async def error_app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 500, "headers": []})
+            await send({"type": "http.response.body", "body": json.dumps(error_response).encode()})
+
+        middleware = A2ASpanMiddleware(error_app)
+        scope = make_scope("/tasks:get")
+        receive = _make_receive(json.dumps(request_body).encode())
+        send = _make_send()
+
+        # When: the task endpoint returns a JSON error response
+        await middleware(scope, receive, send)
+
+        # Then: error.type is set even though response body is valid JSON
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        attrs = dict(spans[0].attributes)
+        assert attrs["error.type"] == "500"
+        assert attrs["http.status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_traces_task_subscribe(self, make_scope, span_exporter):
+        # Given: a tasks:subscribe request (not get or cancel)
+        request_body = {"jsonrpc": "2.0", "method": "tasks/subscribe", "params": {"id": "task-sub"}}
+
+        async def subscribe_app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b'{"result": {}}'})
+
+        middleware = A2ASpanMiddleware(subscribe_app)
+        scope = make_scope("/tasks:subscribe")
+        receive = _make_receive(json.dumps(request_body).encode())
+        send = _make_send()
+
+        # When: subscribing to a task
+        await middleware(scope, receive, send)
+
+        # Then: the span uses subscribe_task as tool name (not cancel_task)
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "A2A subscribe_task"
+        assert dict(spans[0].attributes)["gen_ai.tool.name"] == "subscribe_task"
+
 
 # ---------------------------------------------------------------------------
 # Tests: trace context propagation
@@ -618,9 +702,9 @@ class TestA2ASpanMiddlewareContextPropagation:
 
 class TestInjectTraceContext:
     @pytest.mark.asyncio
-    async def test_injects_traceparent_header(self, span_exporter):
-        # Given: an active span and an httpx request
-        tracer = trace.get_tracer("test")
+    async def test_injects_traceparent_header(self, otel_provider):
+        # Given: an active span from the local provider and an httpx request
+        tracer = otel_provider.get_tracer("test")
         with tracer.start_as_current_span("test-parent"):
             request = httpx.Request("POST", "http://example.com/message:send")
 

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -334,7 +334,7 @@ class TestSetToolAttrs:
         span.set_attribute.assert_any_call("gen_ai.operation.name", "execute_tool")
         span.set_attribute.assert_any_call("gen_ai.tool.name", "fetch_agent_card")
         span.set_attribute.assert_any_call("gen_ai.tool.type", "function")
-        span.set_attribute.assert_any_call("http.status_code", 200)
+        span.set_attribute.assert_any_call("http.response.status_code", 200)
 
     def test_skips_status_code_when_none(self):
         # Given: a mock span
@@ -343,8 +343,8 @@ class TestSetToolAttrs:
         # When: setting tool attributes without a status code
         _set_tool_attrs(span, "get_task", None)
 
-        # Then: http.status_code is not set
-        calls = [c for c in span.set_attribute.call_args_list if c[0][0] == "http.status_code"]
+        # Then: http.response.status_code is not set
+        calls = [c for c in span.set_attribute.call_args_list if c[0][0] == "http.response.status_code"]
         assert len(calls) == 0
 
 
@@ -488,8 +488,8 @@ class TestA2ASpanMiddlewareMessage:
         span = spans[0]
         assert span.name == "A2A message"
         attrs = dict(span.attributes)
-        assert attrs["http.method"] == "POST"
-        assert attrs["http.status_code"] == 200
+        assert attrs["http.request.method"] == "POST"
+        assert attrs["http.response.status_code"] == 200
         assert attrs["a2a.rpc.method"] == "message/send"
         assert attrs["a2a.task.state"] == "completed"
         assert attrs["a2a.task.id"] == "task-123"
@@ -612,7 +612,7 @@ class TestA2ASpanMiddlewareTask:
         assert len(spans) == 1
         attrs = dict(spans[0].attributes)
         assert attrs["error.type"] == "500"
-        assert attrs["http.status_code"] == 500
+        assert attrs["http.response.status_code"] == 500
 
     @pytest.mark.asyncio
     async def test_sets_error_type_on_json_error_response(self, make_scope, span_exporter):
@@ -638,7 +638,7 @@ class TestA2ASpanMiddlewareTask:
         assert len(spans) == 1
         attrs = dict(spans[0].attributes)
         assert attrs["error.type"] == "500"
-        assert attrs["http.status_code"] == 500
+        assert attrs["http.response.status_code"] == 500
 
     @pytest.mark.asyncio
     async def test_traces_task_subscribe(self, make_scope, span_exporter):

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,0 +1,672 @@
+"""Tests for galileo.__future__.a2a - A2A tracing middleware and propagation."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import galileo.__future__.a2a.asgi_middleware as _a2a_mw
+from galileo.__future__.a2a.asgi_middleware import (
+    A2ASpanMiddleware,
+    _get_agent_text,
+    _get_user_text,
+    _parse_json,
+    _set_tool_attrs,
+    _wrap_receive,
+    _wrap_send,
+)
+from galileo.__future__.a2a.propagation import inject_trace_context
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def span_exporter():
+    """Set up an in-memory OTel exporter so we can inspect finished spans."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    # Re-create the module-level tracer so it uses the new provider
+    _a2a_mw._tracer = trace.get_tracer("galileo.a2a")
+    yield exporter
+    exporter.shutdown()
+    provider.shutdown()
+
+
+@pytest.fixture()
+def echo_app():
+    """A minimal ASGI app that echoes back the request body as the response."""
+
+    async def app(scope, receive, send):
+        body = b""
+        while True:
+            msg = await receive()
+            body += msg.get("body", b"")
+            if not msg.get("more_body", False):
+                break
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": body})
+
+    return app
+
+
+@pytest.fixture()
+def make_scope():
+    """Factory to create ASGI HTTP scopes."""
+
+    def _make(path: str, method: str = "POST", headers: list[tuple[bytes, bytes]] | None = None):
+        return {"type": "http", "path": path, "method": method, "headers": headers or []}
+
+    return _make
+
+
+def _make_receive(body: bytes):
+    """Create a simple ASGI receive callable that yields a single body message."""
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+def _make_send():
+    """Create an ASGI send callable that records all messages."""
+    messages: list[dict] = []
+
+    async def send(message: dict):
+        messages.append(message)
+
+    send.messages = messages  # type: ignore[attr-defined]
+    return send
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: JSON extraction helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParseJson:
+    def test_valid_json(self):
+        # Given: valid JSON bytes
+        data = b'{"key": "value"}'
+
+        # When: parsing JSON
+        result = _parse_json(data)
+
+        # Then: the parsed dict is returned
+        assert result == {"key": "value"}
+
+    def test_invalid_json(self):
+        # Given: invalid JSON bytes
+        data = b"not json"
+
+        # When: parsing JSON
+        result = _parse_json(data)
+
+        # Then: None is returned
+        assert result is None
+
+    def test_empty_bytes(self):
+        # Given: empty bytes
+        data = b""
+
+        # When: parsing JSON
+        result = _parse_json(data)
+
+        # Then: None is returned
+        assert result is None
+
+
+class TestGetUserText:
+    def test_extracts_text_from_parts(self):
+        # Given: an A2A request with text parts
+        data = {"params": {"message": {"parts": [{"text": "Hello"}, {"text": "world"}]}}}
+
+        # When: extracting user text
+        result = _get_user_text(data)
+
+        # Then: texts are joined with spaces
+        assert result == "Hello world"
+
+    def test_extracts_text_from_root_key(self):
+        # Given: an A2A request with text nested under root
+        data = {"params": {"message": {"parts": [{"root": {"text": "nested text"}}]}}}
+
+        # When: extracting user text
+        result = _get_user_text(data)
+
+        # Then: the nested text is extracted
+        assert result == "nested text"
+
+    def test_returns_none_for_no_text_parts(self):
+        # Given: an A2A request with non-text parts
+        data = {"params": {"message": {"parts": [{"data": "binary"}]}}}
+
+        # When: extracting user text
+        result = _get_user_text(data)
+
+        # Then: None is returned
+        assert result is None
+
+    def test_returns_none_for_none_input(self):
+        # When/Then: None input returns None
+        assert _get_user_text(None) is None
+
+    def test_returns_none_for_empty_dict(self):
+        # When/Then: empty dict returns None
+        assert _get_user_text({}) is None
+
+
+class TestGetAgentText:
+    def test_extracts_agent_response_text(self):
+        # Given: an A2A response with agent message in history
+        data = {"result": {"history": [{"role": "agent", "parts": [{"text": "I can help"}]}]}}
+
+        # When: extracting agent text
+        result = _get_agent_text(data)
+
+        # Then: the agent text is returned
+        assert result == "I can help"
+
+    def test_extracts_from_root_key(self):
+        # Given: agent text nested under root
+        data = {"result": {"history": [{"role": "agent", "parts": [{"root": {"text": "nested agent"}}]}]}}
+
+        # When: extracting agent text
+        result = _get_agent_text(data)
+
+        # Then: the nested text is extracted
+        assert result == "nested agent"
+
+    def test_skips_non_agent_roles(self):
+        # Given: a response with only user messages
+        data = {"result": {"history": [{"role": "user", "parts": [{"text": "user message"}]}]}}
+
+        # When: extracting agent text
+        result = _get_agent_text(data)
+
+        # Then: None is returned since no agent role found
+        assert result is None
+
+    def test_returns_none_for_none_input(self):
+        # When/Then: None input returns None
+        assert _get_agent_text(None) is None
+
+    def test_returns_none_for_empty_history(self):
+        # Given: response with empty history
+        data = {"result": {"history": []}}
+
+        # When/Then: returns None
+        assert _get_agent_text(data) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: ASGI wrappers
+# ---------------------------------------------------------------------------
+
+
+class TestWrapReceive:
+    @pytest.mark.asyncio
+    async def test_captures_request_body(self):
+        # Given: a receive callable that returns a request body
+        original_receive = _make_receive(b'{"hello": "world"}')
+        get_body, wrapped = _wrap_receive(original_receive)
+
+        # When: calling the wrapped receive
+        message = await wrapped()
+
+        # Then: the body is captured and the message is passed through
+        assert message["type"] == "http.request"
+        assert get_body() == b'{"hello": "world"}'
+
+    @pytest.mark.asyncio
+    async def test_non_request_messages_pass_through(self):
+        # Given: a receive that returns a non-request message
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        get_body, wrapped = _wrap_receive(receive)
+
+        # When: calling the wrapped receive
+        await wrapped()
+
+        # Then: body remains empty since it wasn't a request message
+        assert get_body() == b""
+
+
+class TestWrapSend:
+    @pytest.mark.asyncio
+    async def test_captures_response_body_and_status(self):
+        # Given: a no-op send callable
+        original_send = AsyncMock()
+        get_body, get_status, wrapped = _wrap_send(original_send)
+
+        # When: sending response start and body
+        await wrapped({"type": "http.response.start", "status": 201})
+        await wrapped({"type": "http.response.body", "body": b'{"ok": true}'})
+
+        # Then: status and body are captured
+        assert get_status() == 201
+        assert get_body() == b'{"ok": true}'
+        assert original_send.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_default_status_is_200(self):
+        # Given: a no-op send callable
+        original_send = AsyncMock()
+        _, get_status, _ = _wrap_send(original_send)
+
+        # When/Then: default status is 200 before any messages
+        assert get_status() == 200
+
+    @pytest.mark.asyncio
+    async def test_captures_multi_part_body(self):
+        # Given: a no-op send callable
+        original_send = AsyncMock()
+        get_body, _, wrapped = _wrap_send(original_send)
+
+        # When: sending multiple body chunks
+        await wrapped({"type": "http.response.body", "body": b"chunk1"})
+        await wrapped({"type": "http.response.body", "body": b"chunk2"})
+
+        # Then: all chunks are concatenated
+        assert get_body() == b"chunk1chunk2"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _set_tool_attrs
+# ---------------------------------------------------------------------------
+
+
+class TestSetToolAttrs:
+    def test_sets_all_tool_attributes(self):
+        # Given: a mock span
+        span = MagicMock()
+
+        # When: setting tool attributes with a status code
+        _set_tool_attrs(span, "fetch_agent_card", 200)
+
+        # Then: all gen_ai.tool attributes are set
+        span.set_attribute.assert_any_call("gen_ai.operation.name", "execute_tool")
+        span.set_attribute.assert_any_call("gen_ai.tool.name", "fetch_agent_card")
+        span.set_attribute.assert_any_call("gen_ai.tool.type", "function")
+        span.set_attribute.assert_any_call("http.status_code", 200)
+
+    def test_skips_status_code_when_none(self):
+        # Given: a mock span
+        span = MagicMock()
+
+        # When: setting tool attributes without a status code
+        _set_tool_attrs(span, "get_task", None)
+
+        # Then: http.status_code is not set
+        calls = [c for c in span.set_attribute.call_args_list if c[0][0] == "http.status_code"]
+        assert len(calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: A2ASpanMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestA2ASpanMiddlewareInit:
+    def test_raises_import_error_when_otel_unavailable(self):
+        # Given: OpenTelemetry is not available
+        with patch("galileo.__future__.a2a.asgi_middleware._OTEL_AVAILABLE", False):
+            # When/Then: creating the middleware raises ImportError
+            with pytest.raises(ImportError, match="OpenTelemetry packages are required"):
+                A2ASpanMiddleware(app=AsyncMock())
+
+
+class TestA2ASpanMiddlewareNonHttp:
+    @pytest.mark.asyncio
+    async def test_passes_through_non_http_scopes(self):
+        # Given: a middleware wrapping a no-op app and a websocket scope
+        inner_app = AsyncMock()
+        middleware = A2ASpanMiddleware(inner_app)
+        scope = {"type": "websocket", "path": "/ws"}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        # When: calling with a non-http scope
+        await middleware(scope, receive, send)
+
+        # Then: the underlying app is called directly (no tracing)
+        inner_app.assert_awaited_once_with(scope, receive, send)
+
+
+class TestA2ASpanMiddlewareUnmatchedPath:
+    @pytest.mark.asyncio
+    async def test_passes_through_unmatched_paths(self, echo_app, make_scope, span_exporter):
+        # Given: a middleware and a request to a non-A2A path
+        middleware = A2ASpanMiddleware(echo_app)
+        scope = make_scope("/health")
+        receive = _make_receive(b"")
+        send = _make_send()
+
+        # When: calling with a non-A2A path
+        await middleware(scope, receive, send)
+
+        # Then: the app is called but no A2A spans are created
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 0
+
+
+class TestA2ASpanMiddlewareAgentCard:
+    @pytest.mark.asyncio
+    async def test_traces_agent_card_fetch(self, make_scope, span_exporter):
+        # Given: an app that returns an agent card JSON
+        agent_card = {"name": "TestAgent", "description": "A test agent", "url": "http://localhost"}
+
+        async def card_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": json.dumps(agent_card).encode()})
+
+        middleware = A2ASpanMiddleware(card_app)
+        scope = make_scope("/.well-known/agent-card.json", method="GET")
+        receive = _make_receive(b"")
+        send = _make_send()
+
+        # When: fetching the agent card
+        await middleware(scope, receive, send)
+
+        # Then: a span is created with agent card attributes
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "A2A fetch_agent_card"
+        attrs = dict(span.attributes)
+        assert attrs["gen_ai.operation.name"] == "execute_tool"
+        assert attrs["gen_ai.tool.name"] == "fetch_agent_card"
+        assert attrs["a2a.agent.name"] == "TestAgent"
+        assert attrs["a2a.agent.description"] == "A test agent"
+        assert "gen_ai.tool.call.result" in attrs
+        assert "gen_ai.output.messages" in attrs
+
+    @pytest.mark.asyncio
+    async def test_handles_non_json_agent_card_response(self, make_scope, span_exporter):
+        # Given: an app that returns non-JSON for the agent card
+        async def bad_card_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 500, "headers": []})
+            await send({"type": "http.response.body", "body": b"Internal Error"})
+
+        middleware = A2ASpanMiddleware(bad_card_app)
+        scope = make_scope("/.well-known/agent-card.json", method="GET")
+        receive = _make_receive(b"")
+        send = _make_send()
+
+        # When: fetching returns non-JSON
+        await middleware(scope, receive, send)
+
+        # Then: a span is still created, just without card-specific attributes
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        attrs = dict(spans[0].attributes)
+        assert attrs["gen_ai.tool.name"] == "fetch_agent_card"
+        assert "a2a.agent.name" not in attrs
+
+
+class TestA2ASpanMiddlewareMessage:
+    @pytest.mark.asyncio
+    async def test_traces_message_send(self, make_scope, span_exporter):
+        # Given: an A2A message:send request and response
+        request_body = {
+            "jsonrpc": "2.0",
+            "method": "message/send",
+            "params": {"message": {"parts": [{"text": "What is 2+2?"}]}},
+        }
+        response_body = {
+            "jsonrpc": "2.0",
+            "result": {
+                "id": "task-123",
+                "status": {"state": "completed"},
+                "history": [{"role": "agent", "parts": [{"text": "4"}]}],
+            },
+        }
+
+        async def message_app(scope, receive, send):
+            # consume the request body
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": json.dumps(response_body).encode()})
+
+        middleware = A2ASpanMiddleware(message_app)
+        scope = make_scope("/message:send")
+        receive = _make_receive(json.dumps(request_body).encode())
+        send = _make_send()
+
+        # When: sending a message
+        await middleware(scope, receive, send)
+
+        # Then: a span is created with input/output message attributes
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "A2A message"
+        attrs = dict(span.attributes)
+        assert attrs["http.method"] == "POST"
+        assert attrs["http.status_code"] == 200
+        assert attrs["a2a.rpc.method"] == "message/send"
+        assert attrs["a2a.task.state"] == "completed"
+        assert attrs["a2a.task.id"] == "task-123"
+
+        input_msgs = json.loads(attrs["gen_ai.input.messages"])
+        assert input_msgs[0]["role"] == "user"
+        assert input_msgs[0]["content"] == "What is 2+2?"
+
+        output_msgs = json.loads(attrs["gen_ai.output.messages"])
+        assert output_msgs[0]["role"] == "assistant"
+        assert output_msgs[0]["content"] == "4"
+
+    @pytest.mark.asyncio
+    async def test_traces_message_stream(self, make_scope, span_exporter):
+        # Given: an A2A message:stream request
+        request_body = {
+            "jsonrpc": "2.0",
+            "method": "message/stream",
+            "params": {"message": {"parts": [{"text": "Stream this"}]}},
+        }
+
+        async def stream_app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"{}"})
+
+        middleware = A2ASpanMiddleware(stream_app)
+        scope = make_scope("/message:stream")
+        receive = _make_receive(json.dumps(request_body).encode())
+        send = _make_send()
+
+        # When: streaming a message
+        await middleware(scope, receive, send)
+
+        # Then: a span is created for the stream endpoint
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "A2A message"
+
+
+class TestA2ASpanMiddlewareTask:
+    @pytest.mark.asyncio
+    async def test_traces_task_get(self, make_scope, span_exporter):
+        # Given: a tasks:get request
+        request_body = {"jsonrpc": "2.0", "method": "tasks/get", "params": {"id": "task-abc"}}
+        response_body = {
+            "jsonrpc": "2.0",
+            "result": {"id": "task-abc", "status": {"state": "completed"}, "artifacts": []},
+        }
+
+        async def task_app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": json.dumps(response_body).encode()})
+
+        middleware = A2ASpanMiddleware(task_app)
+        scope = make_scope("/tasks:get")
+        receive = _make_receive(json.dumps(request_body).encode())
+        send = _make_send()
+
+        # When: getting a task
+        await middleware(scope, receive, send)
+
+        # Then: a span is created with task tool attributes
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "A2A get_task"
+        attrs = dict(span.attributes)
+        assert attrs["gen_ai.tool.name"] == "get_task"
+        assert attrs["a2a.task.id"] == "task-abc"
+        assert attrs["a2a.task.state"] == "completed"
+        assert "gen_ai.tool.call.arguments" in attrs
+        assert "gen_ai.tool.call.result" in attrs
+
+    @pytest.mark.asyncio
+    async def test_traces_task_cancel(self, make_scope, span_exporter):
+        # Given: a tasks:cancel request
+        request_body = {"jsonrpc": "2.0", "method": "tasks/cancel", "params": {"id": "task-xyz"}}
+
+        async def cancel_app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b'{"result": {}}'})
+
+        middleware = A2ASpanMiddleware(cancel_app)
+        scope = make_scope("/tasks:cancel")
+        receive = _make_receive(json.dumps(request_body).encode())
+        send = _make_send()
+
+        # When: cancelling a task
+        await middleware(scope, receive, send)
+
+        # Then: the span uses cancel_task as tool name
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "A2A cancel_task"
+        assert dict(spans[0].attributes)["gen_ai.tool.name"] == "cancel_task"
+
+    @pytest.mark.asyncio
+    async def test_sets_error_type_on_failure(self, make_scope, span_exporter):
+        # Given: a tasks:get request that returns 500
+        request_body = {"jsonrpc": "2.0", "method": "tasks/get", "params": {"id": "task-fail"}}
+
+        async def error_app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 500, "headers": []})
+            await send({"type": "http.response.body", "body": b"server error"})
+
+        middleware = A2ASpanMiddleware(error_app)
+        scope = make_scope("/tasks:get")
+        receive = _make_receive(json.dumps(request_body).encode())
+        send = _make_send()
+
+        # When: the task endpoint returns an error
+        await middleware(scope, receive, send)
+
+        # Then: error.type is set on the span
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        attrs = dict(spans[0].attributes)
+        assert attrs["error.type"] == "500"
+        assert attrs["http.status_code"] == 500
+
+
+# ---------------------------------------------------------------------------
+# Tests: trace context propagation
+# ---------------------------------------------------------------------------
+
+
+class TestA2ASpanMiddlewareContextPropagation:
+    @pytest.mark.asyncio
+    async def test_extracts_traceparent_from_headers(self, make_scope, span_exporter):
+        # Given: a request with a traceparent header
+        trace_id = "0af7651916cd43dd8448eb211c80319c"
+        parent_span_id = "b7ad6b7169203331"
+        traceparent = f"00-{trace_id}-{parent_span_id}-01"
+        scope = make_scope(
+            "/.well-known/agent-card.json", method="GET", headers=[(b"traceparent", traceparent.encode())]
+        )
+
+        async def card_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b'{"name": "Agent"}'})
+
+        middleware = A2ASpanMiddleware(card_app)
+        receive = _make_receive(b"")
+        send = _make_send()
+
+        # When: the middleware processes the request
+        await middleware(scope, receive, send)
+
+        # Then: the span has the parent trace context
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.context.trace_id == int(trace_id, 16)
+        assert span.parent.span_id == int(parent_span_id, 16)
+
+
+class TestInjectTraceContext:
+    @pytest.mark.asyncio
+    async def test_injects_traceparent_header(self, span_exporter):
+        # Given: an active span and an httpx request
+        tracer = trace.get_tracer("test")
+        with tracer.start_as_current_span("test-parent"):
+            request = httpx.Request("POST", "http://example.com/message:send")
+
+            # When: injecting trace context
+            await inject_trace_context(request)
+
+            # Then: traceparent header is added
+            assert "traceparent" in request.headers
+
+    @pytest.mark.asyncio
+    async def test_warns_when_otel_unavailable(self):
+        # Given: OpenTelemetry is not importable
+        with patch("galileo.__future__.a2a.propagation.inject_trace_context", new=inject_trace_context):
+            with patch.dict("sys.modules", {"opentelemetry.propagate": None}):
+                # Re-import to trigger the ImportError path
+                # Since the import is inside the function, we patch builtins
+                original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+                def mock_import(name, *args, **kwargs):
+                    if name == "opentelemetry.propagate":
+                        raise ImportError("mocked")
+                    return original_import(name, *args, **kwargs)
+
+                request = httpx.Request("POST", "http://example.com/message:send")
+                with patch("builtins.__import__", side_effect=mock_import):
+                    # When: calling inject without otel available
+                    await inject_trace_context(request)
+
+                # Then: no traceparent header is set (graceful degradation)
+                assert "traceparent" not in request.headers
+
+
+# ---------------------------------------------------------------------------
+# Tests: public API (__init__.py exports)
+# ---------------------------------------------------------------------------
+
+
+class TestPublicAPI:
+    def test_exports_middleware(self):
+        # When/Then: A2ASpanMiddleware is importable from the package
+        from galileo.__future__.a2a import A2ASpanMiddleware as Middleware
+
+        assert Middleware is not None
+
+    def test_exports_inject_trace_context(self):
+        # When/Then: inject_trace_context is importable from the package
+        from galileo.__future__.a2a import inject_trace_context as inject
+
+        assert inject is not None

--- a/tests/test_log_streams_metrics.py
+++ b/tests/test_log_streams_metrics.py
@@ -13,11 +13,18 @@ from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig
 
 @pytest.fixture(autouse=True)
 def reset_env_vars() -> None:
-    """Reset environment variables before each test."""
-    os.environ.pop("GALILEO_PROJECT", None)
-    os.environ.pop("GALILEO_PROJECT_ID", None)
-    os.environ.pop("GALILEO_LOG_STREAM", None)
-    os.environ.pop("GALILEO_LOG_STREAM_ID", None)
+    """Reset environment variables before each test, restoring originals after."""
+    saved = {}
+    keys = ["GALILEO_PROJECT", "GALILEO_PROJECT_ID", "GALILEO_LOG_STREAM", "GALILEO_LOG_STREAM_ID"]
+    for key in keys:
+        saved[key] = os.environ.get(key)
+        os.environ.pop(key, None)
+    yield
+    for key in keys:
+        if saved[key] is not None:
+            os.environ[key] = saved[key]
+        else:
+            os.environ.pop(key, None)
 
 
 @pytest.fixture


### PR DESCRIPTION
# User description
**Shortcut:** https://app.shortcut.com/galileo/story/53283/create-a2a-extension-and-validate-it-end-end

**Description:**

Adds experimental A2A (Agent-to-Agent) tracing support under `galileo.__future__.a2a`:

- `A2ASpanMiddleware`: ASGI middleware that creates OpenTelemetry spans for A2A protocol endpoints (agent card, message send/stream, task get/cancel) with `gen_ai` semantic convention attributes compatible with Galileo's trace viewer
- `inject_trace_context`: httpx event hook for W3C traceparent propagation across A2A service boundaries

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add experimental <code>A2ASpanMiddleware</code> to instrument Agent-to-Agent protocol endpoints with OpenTelemetry so agent card, message, and task flows emit <code>gen_ai.*</code> metadata compatible with Galileo’s trace viewer. Introduce the <code>inject_trace_context</code> HTTPX hook and comprehensive unit coverage to keep traceparent propagation and middleware lifecycle validated end-to-end.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/508?tool=ast&topic=A2A+tracing>A2A tracing</a>
        </td><td>Instrument A2A flows via <code>A2ASpanMiddleware</code>, <code>inject_trace_context</code>, and supporting helpers to wrap ASGI calls, parse JSON payloads, derive tool metadata, emit gen_ai attributes across agent card, message, and task endpoints, and validate the behaviors through unit tests.<details><summary>Modified files (4)</summary><ul><li>src/galileo/__future__/a2a/__init__.py</li>
<li>src/galileo/__future__/a2a/asgi_middleware.py</li>
<li>src/galileo/__future__/a2a/propagation.py</li>
<li>tests/test_a2a.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/508?tool=ast&topic=Test+env+fixture>Test env fixture</a>
        </td><td>Restore <code>GALILEO_*</code> environment variables around log stream tests to avoid leakage between suites.<details><summary>Modified files (1)</summary><ul><li>tests/test_log_streams_metrics.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>vamaq@users.noreply.gi...</td><td>fix-Define-explicit-er...</td><td>February 03, 2026</td></tr>
<tr><td>jweiler@galileo.ai</td><td>feat-Add-GalileoMetric...</td><td>December 19, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/508?tool=ast>(Baz)</a>.