### PR TITLE
fix(docs): update span docstrings with accurate input formats

### DIFF
--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -1246,16 +1246,16 @@ class GalileoLogger(TracesLogger):
         input: str
             Query string passed to the retriever.
             Example: `"What is the capital of France?"`
-        output: Union[str, list[str], dict, list[dict], Document, list[Document], None]
+        output: Union[str, list[str], dict[str, str], list[dict[str, str]], Document, list[Document], None]
             Documents retrieved by the retriever.
-            Accepted formats: string, list of strings, dict, list of dicts,
+            Accepted formats: string, list of strings, dict[str, str], list of dict[str, str],
             Document, list of Documents, or None.
             Example (Documents): `[Document(content="Paris is the capital.", metadata={"source": "wiki"})]`
             Example (strings): `["Paris is the capital.", "France is in Europe."]`
             Example (dicts): `[{"content": "Paris is the capital."}]`
         redacted_input: Optional[str]
             Redacted version of the query string (sensitive information removed).
-        redacted_output: Union[str, list[str], dict, list[dict], Document, list[Document], None]
+        redacted_output: Union[str, list[str], dict[str, str], list[dict[str, str]], Document, list[Document], None]
             Redacted version of the retrieved documents (sensitive information removed).
             Same accepted formats as output.
         name: Optional[str]

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -947,12 +947,17 @@ class GalileoLogger(TracesLogger):
         ----------
         input: LlmSpanAllowedInputType
             Input to the node.
-            Expected format: List of Message objects.
-            Example: `[Message(content="Say this is a test", role=MessageRole.user)]`
+            Accepted formats: list of Message objects, single Message, plain string,
+            dict, or list of dicts.
+            Example (Messages): `[Message(content="Say this is a test", role=MessageRole.user)]`
+            Example (string): `"Say this is a test"`
+            Example (dict): `{"content": "Say this is a test", "role": "user"}`
         output: LlmSpanAllowedOutputType
             Output of the node.
-            Expected format: Single Message object.
-            Example: `Message(content="The response text", role=MessageRole.assistant)`
+            Accepted formats: Message object, plain string, or dict.
+            Example (Message): `Message(content="The response text", role=MessageRole.assistant)`
+            Example (string): `"The response text"`
+            Example (dict): `{"content": "The response text", "role": "assistant"}`
         model: Optional[str]
             Model used for this span.
             Example: "gpt-4o", "claude-4-sonnet"
@@ -1111,12 +1116,17 @@ class GalileoLogger(TracesLogger):
         ----------
         input: LlmSpanAllowedInputType
             Input to the node.
-            Expected format: List of Message objects.
-            Example: `[Message(content="Say this is a test", role=MessageRole.user)]`
+            Accepted formats: list of Message objects, single Message, plain string,
+            dict, or list of dicts.
+            Example (Messages): `[Message(content="Say this is a test", role=MessageRole.user)]`
+            Example (string): `"Say this is a test"`
+            Example (dict): `{"content": "Say this is a test", "role": "user"}`
         output: LlmSpanAllowedOutputType
             Output of the node.
-            Expected format: Single Message object.
-            Example: `Message(content="The response text", role=MessageRole.assistant)`
+            Accepted formats: Message object, plain string, or dict.
+            Example (Message): `Message(content="The response text", role=MessageRole.assistant)`
+            Example (string): `"The response text"`
+            Example (dict): `{"content": "The response text", "role": "assistant"}`
         model: Optional[str]
             Model used for this span.
             Example: "gpt-4o", "claude-4-sonnet"
@@ -1234,13 +1244,20 @@ class GalileoLogger(TracesLogger):
         Parameters
         ----------
         input: str
-            Input to the node.
-        output: Union[str, list[str], dict[str, str], list[dict[str, str]], Document, list[Document], None]
-            Documents retrieved from the retriever.
+            Query string passed to the retriever.
+            Example: `"What is the capital of France?"`
+        output: Union[str, list[str], dict, list[dict], Document, list[Document], None]
+            Documents retrieved by the retriever.
+            Accepted formats: string, list of strings, dict, list of dicts,
+            Document, list of Documents, or None.
+            Example (Documents): `[Document(content="Paris is the capital.", metadata={"source": "wiki"})]`
+            Example (strings): `["Paris is the capital.", "France is in Europe."]`
+            Example (dicts): `[{"content": "Paris is the capital."}]`
         redacted_input: Optional[str]
