### PR TITLE
feat(experiments): add on_error callback to flush and experiment run

### DIFF
--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -1089,6 +1089,7 @@ class GalileoDecorator:
         log_stream: str | None = None,
         experiment_id: str | None = None,
         mode: str | None = None,
+        on_error: Callable[[Exception], None] | None = None,
     ) -> None:
         """
         Upload all captured traces under a project and log stream context to Galileo.
@@ -1105,14 +1106,29 @@ class GalileoDecorator:
             The experiment ID. Defaults to None.
         mode
             The logger mode. Defaults to None.
+        on_error
+            Optional callback invoked with the exception when a flush error occurs. If None,
+            a warning is logged instead. Defaults to None.
         """
-        # Telemetry initialization errors should not crash user code
+
+        # Build a wrapper that logs via this module's logger (so callers can patch
+        # "galileo.decorator._logger") and then forwards to the user callback.
+        def _on_flush_error(exc: Exception) -> None:
+            if on_error is not None:
+                _logger.debug(f"Galileo flush failed, continuing without flushing: {exc}")
+                try:
+                    on_error(exc)
+                except Exception as cb_exc:
+                    _logger.warning(f"Galileo flush on_error callback raised: {cb_exc}")
+            else:
+                _logger.warning(f"Galileo flush failed, continuing without flushing: {exc}")
+
         try:
             self.get_logger_instance(
                 project=project, log_stream=log_stream, experiment_id=experiment_id, mode=mode
-            ).flush()
+            ).flush(on_error=_on_flush_error)
         except Exception as e:
-            _logger.warning(f"Galileo flush failed, continuing without flushing: {e}")
+            _on_flush_error(e)
 
         # Reset trace state if we're flushing the current context
         current_mode = _get_mode_or_default(mode) if mode is not None else _mode_context.get()

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -196,6 +196,7 @@ class Experiments:
         records: builtins.list[DatasetRecord] | None,
         func: Callable,
         local_metrics: builtins.list[LocalMetricConfig],
+        on_error: Callable[[Exception], None] | None = None,
     ) -> dict[str, Any]:
         if dataset_obj is None and records is None:
             raise ValueError("Either dataset_obj or records must be provided")
@@ -213,7 +214,7 @@ class Experiments:
                 galileo_context.reset_trace_context()
                 if getsizeof(results) > MAX_REQUEST_SIZE_BYTES or len(results) >= MAX_INGEST_BATCH_SIZE:
                     _logger.info("Flushing logger due to size limit")
-                    galileo_context.flush()
+                    galileo_context.flush(on_error=on_error)
                     results = []
         # For dataset object, paginate through content
         elif dataset_obj is not None:
@@ -236,13 +237,13 @@ class Experiments:
                         galileo_context.reset_trace_context()
                         if getsizeof(results) > MAX_REQUEST_SIZE_BYTES or len(results) >= MAX_INGEST_BATCH_SIZE:
                             _logger.info("Flushing logger due to size limit")
-                            galileo_context.flush()
+                            galileo_context.flush(on_error=on_error)
                             results = []
 
                     starting_token += len(batch_records)
 
         # flush the logger
-        galileo_context.flush()
+        galileo_context.flush(on_error=on_error)
 
         _logger.info(f" {len(results)} rows processed for experiment {experiment_obj.name}.")
 
