### PR TITLE
feat: add IngestTraces client with GALILEO_INGEST_URL routing

### DIFF
--- a/src/galileo/constants/routes.py
+++ b/src/galileo/constants/routes.py
@@ -23,3 +23,6 @@ class Routes(str, Enum):
 
     sessions = "/v2/projects/{project_id}/sessions"
     sessions_search = "/v2/projects/{project_id}/sessions/search"
+
+    ingest_traces = "/ingest/traces/{project_id}"
+    ingest_spans = "/ingest/spans/{project_id}"

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -4,6 +4,7 @@ import copy
 import inspect
 import json
 import logging
+import os
 import time
 import uuid
 from datetime import datetime
@@ -39,7 +40,7 @@ from galileo.schema.trace import (
     TracesIngestRequest,
     TraceUpdateRequest,
 )
-from galileo.traces import Traces
+from galileo.traces import GALILEO_INGEST_URL_ENV, IngestTraces, Traces
 from galileo.utils.decorators import (
     async_warn_catch_exception,
     nop_async,
@@ -160,7 +161,7 @@ class GalileoLogger(TracesLogger):
     _session_external_id: Optional[str] = None
 
     _logger = logging.getLogger("galileo.logger")
-    _traces_client: Optional["Traces"] = None
+    _traces_client: Optional[Union["Traces", "IngestTraces"]] = None
     _task_handler: ThreadPoolTaskHandler
     _trace_completion_submitted: bool
 
@@ -309,10 +310,7 @@ class GalileoLogger(TracesLogger):
             if not (self.log_stream_id or self.experiment_id):
                 self._init_log_stream()
 
-            if self.log_stream_id:
-                self._traces_client = Traces(project_id=self.project_id, log_stream_id=self.log_stream_id)
-            elif self.experiment_id:
-                self._traces_client = Traces(project_id=self.project_id, experiment_id=self.experiment_id)
+            self._traces_client = self._create_traces_client()
         else:
             # ingestion_hook path: Traces client not created eagerly.
             # If the user later calls ingest_traces(), it will be created lazily.
@@ -356,13 +354,29 @@ class GalileoLogger(TracesLogger):
         else:
             self.log_stream_id = log_stream_obj.id
 
-    def _create_traces_client(self) -> Traces:
-        """Lazily create a Traces client when needed (e.g. ingestion_hook users calling ingest_traces)."""
-        self._logger.info("Creating Traces client lazily for explicit ingest_traces call.")
+    def _create_traces_client(self) -> Union[Traces, IngestTraces]:
+        """Create the appropriate traces client.
+
+        If GALILEO_INGEST_URL is set, routes ingestion to the dedicated Go
+        ingest service via IngestTraces. Otherwise uses the standard API client.
+        """
         if not self.project_id:
             self._init_project()
         if not (self.log_stream_id or self.experiment_id):
             self._init_log_stream()
+
+        ingest_url = os.environ.get(GALILEO_INGEST_URL_ENV)
+        if ingest_url:
+            api_key = os.environ.get("GALILEO_API_KEY", "")
+            self._logger.info("Using dedicated ingest service at %s for project %s", ingest_url, self.project_id)
+            return IngestTraces(
+                project_id=self.project_id,
+                base_url=ingest_url,
+                api_key=api_key,
+                log_stream_id=self.log_stream_id,
+                experiment_id=self.experiment_id,
+            )
+
         if self.log_stream_id:
             return Traces(project_id=self.project_id, log_stream_id=self.log_stream_id)
         if self.experiment_id:

--- a/src/galileo/traces.py
+++ b/src/galileo/traces.py
@@ -2,6 +2,8 @@ import logging
 from typing import Any, Optional
 from uuid import UUID
 
+import httpx
+
 from galileo.config import GalileoPythonConfig
 from galileo.constants.routes import Routes
 from galileo.schema.trace import (
@@ -18,6 +20,8 @@ from galileo_core.constants.http_headers import HttpHeaders
 from galileo_core.constants.request_method import RequestMethod
 
 _logger = logging.getLogger(__name__)
+
+GALILEO_INGEST_URL_ENV = "GALILEO_INGEST_URL"
 
 
 class Traces:
@@ -159,3 +163,58 @@ class Traces:
         return await self._make_async_request(
             RequestMethod.GET, endpoint=Routes.span.format(project_id=self.project_id, span_id=span_id)
         )
+
+
+class IngestTraces:
+    """Client that sends traces/spans directly to the Galileo ingest service.
+
+    Used when GALILEO_INGEST_URL is set, bypassing the main API and posting
+    to the dedicated Go ingest service instead.
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        base_url: str,
+        api_key: str,
+        log_stream_id: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+    ) -> None:
+        self.project_id = project_id
+        self.log_stream_id = log_stream_id
+        self.experiment_id = experiment_id
+        self.base_url = base_url.rstrip("/")
+        self._headers = {
+            "Content-Type": "application/json",
+            "Galileo-API-Key": api_key,
+            "X-Galileo-SDK": get_sdk_header(),
+        }
+        self._client = httpx.AsyncClient(timeout=60)
+
+    @async_warn_catch_exception(logger=_logger)
+    async def ingest_traces(self, traces_ingest_request: TracesIngestRequest) -> dict[str, Any]:
+        if self.experiment_id:
+            traces_ingest_request.experiment_id = UUID(self.experiment_id)
+        elif self.log_stream_id:
+            traces_ingest_request.log_stream_id = UUID(self.log_stream_id)
+
+        url = f"{self.base_url}{Routes.ingest_traces.format(project_id=self.project_id)}"
+        payload = traces_ingest_request.model_dump(mode="json", exclude_none=True)
+        _logger.info("IngestTraces: posting %d trace(s) to %s", len(traces_ingest_request.traces), url)
+        resp = await self._client.post(url, json=payload, headers=self._headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    @async_warn_catch_exception(logger=_logger)
+    async def ingest_spans(self, spans_ingest_request: SpansIngestRequest) -> dict[str, Any]:
+        if self.experiment_id:
+            spans_ingest_request.experiment_id = UUID(self.experiment_id)
+        elif self.log_stream_id:
+            spans_ingest_request.log_stream_id = UUID(self.log_stream_id)
+
+        url = f"{self.base_url}{Routes.ingest_spans.format(project_id=self.project_id)}"
+        payload = spans_ingest_request.model_dump(mode="json", exclude_none=True)
+        _logger.info("IngestTraces: posting %d span(s) to %s", len(spans_ingest_request.spans), url)
+        resp = await self._client.post(url, json=payload, headers=self._headers)
+        resp.raise_for_status()
+        return resp.json()

--- a/src/galileo/traces.py
+++ b/src/galileo/traces.py
@@ -1,4 +1,5 @@
 import logging
+from threading import local
 from typing import Any, Optional
 from uuid import UUID
 
@@ -189,7 +190,14 @@ class IngestTraces:
             "Galileo-API-Key": api_key,
             "X-Galileo-SDK": get_sdk_header(),
         }
-        self._client = httpx.AsyncClient(timeout=60)
+        self._thread_local = local()
+
+    @property
+    def _client(self) -> httpx.AsyncClient:
+        """Per-thread AsyncClient to avoid cross-event-loop errors."""
+        if not hasattr(self._thread_local, "client"):
+            self._thread_local.client = httpx.AsyncClient(timeout=60)
+        return self._thread_local.client
 
     @async_warn_catch_exception(logger=_logger)
     async def ingest_traces(self, traces_ingest_request: TracesIngestRequest) -> dict[str, Any]:


### PR DESCRIPTION
# User description
## Summary

- Adds `IngestTraces` client that sends traces/spans directly to the dedicated Go ingest service via `httpx`
- Routes ingestion to the ingest service when `GALILEO_INGEST_URL` env var is set, otherwise uses the existing API client
- Adds `/ingest/traces/{project_id}` and `/ingest/spans/{project_id}` route definitions

## Context

The Go ingest service handles multimodal content processing (base64 decoding, S3 upload, file ref rewriting). This PR adds the SDK-side routing so that when `GALILEO_INGEST_URL` is set (e.g. `http://localhost:8081`), traces go directly to the ingest service instead of the Python API.

This is primarily for internal Galileo testing of the ingest pipeline. No tests added intentionally, since the routing is validated via E2E tests against the local stack.

Related: https://github.com/rungalileo/galileo-python/pull/501

## Changes

**`src/galileo/constants/routes.py`**: Added `ingest_traces` and `ingest_spans` routes

**`src/galileo/traces.py`**: Added `IngestTraces` class that:
- Uses `httpx.AsyncClient` directly with `Galileo-API-Key` header auth
- Sets `log_stream_id`/`experiment_id` on requests (same as `Traces`)
- Has `ingest_traces()` and `ingest_spans()` methods posting to `/ingest/` routes

**`src/galileo/logger/logger.py`**: 
- Unified client creation into `_create_traces_client()` (was duplicated between init and lazy path)
- `_create_traces_client()` checks `GALILEO_INGEST_URL` env var and returns `IngestTraces` if set


Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce <code>IngestTraces</code> to post traces and spans through the <code>/ingest/...</code> endpoints using <code>httpx.AsyncClient</code>, SDK metadata, and <code>Galileo-API-Key</code> headers. Route <code>GalileoLogger</code> to instantiate <code>IngestTraces</code> when <code>GALILEO_INGEST_URL</code> is set and fall back to <code>Traces</code> otherwise.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/520?tool=ast&topic=Ingest+client>Ingest client</a>
        </td><td>Introduce <code>IngestTraces</code> to send trace and span payloads directly to <code>/ingest/traces/{project_id}</code> and <code>/ingest/spans/{project_id}</code> with per-thread <code>httpx.AsyncClient</code>, headers, and SDK metadata such as <code>log_stream_id</code> or <code>experiment_id</code>.<details><summary>Modified files (2)</summary><ul><li>src/galileo/constants/routes.py</li>
<li>src/galileo/traces.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>vamaq@users.noreply.gi...</td><td>fix: Define explicit e...</td><td>February 03, 2026</td></tr>
<tr><td>nachiket@galileo.ai</td><td>feat: Upgrade linters ...</td><td>September 24, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/520?tool=ast&topic=Client+selection>Client selection</a>
        </td><td>Route <code>GalileoLogger</code>'s <code>_create_traces_client</code> to return <code>IngestTraces</code> when <code>GALILEO_INGEST_URL</code> is configured and log that endpoint usage, while otherwise creating the existing <code>Traces</code> client.<details><summary>Modified files (1)</summary><ul><li>src/galileo/logger/logger.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>pratyusha@galileo.ai</td><td>feat: serialize trace ...</td><td>March 24, 2026</td></tr>
<tr><td>calebe.sep@hotmail.com</td><td>fix: auto-convert non-...</td><td>March 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/520?tool=ast>(Baz)</a>.