### PR TITLE
feat(logger): validate input types in start_trace

### DIFF
--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -18,7 +18,7 @@ from galileo.exceptions import GalileoLoggerException
 from galileo.log_streams import LogStreams
 from galileo.logger.task_handler import ThreadPoolTaskHandler
 from galileo.projects import Projects
-from galileo.schema.content_blocks import is_content_block_list
+from galileo.schema.content_blocks import is_content_block_list, normalize_content_block_list
 from galileo.schema.logged import (
     IngestOutputType,
     LoggedAgentSpan,
@@ -488,6 +488,45 @@ class GalileoLogger(TracesLogger):
         return serialize_to_str(value)
 
     @staticmethod
+    def _coerce_trace_input(param_name: str, value: object) -> TextOrContentBlocks | None:
+        """Validate and normalize a ``start_trace`` input/redacted_input value.
+
+        Accepted types and their treatment:
+
+        - ``None`` or ``str``: returned as-is.
+        - ``dict``: serialized to a JSON string (common user mistake).
+        - ``list`` of content block model instances or matching dicts: coerced to
+          a list of ``TextContentBlock``/``DataContentBlock`` model instances.
+        - ``list[dict]`` whose elements don't match the content block schema
+          (message-like lists): serialized to a JSON string.
+
+        Raises ``TypeError`` for any other type or a list with mixed/unsupported
+        element types.
+        """
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            return json.dumps(value)
+        if isinstance(value, list):
+            normalized = normalize_content_block_list(value)
+            if normalized is not None:
+                return normalized
+            if all(isinstance(i, dict) for i in value):
+                # Message-like list[dict]: serialize to JSON
+                return json.dumps(value)
+            raise TypeError(
+                f"start_trace() argument '{param_name}' must be str, dict, list[dict], or "
+                f"list[TextContentBlock | DataContentBlock]; "
+                f"got list with mixed or unsupported element types"
+            )
+        raise TypeError(
+            f"start_trace() argument '{param_name}' must be str, dict, list[dict], or "
+            f"list[TextContentBlock | DataContentBlock]; got {type(value).__name__}"
+        )
+
+    @staticmethod
     @nop_sync
     @warn_catch_exception(exceptions=(Exception,))
     def _get_last_output(node: BaseStep | None) -> tuple[IngestOutputType | None, IngestOutputType | None]:
@@ -811,7 +850,7 @@ class GalileoLogger(TracesLogger):
         return headers
 
     @nop_sync
-    @warn_catch_exception(exceptions=(Exception,))
+    @warn_catch_exception()
     def start_trace(
         self,
         input: TextOrContentBlocks | dict,
@@ -875,11 +914,9 @@ class GalileoLogger(TracesLogger):
         LoggedTrace
             The created trace.
         """
-        # Auto-convert dict input to JSON string (addresses common user mistake)
-        if isinstance(input, dict):
-            input = json.dumps(input)
-        if isinstance(redacted_input, dict):
-            redacted_input = json.dumps(redacted_input)
+        # Validate and normalize input types (dict→JSON, list[dict]→JSON or content blocks)
+        input = GalileoLogger._coerce_trace_input("input", input)
+        redacted_input = GalileoLogger._coerce_trace_input("redacted_input", redacted_input)
 
         # Auto-convert non-string metadata values to strings
         # Note: Must use class name, not self, because DecorateAllMethods removes @staticmethod

--- a/src/galileo/schema/content_blocks.py
+++ b/src/galileo/schema/content_blocks.py
@@ -10,7 +10,7 @@ while read-side ContentParts reference stored files by file_id.
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, TypeAdapter, model_validator
 
 from galileo_core.schemas.shared.multimodal import ContentModality
 
@@ -54,3 +54,27 @@ IngestMessageContent = str | list[IngestContentBlock]
 def is_content_block_list(value: object) -> bool:
     """True when value is a (possibly empty) list whose elements are content blocks."""
     return isinstance(value, list) and all(isinstance(v, TextContentBlock | DataContentBlock) for v in value)
+
+
+_content_block_adapter: TypeAdapter[IngestContentBlock] = TypeAdapter(IngestContentBlock)
+
+
+def normalize_content_block_list(value: list) -> list[TextContentBlock | DataContentBlock] | None:
+    """Normalize a list to content block model instances, or return ``None``.
+
+    Accepts lists whose elements are already ``TextContentBlock``/``DataContentBlock``
+    instances or dicts matching the content block schema (discriminated on ``type``).
+    Returns ``None`` when any element cannot be coerced (e.g. message-like dicts).
+    """
+    result: list[TextContentBlock | DataContentBlock] = []
+    for item in value:
+        if isinstance(item, TextContentBlock | DataContentBlock):
+            result.append(item)
+        elif isinstance(item, dict):
+            try:
+                result.append(_content_block_adapter.validate_python(item))
+            except Exception:
+                return None
+        else:
+            return None
+    return result

--- a/tests/test_logger_batch.py
+++ b/tests/test_logger_batch.py
@@ -1927,6 +1927,73 @@ def test_multimodal_input_not_stringified_at_trace_level(
 
 
 @pytest.mark.parametrize(
+    "valid_input",
+    [
+        pytest.param("Say this is a test", id="string"),
+        pytest.param({"query": "hello", "context": "world"}, id="dict"),
+        pytest.param([TextContentBlock(text="Analyze this")], id="text_content_block_list"),
+        pytest.param(
+            [DataContentBlock(modality=ContentModality.image, url="https://example.com/img.png")],
+            id="data_content_block_list",
+        ),
+        pytest.param(
+            [
+                TextContentBlock(text="Describe this image"),
+                DataContentBlock(modality=ContentModality.image, url="https://example.com/img.png"),
+            ],
+            id="mixed_content_block_list",
+        ),
+        pytest.param([{"type": "text", "text": "Describe this image"}], id="text_content_block_dict"),
+        pytest.param(
+            [{"type": "data", "modality": "image", "url": "https://example.com/img.png"}], id="data_content_block_dict"
+        ),
+        pytest.param(
+            [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}], id="message_like_list_dict"
+        ),
+    ],
+)
+@patch("galileo.logger.logger.LogStreams")
+@patch("galileo.logger.logger.Projects")
+@patch("galileo.logger.logger.Traces")
+def test_start_trace_valid_input_types(
+    mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, valid_input: object
+) -> None:
+    """start_trace accepts all valid input types: str, dict, and list[ContentBlock]."""
+    setup_mock_traces_client(mock_traces_client)
+    setup_mock_projects_client(mock_projects_client)
+    setup_mock_logstreams_client(mock_logstreams_client)
+
+    # Given: a logger and a valid input value
+    logger = GalileoLogger(project="my_project", log_stream="my_log_stream")
+
+    # When: starting a trace with the valid input
+    trace = logger.start_trace(input=valid_input)
+
+    # Then: the trace is created without error
+    assert trace is not None
+
+
+def test_start_trace_invalid_input_type_raises() -> None:
+    """start_trace raises TypeError when given an unsupported input type."""
+    # Given: a logger initialized with an ingestion hook (bypasses project/log-stream API calls)
+    logger = GalileoLogger(project="my_project", log_stream="my_log_stream", ingestion_hook=lambda x: None)
+
+    # When/Then: starting a trace with an unsupported type raises TypeError
+    with pytest.raises(TypeError, match="start_trace\\(\\) argument 'input'"):
+        logger.start_trace(input=42)  # type: ignore[arg-type]
+
+
+def test_start_trace_invalid_redacted_input_type_raises() -> None:
+    """start_trace raises TypeError when redacted_input has an unsupported type."""
+    # Given: a logger initialized with an ingestion hook (bypasses project/log-stream API calls)
+    logger = GalileoLogger(project="my_project", log_stream="my_log_stream", ingestion_hook=lambda x: None)
+
+    # When/Then: a list of non-dict, non-content-block elements raises TypeError
+    with pytest.raises(TypeError, match="start_trace\\(\\) argument 'redacted_input'"):
+        logger.start_trace(input="valid input", redacted_input=["not", "content", "blocks"])  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
     "span_method,span_kwargs,expected_metadata",
     [
         pytest.param(


### PR DESCRIPTION
# User description
**Shortcut:**
[sc-54238](https://app.shortcut.com/galileo/story/54238/qa2-0-sdk-ls-no-error-but-trace-not-created)

**Description:**

  - start_trace() now raises TypeError when input or redacted_input is not one of the     
  accepted types: str, dict, or list[TextContentBlock | DataContentBlock]
  - Invalid values are caught by the existing @warn_catch_exception decorator and surfaced
   as a warning, consistent with the SDK's telemetry resilience pattern (bad input doesn't
   crash the user's application)  

**Tests:**

  - test_start_trace_valid_input_types — parametrized over all 5 valid forms: plain       
  string, dict, list[TextContentBlock], list[DataContentBlock], mixed list
  - test_start_trace_invalid_input_type_returns_none — integer input returns None and     
  emits a warning                                                                         
  - test_start_trace_invalid_redacted_input_type_returns_none — list[str] for            
  redacted_input returns None and emits a warning                                         
  - Full test_logger_batch.py suite (82 tests) passes

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Validate <code>start_trace</code> input handling by routing <code>GalileoLogger</code> through <code>_coerce_trace_input</code>, which accepts strings, dicts, and normalized content-block lists while raising errors for unsupported values before surfacing warnings via <code>warn_catch_exception</code>. Reinforce content-block normalization through updates to <code>normalize_content_block_list</code> and the logger test suite so all valid and invalid inputs are exercised and trace failures no longer happen silently.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/539?tool=ast&topic=Trace+input+tests>Trace input tests</a>
        </td><td>Validate the new input rules with parameterized coverage of every accepted form plus invalid <code>input</code>/<code>redacted_input</code> cases to ensure errors surface consistently.<details><summary>Modified files (1)</summary><ul><li>tests/test_logger_batch.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>pratyusha@galileo.ai</td><td>feat: serialize trace ...</td><td>March 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/539?tool=ast&topic=Trace+input+validation>Trace input validation</a>
        </td><td>Validate <code>start_trace</code> input and <code>redacted_input</code> via <code>_coerce_trace_input</code>, emitting warnings for bad values, serializing dicts/message-like lists, normalizing blocks through <code>normalize_content_block_list</code>, and raising <code>TypeError</code> when unsupported types are mixed or invalid.<details><summary>Modified files (2)</summary><ul><li>src/galileo/logger/logger.py</li>
<li>src/galileo/schema/content_blocks.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>pratyusha@galileo.ai</td><td>feat: serialize trace ...</td><td>March 24, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/539?tool=ast>(Baz)</a>.