-            Input that removes any sensitive information (redacted input to the node).
-        redacted_output: Union[str, list[str], dict[str, str], list[dict[str, str]], Document, list[Document], None]
-            Output that removes any sensitive information (redacted documents retrieved from the retriever).
+            Redacted version of the query string (sensitive information removed).
+        redacted_output: Union[str, list[str], dict, list[dict], Document, list[Document], None]
+            Redacted version of the retrieved documents (sensitive information removed).
+            Same accepted formats as output.
         name: Optional[str]
             Name of the span.
         duration_ns: Optional[int]

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -1284,16 +1284,16 @@ class GalileoLogger(TracesLogger):
         input: str
             Query string passed to the retriever.
             Example: `"What is the capital of France?"`
-        output: Union[str, list[str], dict[str, str], list[dict[str, str]], Document, list[Document], None]
+        output: Union[str, list[str], dict[str, Any], list[dict[str, Any]], Document, list[Document], None]
             Documents retrieved by the retriever.
-            Accepted formats: string, list of strings, dict[str, str], list of dict[str, str],
+            Accepted formats: string, list of strings, dict, list of dicts,
             Document, list of Documents, or None.
             Example (Documents): `[Document(content="Paris is the capital.", metadata={"source": "wiki"})]`
             Example (strings): `["Paris is the capital.", "France is in Europe."]`
             Example (dicts): `[{"content": "Paris is the capital."}]`
         redacted_input: Optional[str]
             Redacted version of the query string (sensitive information removed).
-        redacted_output: Union[str, list[str], dict[str, str], list[dict[str, str]], Document, list[Document], None]
+        redacted_output: Union[str, list[str], dict[str, Any], list[dict[str, Any]], Document, list[Document], None]
             Redacted version of the retrieved documents (sensitive information removed).
             Same accepted formats as output.
         name: Optional[str]

--- a/src/galileo/schema/trace.py
+++ b/src/galileo/schema/trace.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import UUID4, BaseModel, Field
 
@@ -151,5 +151,5 @@ class LogRecordsSearchRequest(BaseLogStreamOrExperimentModel):
 
 
 RetrieverSpanAllowedOutputType = (
-    str | list[str] | dict[str, str] | list[dict[str, str]] | Document | list[Document] | None
+    str | list[str] | dict[str, Any] | list[dict[str, Any]] | Document | list[Document] | None
 )


### PR DESCRIPTION
# User description
**Shortcut:** https://app.shortcut.com/galileo/story/54367

**Description:**

Update docstrings for `add_llm_span` and `add_retriever_span` in `GalileoLogger` to accurately document all accepted input/output formats.

- `add_llm_span`: Document that input accepts `list[Message]`, single `Message`, `str`, `dict`, or `list[dict]` (not just `list[Message]`). Output accepts `Message`, `str`, or `dict` (not just `Message`).
- `add_retriever_span`: Clarify that input is a query string, and output accepts `str`, `list[str]`, `dict`, `list[dict]`, `Document`, `list[Document]`, or `None`.

**Tests:**

- [ ] Unit Tests Added
- [x] No tests needed (documentation-only change)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document <code>add_llm_span</code> and <code>add_single_llm_span_trace</code> docstrings to enumerate every supported input and output type instead of implying only message sequences are accepted. Align retriever span documentation and <code>RetrieverSpanAllowedOutputType</code> with the actual query-input/output acceptance so users can find accurate format guidance.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/541?tool=ast&topic=LLM+span+docs>LLM span docs</a>
        </td><td>Clarify the accepted input/output formats for <code>add_llm_span</code> and <code>add_single_llm_span_trace</code>, covering strings, dicts, and lists alongside <code>Message</code> objects so the span documentation matches the real <code>LlmSpanAllowedInputType</code>/<code>OutputType</code> behavior.<details><summary>Modified files (1)</summary><ul><li>src/galileo/logger/logger.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>feat(experiments): add...</td><td>April 09, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/541?tool=ast&topic=Retriever+span+docs>Retriever span docs</a>
        </td><td>Clarify the retriever span documentation with query string inputs and all supported output variants, and update <code>RetrieverSpanAllowedOutputType</code> to allow <code>dict[str, Any]</code> so the SDK docs describe the actual formats returned by the retriever.<details><summary>Modified files (2)</summary><ul><li>src/galileo/logger/logger.py</li>
<li>src/galileo/schema/trace.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>feat(experiments): add...</td><td>April 09, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/541?tool=ast>(Baz)</a>.