### PR TITLE
fix: resolve OpenAI test failures when Azure env vars are set

### DIFF
--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -18,6 +18,11 @@ from tests.testutils.streaming import EventStream, ResponsesEventStream
 def ensure_openai_api_key(monkeypatch):
     """Ensure OPENAI_API_KEY is set for OpenAI tests."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    # When both OPENAI_API_KEY and AZURE_OPENAI_* env vars are set, the openai module-level
+    # client raises _AmbiguousModuleClientUsageError. We must set both the env var and the
+    # module attribute because openai.api_type is cached at import time from OPENAI_API_TYPE.
+    monkeypatch.setenv("OPENAI_API_TYPE", "openai")
+    monkeypatch.setattr("openai.api_type", "openai")
 
 
 def openai_incorrect_api_key_error() -> bytes:


### PR DESCRIPTION
# User description
## Summary
- Fixes all 13 `tests/test_openai.py` failures caused by `_AmbiguousModuleClientUsageError` when both `OPENAI_API_KEY` and `AZURE_OPENAI_*` environment variables are set
- Sets `OPENAI_API_TYPE=openai` env var and patches `openai.api_type` module attribute in the test fixture to explicitly disambiguate the API backend
- Both are needed because `openai.api_type` is cached at module import time from the env var

## Test plan
- [x] All 13 previously failing tests in `tests/test_openai.py` now pass
- [ ] CI passes

[sc-61948](https://app.shortcut.com/galileo/story/61948)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enforce the <code>openai</code> backend in the <code>ensure_openai_api_key</code> fixture so the module-level client always uses standard OpenAI even if Azure env vars are present. Keep both the <code>OPENAI_API_TYPE</code> env var and the cached <code>openai.api_type</code> attribute aligned to unblock the entire <code>tests/test_openai.py</code> suite.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>vamaq@users.noreply.gi...</td><td>fix: Define explicit e...</td><td>February 03, 2026</td></tr>
<tr><td>Focadecombate</td><td>feat: add support for ...</td><td>January 15, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/540?tool=ast>(Baz)</a>.