### PR TITLE
chore: add devcontainer for sandboxed development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "Galileo Python SDK",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.13",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker"
+      ],
+      "settings": {
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Poetry via pipx (pipx is pre-installed in Microsoft Python devcontainer images)
+pipx install poetry
+
+# Use a container-local virtualenv path to avoid clobbering the host's .venv
+poetry config virtualenvs.in-project false
+poetry config virtualenvs.path "$HOME/.cache/pypoetry/virtualenvs"
+
+# Install all project dependencies including optional extras
+poetry install --all-extras
+
+# Set up pre-commit hooks
+poetry run pre-commit install --hook-type pre-commit
+
+# Install Claude Code globally
+npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
[SC-59914](https://app.shortcut.com/galileo/story/59914/create-initial-devcontainer-for-galileo-python)

# User description
## Summary
- Adds a devcontainer configuration with Microsoft Python 3.13 base image, Node.js, Poetry, all project extras, pre-commit hooks, and Claude Code pre-installed
- Virtualenv is stored in the container's home directory (`~/.cache/pypoetry/virtualenvs`) to avoid clobbering the host's `.venv` via the bind mount
- Includes VS Code customizations (Python, Ruff, mypy extensions with format-on-save)

## Test plan
- [x] `devcontainer up` builds and starts successfully
- [x] Python 3.13.5 available
- [x] Poetry 2.3.2 installed
- [x] `import galileo` works (version 1.50.1)
- [x] Optional extras available (`langchain_core`, `openai`)
- [x] Claude Code installed (2.1.81)
- [x] `ruff check src/` runs correctly
- [x] Smoke test: `pytest tests/test_decorator.py` — 51/51 passed
- [x] Full test suite: 5808 passed, 5 skipped
- [x] Host `.venv` remains untouched after container build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Provision a devcontainer configuration and bootstrap script to install Python 3.13, Node, Poetry-managed dependencies, and Claude Code so the Galileo SDK can be developed in an isolated environment. Enable VS Code extensions, formatting defaults, and pre-commit hooks within the container to mirror the repository’s expected tooling.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/516?tool=ast>(Baz)</a>.