### PR TITLE
fix(datasets): preserve all prompt_settings fields in extend_dataset

### DIFF
--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -581,13 +581,10 @@ class Datasets:
         httpx.TimeoutException
             If the request takes longer than Client.timeout.
         """
-        # Convert prompt_settings dict to PromptRunSettings if provided
-        model_alias = (
-            prompt_settings.get("model_alias", DEFAULT_EXTEND_MODEL_ALIAS)
-            if prompt_settings
-            else DEFAULT_EXTEND_MODEL_ALIAS
-        )
-        prompt_run_settings = PromptRunSettings(model_alias=model_alias)
+        # Convert prompt_settings dict to PromptRunSettings, preserving all caller fields
+        settings_dict = dict(prompt_settings) if prompt_settings else {}
+        settings_dict.setdefault("model_alias", DEFAULT_EXTEND_MODEL_ALIAS)
+        prompt_run_settings = PromptRunSettings.from_dict(settings_dict)
 
         # Convert data_types strings to SyntheticDataTypes enum if provided
         synthetic_data_types: builtins.list[SyntheticDataTypes] | Unset = UNSET

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -606,6 +606,44 @@ def test_extend_dataset_uses_default_model_alias_when_model_alias_key_missing(ex
 
 
 @patch("galileo.datasets.extend_dataset_content_datasets_extend_post")
+def test_extend_dataset_preserves_non_model_alias_prompt_settings(extend_dataset_mock: Mock) -> None:
+    """Regression for sc-61766: extend_dataset must forward all prompt_settings fields,
+    not just model_alias."""
+    # Given: prompt_settings with model_alias plus extra fields
+    extend_dataset_mock.sync.return_value = HTTPValidationError()
+
+    # When: extend_dataset is called with multiple prompt_settings fields
+    with pytest.raises(DatasetAPIException):
+        extend_dataset(
+            prompt_settings={"model_alias": "GPT-4o mini", "temperature": 0.2, "max_tokens": 256, "top_p": 0.9},
+            prompt="Test prompt",
+            count=1,
+        )
+
+    # Then: every caller-provided field reaches the API request body
+    call_body = extend_dataset_mock.sync.call_args.kwargs["body"]
+    assert call_body.prompt_settings.model_alias == "GPT-4o mini"
+    assert call_body.prompt_settings.temperature == 0.2
+    assert call_body.prompt_settings.max_tokens == 256
+    assert call_body.prompt_settings.top_p == 0.9
+
+
+@patch("galileo.datasets.extend_dataset_content_datasets_extend_post")
+def test_extend_dataset_does_not_mutate_caller_prompt_settings(extend_dataset_mock: Mock) -> None:
+    """extend_dataset must not mutate the caller's prompt_settings dict (e.g. inject model_alias)."""
+    # Given: a caller dict without model_alias
+    extend_dataset_mock.sync.return_value = HTTPValidationError()
+    caller_settings = {"temperature": 0.5}
+
+    # When: extend_dataset is called
+    with pytest.raises(DatasetAPIException):
+        extend_dataset(prompt_settings=caller_settings, prompt="Test prompt", count=1)
+
+    # Then: the caller dict is untouched
+    assert caller_settings == {"temperature": 0.5}
+
+
+@patch("galileo.datasets.extend_dataset_content_datasets_extend_post")
 def test_extend_dataset_api_failure(extend_dataset_mock: Mock) -> None:
     """Test extend_dataset when the initial API call fails."""
 


### PR DESCRIPTION
# User description
**Shortcut:**
[sc-61766](https://app.shortcut.com/galileo/story/61766/bug-dataset-extend-silently-drops-prompt-settings-fields-other-than-model-alias)

**Description:**

`extend_dataset()` (used by `Dataset.extend()`) previously extracted only `model_alias` from the caller's `prompt_settings` dict and silently discarded every other field:

```python
model_alias = (
    prompt_settings.get("model_alias", DEFAULT_EXTEND_MODEL_ALIAS)
    if prompt_settings
    else DEFAULT_EXTEND_MODEL_ALIAS
)
prompt_run_settings = PromptRunSettings(model_alias=model_alias)
```

If a caller passed `{"model_alias": "GPT-4o mini", "temperature": 0.2}`, the `temperature` was dropped and the API received `PromptRunSettings` class defaults (`max_tokens=4096`, `top_p=1.0`, ...). This was inconsistent with `experiments.py`, which forwards the full dict via `PromptRunSettings.from_dict(...)`.

This PR uses `PromptRunSettings.from_dict()` against a copy of the caller's dict so every user-provided field reaches the API, applying `DEFAULT_EXTEND_MODEL_ALIAS` only when `model_alias` is not supplied. The caller's dict is no longer mutated.

Added two regression tests:
- `test_extend_dataset_preserves_non_model_alias_prompt_settings` — asserts `temperature`, `max_tokens`, and `top_p` reach the request body alongside `model_alias`.
- `test_extend_dataset_does_not_mutate_caller_prompt_settings` — asserts the caller's dict is untouched after the call.

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Preserve all <code>prompt_settings</code> fields when <code>extend_dataset</code> builds a <code>PromptRunSettings</code>, defaulting <code>model_alias</code> only when the caller omits it so every user-provided option reaches the API. Avoid mutating the caller’s dict by copying the settings before passing them through <code>PromptRunSettings.from_dict</code> to ensure the dataset extension flow honors standalone configuration values.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/549?tool=ast&topic=Prompt+settings>Prompt settings</a>
        </td><td>Preserve every <code>prompt_settings</code> field when <code>extend_dataset</code> builds <code>PromptRunSettings</code>, defaulting <code>model_alias</code> only if omitted and copying the caller’s dict so no other option is dropped.<details><summary>Modified files (1)</summary><ul><li>src/galileo/datasets.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix(datasets): adjust ...</td><td>April 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/549?tool=ast&topic=Regression+tests>Regression tests</a>
        </td><td>Validate that <code>extend_dataset</code> forwards non-<code>model_alias</code> fields and leaves the caller’s settings intact via targeted regression tests.<details><summary>Modified files (1)</summary><ul><li>tests/test_datasets.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix(datasets): adjust ...</td><td>April 07, 2026</td></tr>
<tr><td>bipin@galileo.ai</td><td>fix: normalize ground_...</td><td>February 18, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/549?tool=ast>(Baz)</a>.