@@ -282,6 +283,7 @@ def run_experiment(
     metrics: list[GalileoMetrics | Metric | LocalMetricConfig | str] | None = None,
     function: Callable | None = None,
     experiment_tags: dict[str, str] | None = None,
+    on_error: Callable[[Exception], None] | None = None,
 ) -> Any:
     """
     Run an experiment with the specified parameters.
@@ -319,6 +321,11 @@ def run_experiment(
         Optional function to run with the experiment
     experiment_tags
         Optional dictionary of key-value pairs to tag the experiment with
+    on_error
+        Optional callback invoked with the exception when a flush error occurs. Only applies
+        to the function flow — ignored in the prompt-template flow (a warning is logged if
+        provided there). Creation errors always propagate regardless of this callback. If None,
+        flush errors are logged as warnings. Defaults to None.
 
     Returns
     -------
@@ -390,6 +397,7 @@ def run_experiment(
             records=records,
             func=function,
             local_metrics=local_metrics,
+            on_error=on_error,
         )
 
     if dataset_obj is None:
@@ -403,6 +411,12 @@ def run_experiment(
 
     if local_metrics_check:
         raise ValueError("Local metrics can only be used with a locally run experiment, not a prompt experiment.")
+
+    if on_error is not None:
+        _logger.warning(
+            "on_error was provided but will not be invoked in the prompt-template flow "
+            "(no flush occurs on this path). on_error is only used in the function flow."
+        )
 
     # Execute a prompt template or generated-output experiment via trigger=True.
     # Single API call: creates experiment + triggers runner job.

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -1731,10 +1731,17 @@ class GalileoLogger(TracesLogger):
         return current_parent
 
     @nop_sync
-    @warn_catch_exception(exceptions=(Exception,))
-    def flush(self) -> list[LoggedTrace]:
+    def flush(self, on_error: Callable[[Exception], None] | None = None) -> list[LoggedTrace]:
         """
         Upload all traces to Galileo.
+
+        Parameters
+        ----------
+        on_error : Optional[Callable[[Exception], None]]
+            Callback invoked when a flush error occurs. When provided the exception
+            is passed to the callback instead of being logged as a warning. The
+            callback itself is protected: if it raises, the exception is logged as a warning.
+            Defaults to None (swallow and log warning).
 
         Returns
         -------
@@ -1742,13 +1749,28 @@ class GalileoLogger(TracesLogger):
             The list of uploaded traces.
         """
         try:
-            if self.mode == "distributed":
-                return async_run(self._flush_distributed())
-            return async_run(self._flush_batch())
-        finally:
-            # Reset parent tracking in the main thread (async_run uses thread pool).
-            # Using finally ensures cleanup even if ingestion fails.
-            self._set_current_parent(None)
+            try:
+                if self.mode == "distributed":
+                    return async_run(self._flush_distributed())
+                return async_run(self._flush_batch())
+            finally:
+                # Reset parent tracking in the main thread (async_run uses thread pool).
+                # Using finally ensures cleanup even if ingestion fails.
+                self._set_current_parent(None)
+        except Exception as e:
+            if on_error is not None:
+                # Guard the callback so a buggy on_error never crashes the caller.
+                # When flush() is called through GalileoDecorator, the decorator wraps
+                # the user callback in _on_flush_error before passing it here, so this
+                # try/except is effectively a no-op on that path — it exists solely for
+                # callers that invoke flush() directly and supply their own callback.
+                try:
+                    on_error(e)
+                except Exception as cb_exc:
+                    self._logger.warning(f"on_error callback raised: {cb_exc}")
+            else:
+                self._logger.warning(f"Ingestion error in flush: {e}")
+            return []
 
     @nop_async
     @async_warn_catch_exception(exceptions=(Exception,))
@@ -1869,7 +1891,6 @@ class GalileoLogger(TracesLogger):
                 self._wait_for_pending_span_ingests(timeout_seconds=DISTRIBUTED_FLUSH_TIMEOUT_SECONDS)
                 self._update_trace_streaming(trace, is_complete=True)
 
-    @async_warn_catch_exception(exceptions=(Exception,))
     async def _flush_distributed(self) -> list[LoggedTrace]:
         """Flush in distributed mode: conclude traces and wait for pending tasks.
 
@@ -1899,7 +1920,6 @@ class GalileoLogger(TracesLogger):
 
         return []
 
