### PR TITLE
ci(a2a): add test and release workflows for galileo-a2a

### DIFF
--- a/.github/workflows/release-a2a.yaml
+++ b/.github/workflows/release-a2a.yaml
@@ -1,0 +1,155 @@
+name: Release galileo-a2a
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 0.8.0, 1.0.0-beta.1). Leave empty for automatic semantic versioning.'
+        required: false
+        type: string
+      prerelease:
+        description: 'Mark as pre-release?'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # Required for OIDC trusted publishing to PyPI
+      contents: write   # Required for creating releases, tags, and pushing commits
+
+    defaults:
+      run:
+        working-directory: galileo-a2a
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GALILEO_AUTOMATION_GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install --upgrade pip build hatchling
+
+      # =======================================================================
+      # PATH 1: Custom Version (Manual Override)
+      # =======================================================================
+      - name: Set Custom Version
+        id: custom_version
+        if: inputs.version != ''
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Validate version matches strict semver pattern
+          if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Invalid version format: '${INPUT_VERSION}'. Must match semver (e.g., 1.2.3 or 1.2.3-beta.1)."
+            exit 1
+          fi
+
+          VERSION="$INPUT_VERSION"
+          echo "Using custom version: ${VERSION}"
+
+          # Update version in pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
+
+          # Update version in __init__.py
+          sed -i "s/__version__ = \".*\"/__version__ = \"${VERSION}\"/" src/galileo_a2a/__init__.py
+
+          # Configure git
+          git config user.name "galileo-automation"
+          git config user.email "ci@rungalileo.io"
+
+          # Commit and tag
+          git add pyproject.toml src/galileo_a2a/__init__.py
+          git commit -m "chore(release): galileo-a2a v${VERSION}"
+          git tag -a "galileo-a2a-v${VERSION}" -m "Release galileo-a2a v${VERSION}"
+
+          # Push changes
+          git push origin "HEAD:${REF_NAME}"
+          git push origin "galileo-a2a-v${VERSION}"
+
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # =======================================================================
+      # PATH 2: Semantic Release (Automatic Versioning)
+      # =======================================================================
+      - name: Python Semantic Release
+        id: semantic_release
+        if: inputs.version == ''
+        uses: python-semantic-release/python-semantic-release@v10.2.0
+        with:
+          directory: galileo-a2a
+          git_committer_name: galileo-automation
+          git_committer_email: ci@rungalileo.io
+          github_token: ${{ secrets.GALILEO_AUTOMATION_GITHUB_TOKEN }}
+          ssh_public_signing_key: ${{ secrets.GALILEO_AUTOMATION_SSH_PUBLIC_KEY }}
+          ssh_private_signing_key: ${{ secrets.GALILEO_AUTOMATION_SSH_PRIVATE_KEY }}
+          vcs_release: true
+
+      # =======================================================================
+      # Determine Release Status
+      # =======================================================================
+      - name: Set Release Status
+        id: release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          CUSTOM_RELEASED: ${{ steps.custom_version.outputs.released }}
+          CUSTOM_VERSION: ${{ steps.custom_version.outputs.version }}
+          SEMANTIC_RELEASED: ${{ steps.semantic_release.outputs.released }}
+          SEMANTIC_VERSION: ${{ steps.semantic_release.outputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "released=${CUSTOM_RELEASED}" >> "$GITHUB_OUTPUT"
+            echo "version=${CUSTOM_VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=${SEMANTIC_RELEASED}" >> "$GITHUB_OUTPUT"
+            echo "version=${SEMANTIC_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # =======================================================================
+      # Build and Publish
+      # =======================================================================
+      - name: Build Package
+        if: steps.release.outputs.released == 'true'
+        run: |
+          python -m build
+          echo "Built artifacts:"
+          ls -la dist/
+
+      - name: Create GitHub Release
+        if: steps.release.outputs.released == 'true' && inputs.version != ''
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: galileo-a2a-v${{ steps.release.outputs.version }}
+          name: galileo-a2a v${{ steps.release.outputs.version }}
+          body: |
+            ## galileo-a2a v${{ steps.release.outputs.version }}
+
+            ### Installation
+            ```bash
+            pip install galileo-a2a==${{ steps.release.outputs.version }}
+            ```
+
+            This is a manually triggered release.
+          prerelease: ${{ inputs.prerelease }}
+          token: ${{ secrets.GALILEO_AUTOMATION_GITHUB_TOKEN }}
+          files: galileo-a2a/dist/*
+
+      - name: Publish to PyPI
+        if: steps.release.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: galileo-a2a/dist/
+          verbose: true
+          print-hash: true

--- a/.github/workflows/test-a2a.yaml
+++ b/.github/workflows/test-a2a.yaml
@@ -1,0 +1,61 @@
+name: Test galileo-a2a
+
+on:
+  pull_request:
+    paths:
+      - 'galileo-a2a/**'
+      - '.github/workflows/test-a2a.yaml'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        galileo-version: ["min", "latest"]
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: galileo-a2a
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Pin galileo to minimum version
+        if: matrix.galileo-version == 'min'
+        run: uv pip install galileo==1.47.0
+
+      - name: Upgrade galileo to latest
+        if: matrix.galileo-version == 'latest'
+        run: uv pip install --upgrade galileo
+
+      - name: Show installed versions
+        run: uv pip list | grep -E "^(galileo|a2a-sdk)"
+
+      - name: Run type check
+        run: uv run mypy src/
+
+      - name: Run tests
+        run: uv run pytest --cov=galileo_a2a --cov-report=xml
+
+      - name: Upload coverage
+        if: matrix.python-version == '3.11' && matrix.galileo-version == 'latest'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: galileo-a2a
+          files: galileo-a2a/coverage.xml


### PR DESCRIPTION
# User description
**Shortcut:** https://app.shortcut.com/galileo-ai/story/61854

**Description:**

Add CI/CD pipelines for the `galileo-a2a` package, mirroring the existing `galileo-adk` setup:

- **Test workflow** (`test-a2a.yaml`): Runs on PRs touching `galileo-a2a/`, with a matrix of Python 3.10–3.13 and min/latest galileo versions. Includes type checking (mypy), pytest with coverage, and Codecov upload.
- **Release workflow** (`release-a2a.yaml`): Manual dispatch with two paths — custom version (semver validated) or automatic semantic release. Builds and publishes to PyPI via trusted publishing.

**Tests:**

- [ ] Unit Tests Added
- [x] CI workflows validated against existing galileo-adk pipelines as reference
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Configure a dedicated test workflow that exercises <code>galileo-a2a</code> across Python 3.10–3.13 with min/latest Galileo versions, running mypy, pytest coverage, and uploading to Codecov. Add a release workflow that builds and publishes <code>galileo-a2a</code> through manual semver validation or semantic release, pushing tags and PyPI artifacts via trusted OIDC.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/542?tool=ast&topic=Testing+workflow>Testing workflow</a>
        </td><td>Validate galileo-a2a via a matrix of Python and Galileo versions using uv-managed dependencies, mypy, pytest coverage, and Codecov reporting.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/test-a2a.yaml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/542?tool=ast&topic=Release+workflow>Release workflow</a>
        </td><td>Enable manual or automatic galileo-a2a releases with custom semver validation, semantic-release automation, GitHub tagging, and trusted PyPI publishing.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/release-a2a.yaml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/542?tool=ast>(Baz)</a>.