### PR TITLE
fix(experiment): reset _run_result_consumed flag in create()

### DIFF
--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -482,6 +482,7 @@ class Experiment(StateManagementMixin):
                     ),
                 }
             )
+            self._run_result_consumed = False
 
             # Set state to synced
             self._set_state(SyncState.SYNCED)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -744,6 +744,61 @@ class TestExperimentRun:
         with pytest.raises(ValueError, match="has already been run"):
             experiment.run()
 
+    @patch("galileo.experiment.create_metric_configs")
+    @patch("galileo.experiment.get_prompt")
+    @patch("galileo.experiment.load_dataset_and_records")
+    @patch("galileo.experiment.Projects")
+    @patch("galileo.experiment.ExperimentsService")
+    def test_create_run_create_run_resets_consumed_flag(
+        self,
+        mock_experiments_class: MagicMock,
+        mock_projects_class: MagicMock,
+        mock_load_dataset: MagicMock,
+        mock_get_prompt: MagicMock,
+        mock_create_metrics: MagicMock,
+        reset_configuration: None,
+        mock_experiment_response: MagicMock,
+        mock_project: MagicMock,
+    ) -> None:
+        """Regression for sc-61309: a second create() must reset _run_result_consumed
+        so the following run() returns the new cached result instead of raising."""
+        # Given: a fully mocked create() flow
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.return_value = mock_project
+
+        mock_dataset = MagicMock()
+        mock_load_dataset.return_value = (mock_dataset, [])
+
+        mock_prompt = MagicMock()
+        mock_prompt.selected_version_id = str(uuid4())
+        mock_get_prompt.return_value = mock_prompt
+
+        mock_create_metrics.return_value = (None, [])
+
+        mock_experiments_service = MagicMock()
+        mock_experiments_class.return_value = mock_experiments_service
+        mock_experiments_service.get.return_value = None
+        mock_experiments_service.create.return_value = mock_experiment_response
+        mock_experiments_service.config.console_url = "http://console.test.com"
+
+        # When: create() -> run() -> create() -> run()
+        experiment = Experiment(
+            name="Test Experiment", dataset_name="test-dataset", prompt_name="test-prompt", project_name="Test Project"
+        ).create()
+        first_run = experiment.run()
+        assert experiment._run_result_consumed is True
+
+        experiment.create()
+
+        # Then: the second create() resets the consumed flag and re-populates _run_result
+        assert experiment._run_result_consumed is False
+        assert experiment._run_result is not None
+
+        second_run = experiment.run()
+        assert isinstance(first_run, ExperimentRunResult)
+        assert isinstance(second_run, ExperimentRunResult)
+
 
 class TestExperimentQuery:
     """Test suite for Experiment query methods."""


### PR DESCRIPTION
# User description
**Shortcut:**
[sc-61309](https://app.shortcut.com/galileo/story/61309/reset-run-result-consumed-flag-in-experiment-create)

**Description:**

`Experiment.run()` sets `self._run_result_consumed = True` after returning the cached result, but `Experiment.create()` never reset it. The sequence `create() -> run() -> create() -> run()` left the flag stale from the first run. The current code path happens to work because `run()` checks `_run_result is not None` before inspecting the consumed flag, but it's a latent inconsistency that could surface as a spurious `ValueError("has already been run")` if the `run()` ordering is ever rearranged.

This PR resets `self._run_result_consumed = False` in `create()` alongside the `_run_result` assignment, keeping the two pieces of state in sync.

Added regression test `test_create_run_create_run_resets_consumed_flag` covering the full `create() -> run() -> create() -> run()` sequence and asserting both the flag and the cached result are restored on the second `create()`.

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Reset <code>_run_result_consumed</code> alongside <code>_run_result</code> in <code>Experiment.create</code> so repeated <code>run()</code> invocations stay consistent with the refreshed experiment metadata. Verify the full <code>create()</code>→<code>run()</code>→<code>create()</code>→<code>run()</code> flow through <code>Experiment.run</code> to prove the cache and flag are reset before the second run.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/548?tool=ast&topic=Create+run+state>Create run state</a>
        </td><td>Reset <code>_run_result_consumed</code> when re-creating an experiment so <code>Experiment.run</code> sees the fresh <code>ExperimentRunResult</code> state instead of the stale flag.<details><summary>Modified files (1)</summary><ul><li>src/galileo/experiment.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix: regression issues...</td><td>April 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/548?tool=ast&topic=Sequence+regression>Sequence regression</a>
        </td><td>Validate the <code>create()</code>→<code>run()</code>→<code>create()</code>→<code>run()</code> sequence to ensure the cached result and consumed flag are restored for the second run.<details><summary>Modified files (1)</summary><ul><li>tests/test_experiment.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix: regression issues...</td><td>April 05, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/548?tool=ast>(Baz)</a>.