-    @async_warn_catch_exception(exceptions=(Exception,))
     async def _flush_batch(self) -> list[LoggedTrace]:
         """Flush in batch mode: conclude unconcluded traces and send all traces to backend."""
         if not self.traces:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1552,3 +1552,121 @@ def test_start_session_overrides_context_session(
         new_session_id = galileo_context.start_session(name="new-session")
         assert galileo_context.get_logger_instance().session_id == new_session_id
         assert _session_id_context.get() == new_session_id
+
+
+@patch("galileo.logger.logger.LogStreams")
+@patch("galileo.logger.logger.Projects")
+@patch("galileo.logger.logger.Traces")
+def test_flush_on_error_called_when_flush_raises(
+    mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
+) -> None:
+    # Given: the logger's flush raises and an on_error callback is provided
+    mock_traces_client_instance = setup_mock_traces_client(mock_traces_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+    flush_error = RuntimeError("network error")
+    mock_traces_client_instance.ingest_traces.side_effect = flush_error
+
+    on_error = Mock()
+
+    galileo_context.init(project="project-X", log_stream="log-stream-X")
+
+    @log(span_type="llm")
+    def llm_call(query: str) -> str:
+        return "response"
+
+    llm_call(query="input")
+
+    # When: flush is called with on_error
+    galileo_context.flush(on_error=on_error)
+
+    # Then: on_error is invoked with the exception; no warning is raised
+    on_error.assert_called_once()
+    assert isinstance(on_error.call_args[0][0], Exception)
+
+
+@patch("galileo.logger.logger.LogStreams")
+@patch("galileo.logger.logger.Projects")
+@patch("galileo.logger.logger.Traces")
+def test_flush_warns_when_flush_raises_without_on_error(
+    mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
+) -> None:
+    # Given: the logger's flush raises and no on_error callback is provided
+    mock_traces_client_instance = setup_mock_traces_client(mock_traces_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+    mock_traces_client_instance.ingest_traces.side_effect = RuntimeError("network error")
+
+    galileo_context.init(project="project-X", log_stream="log-stream-X")
+
+    @log(span_type="llm")
+    def llm_call(query: str) -> str:
+        return "response"
+
+    llm_call(query="input")
+
+    # When/Then: flush does not raise; a warning is logged instead
+
+    with patch("galileo.decorator._logger") as mock_logger:
+        galileo_context.flush()
+        mock_logger.warning.assert_called_once()
+        assert "flush failed" in mock_logger.warning.call_args[0][0]
+
+
+@patch("galileo.logger.logger.LogStreams")
+@patch("galileo.logger.logger.Projects")
+@patch("galileo.logger.logger.Traces")
+def test_flush_on_error_callback_raises_is_swallowed(
+    mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
+) -> None:
+    # Given: the logger's flush raises, on_error is provided but also raises
+    mock_traces_client_instance = setup_mock_traces_client(mock_traces_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+    mock_traces_client_instance.ingest_traces.side_effect = RuntimeError("network error")
+
+    def bad_callback(exc: Exception) -> None:
+        raise ValueError("callback failed")
+
+    galileo_context.init(project="project-X", log_stream="log-stream-X")
+
+    @log(span_type="llm")
+    def llm_call(query: str) -> str:
+        return "response"
+
+    llm_call(query="input")
+
+    # When/Then: flush does not raise even though the callback raises
+    with patch("galileo.decorator._logger") as mock_logger:
+        galileo_context.flush(on_error=bad_callback)  # must not raise
+        mock_logger.warning.assert_called_once()
+        assert "on_error callback raised" in mock_logger.warning.call_args[0][0]
+
+
+@patch("galileo.logger.logger.LogStreams")
+@patch("galileo.logger.logger.Projects")
+@patch("galileo.logger.logger.Traces")
+def test_flush_on_error_logs_at_debug_not_warning(
+    mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
+) -> None:
+    # Given: the logger's flush raises and an on_error callback is provided
+    mock_traces_client_instance = setup_mock_traces_client(mock_traces_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+    mock_traces_client_instance.ingest_traces.side_effect = RuntimeError("network error")
+
+    galileo_context.init(project="project-X", log_stream="log-stream-X")
+
+    @log(span_type="llm")
+    def llm_call(query: str) -> str:
+        return "response"
+
+    llm_call(query="input")
+
+    # When: flush is called with on_error
+    with patch("galileo.decorator._logger") as mock_logger:
+        galileo_context.flush(on_error=Mock())
+
+        # Then: debug is called, not warning
+        mock_logger.debug.assert_called_once()
+        mock_logger.warning.assert_not_called()

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from functools import reduce
 from statistics import mean
 from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import call as mock_call
 from uuid import UUID
 
 import pytest
@@ -1040,6 +1041,21 @@ class TestExperiments:
         assert ps_dict["temperature"] == 0.5
         assert ps_dict["max_tokens"] == 256
 
+    @patch.object(galileo.experiments.Experiments, "create")
+    def test_experiments_run_raises_when_create_raises(self, mock_create: Mock) -> None:
+        # Given: Experiments.create raises
+        mock_create.side_effect = RuntimeError("API unavailable")
+
+        # When/Then: the exception propagates — create() is a resource management operation
+        with pytest.raises(RuntimeError, match="API unavailable"):
+            Experiments().run(
+                project_obj=project(),
+                dataset_obj=Mock(spec=galileo.datasets.Dataset),
+                experiment_name="test_experiment",
+                prompt_template=None,
+                scorers=None,
+            )
+
     @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
     def test_experiments_run_with_prompt_settings_as_dict(self, mock_create: Mock) -> None:
         # Given: a project, dataset, and prompt_settings passed as a plain dict
@@ -1129,6 +1145,111 @@ class TestExperiments:
             payload.traces[0].input == '{"input": {"question": "Which continent is Spain in?", "expected": "Europe"}}'
         )
         assert payload.traces[0].output == "Say hello: Which continent is Spain in?"
+
+    @travel(datetime(2012, 1, 1), tick=False)
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.experiments.Experiments, "create")
+    @patch.object(galileo.experiments.Experiments, "get")
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
+    def test_run_experiment_raises_when_create_raises(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_experiment: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ) -> None:
+        # Given: Experiments.create raises
+        mock_create_experiment.side_effect = RuntimeError("server error")
+
+        # When/Then: the exception propagates regardless of on_error — create() is a resource management operation
+        with pytest.raises(RuntimeError, match="server error"):
+            run_experiment(
+                "test_experiment",
+                project="awesome-new-project",
+                dataset_id=str(UUID(int=0)),
+                prompt_template=prompt_template(),
+            )
+
+    @travel(datetime(2012, 1, 1), tick=False)
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(
+        galileo.experiments.Experiments,
+        "run",
+        return_value={"experiment": experiment_response(), "link": "http://example.com", "message": "done"},
+    )
+    @patch.object(galileo.experiments.Experiments, "get", return_value=None)
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
+    def test_run_experiment_on_error_warns_when_unused_in_prompt_template_flow(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_run: Mock,
+        mock_get_dataset: Mock,
+        dataset_content: DatasetContent,
+    ) -> None:
+        # Given: an on_error callback is provided for the prompt-template flow
+        on_error = Mock()
+
+        # When: run_experiment() is called with a prompt template and on_error
+        with patch("galileo.experiments._logger") as mock_logger:
+            run_experiment(
+                "test_experiment",
+                project="awesome-new-project",
+                dataset_id=str(UUID(int=0)),
+                prompt_template=prompt_template(),
+                on_error=on_error,
+            )
+
+        # Then: a warning is logged and on_error is never invoked
+        mock_logger.warning.assert_any_call(
+            "on_error was provided but will not be invoked in the prompt-template flow "
+            "(no flush occurs on this path). on_error is only used in the function flow."
+        )
+        on_error.assert_not_called()
+
+    @patch("galileo.logger.logger.LogStreams")
+    @patch("galileo.logger.logger.Projects")
+    @patch("galileo.logger.logger.Traces")
+    @patch.object(galileo.datasets.Datasets, "get")
+    @patch.object(galileo.experiments.Experiments, "create", return_value=experiment_response())
+    @patch.object(galileo.experiments.Experiments, "get", return_value=experiment_response())
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
+    def test_run_experiment_on_error_passed_to_flush_in_function_flow(
+        self,
+        mock_get_project: Mock,
+        mock_get_experiment: Mock,
+        mock_create_experiment: Mock,
+        mock_get_dataset: Mock,
+        mock_traces_client: Mock,
+        mock_projects_client: Mock,
+        mock_logstreams_client: Mock,
+        dataset_content: DatasetContent,
+        reset_context,
+    ) -> None:
+        # Given: an on_error callback is provided for the function flow
+        setup_mock_traces_client(mock_traces_client)
+        setup_mock_projects_client(mock_projects_client)
+        setup_mock_logstreams_client(mock_logstreams_client)
+        mock_get_dataset_instance = mock_get_dataset.return_value
+        mock_get_dataset_instance.get_content = MagicMock(
+            side_effect=lambda starting_token=0, limit=1000: dataset_content if starting_token == 0 else None
+        )
+        on_error = Mock()
+
+        # When: run_experiment() is called with a function and on_error (function flow)
+        with patch("galileo.experiments.galileo_context.flush") as mock_flush:
+            run_experiment(
+                experiment_name="test_experiment",
+                project="awesome-new-project",
+                dataset_id=str(UUID(int=0, version=4)),
+                function=lambda x: "output",
+                on_error=on_error,
+            )
+
+        # Then: every flush call received on_error — no call was made without it
+        assert mock_flush.call_count >= 1
+        assert all(c == mock_call(on_error=on_error) for c in mock_flush.call_args_list)
 
     @patch.object(galileo.datasets.Datasets, "get")
     def test_run_experiment_with_prompt_template_and_function(


### PR DESCRIPTION
# User description
**Shortcut:**
[SC-56022](https://app.shortcut.com/galileo/story/56022/run-experiment-hides-flush-errors-causing-0-trace-failures)

**Description:**

Adds an optional on_error parameter to GalileoDecorator.flush(), Experiments.run(), Experiments.run_with_function(), and run_experiment().
When provided, flush errors log at debug level and invoke the callback instead of logging a warning. Experiments.run() also uses on_error to handle creation failures without raising when a callback is supplied.

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add optional <code>on_error</code> callbacks to the flush pipeline so callers can handle ingestion failures without flooding warnings from <code>GalileoDecorator</code> and <code>GalileoLogger</code>. Propagate the callback through the <code>Experiments</code> flows and <code>run_experiment</code> to keep creation failures raised while warning when the hook is unused in the prompt-template path.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/537?tool=ast&topic=Flush+error+handling>Flush error handling</a>
        </td><td>Guard flush errors by logging at debug when a callback exists, invoking the user-supplied <code>on_error</code>, and warning if the callback itself raises.<details><summary>Modified files (3)</summary><ul><li>src/galileo/decorator.py</li>
<li>src/galileo/logger/logger.py</li>
<li>tests/test_decorator.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>pratyusha@galileo.ai</td><td>feat: serialize trace ...</td><td>March 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/537?tool=ast&topic=Experiment+on_error+path>Experiment on_error path</a>
        </td><td>Extend the experiment flows to accept <code>on_error</code>, route it into the function-run flushes, and warn when it cannot be used in the prompt-template path while keeping creation failures raised.<details><summary>Modified files (2)</summary><ul><li>src/galileo/experiments.py</li>
<li>tests/test_experiments.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix: regression issues...</td><td>April 05, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/537?tool=ast>(Baz)</a>.