### PR TITLE
fix(otel): surface silently-rejected spans via partial_success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- **OTel: surface silently-rejected spans**: `GalileoOTLPExporter` now parses the OTLP `partial_success` field on the server response and logs a `WARNING` on the `galileo.otel` logger whenever the backend rejects one or more spans. Previously the standard Python `OTLPSpanExporter` treated any 2xx response as success and discarded the response body, hiding rejection counts and error messages from users. The new `_export` override handles both JSON and protobuf response bodies, degrades to a DEBUG log on malformed bodies, and does not change the `SpanExportResult` returned to upstream retry logic ([sc-62612](https://app.shortcut.com/galileo/story/62612)).
+
 ### Features
 
 - **New `generated_output` field**: Add `generated_output` field to `DatasetRecord` for storing model-generated outputs separately from ground truth. This allows you to track both the expected output (ground truth) and the actual model output in the same dataset record. In the UI, this field is displayed as "Generated Output".

--- a/src/galileo/otel.py
+++ b/src/galileo/otel.py
@@ -38,6 +38,10 @@ try:
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
         OTLPSpanExporter,  # pyright: ignore[reportAssignmentType]
     )
+    from google.protobuf.json_format import Parse as _ProtoJsonParse  # pyright: ignore[reportAssignmentType]
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (  # pyright: ignore[reportAssignmentType]
+        ExportTraceServiceResponse,
+    )
     from opentelemetry.sdk.resources import Resource  # pyright: ignore[reportAssignmentType]
     from opentelemetry.sdk.trace import Span, SpanProcessor  # pyright: ignore[reportAssignmentType]
     from opentelemetry.sdk.trace.export import BatchSpanProcessor  # pyright: ignore[reportAssignmentType]
@@ -196,6 +200,38 @@ class GalileoOTLPExporter(OTLPSpanExporter):
                 self._session.headers.pop("logstream", None)  # Remove logstream header if experiment is present
 
         return super().export(spans)
+
+    def _export(self, serialized_data: bytes, timeout_sec: float | None = None) -> Any:
+        """Wrap upstream _export to surface OTLP partial_success rejections.
+
+        The Galileo backend reports unrecognized/invalid spans via the OTLP
+        partial_success protocol on a 200 OK response. The upstream
+        OTLPSpanExporter treats any 2xx as SUCCESS and never inspects the body,
+        so rejections are invisible to users. We parse the response here and
+        log a warning so the signal isn't lost.
+        """
+        resp = super()._export(serialized_data, timeout_sec)
+        if resp.ok and resp.content:
+            try:
+                parsed = ExportTraceServiceResponse()
+                content_type = (resp.headers.get("content-type") or "").split(";")[0].strip().lower()
+                # The Galileo API returns application/json for partial_success, not protobuf,
+                # so we branch on Content-Type and parse accordingly.
+                if content_type == "application/json":
+                    _ProtoJsonParse(resp.content.decode("utf-8"), parsed)
+                else:
+                    parsed.ParseFromString(resp.content)
+                rejected = parsed.partial_success.rejected_spans
+                if rejected:
+                    error_message = parsed.partial_success.error_message or "(no error message returned by server)"
+                    logger.warning(
+                        "Galileo OTLP server rejected %d span(s) via partial_success: %s",
+                        rejected,
+                        error_message,
+                    )
+            except Exception as e:
+                logger.debug("Failed to parse OTLP partial_success response: %s", e)
+        return resp
 
 
 class GalileoSpanProcessor(SpanProcessor):

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -125,6 +125,124 @@ class TestGalileoOTLPExporter:
         with pytest.raises(ValueError, match="API key is required"):
             GalileoOTLPExporter()
 
+    @pytest.fixture
+    def exporter(self, mock_config, clear_env_vars):
+        """Build a GalileoOTLPExporter without hitting OTLPSpanExporter.__init__."""
+        with patch("galileo.otel.OTLPSpanExporter.__init__", return_value=None):
+            return GalileoOTLPExporter(project="test-project", logstream="test-logstream")
+
+    @staticmethod
+    def _fake_response(status_code: int, content: bytes, content_type: str) -> Mock:
+        resp = Mock()
+        resp.status_code = status_code
+        resp.ok = 200 <= status_code < 300
+        resp.content = content
+        resp.headers = {"content-type": content_type}
+        return resp
+
+    @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
+    @patch("galileo.otel.OTLPSpanExporter._export")
+    def test_export_logs_warning_on_json_partial_success(self, mock_parent_export, exporter, caplog):
+        """Logs a WARNING when the server reports rejected spans via JSON partial_success."""
+        # Given: the Galileo server returns a JSON partial_success body with rejected spans
+        body = (
+            b'{"partialSuccess":{"rejectedSpans":"2",'
+            b'"errorMessage":"Group 0: No GenAI patterns detected in spans."}}'
+        )
+        mock_parent_export.return_value = self._fake_response(200, body, "application/json")
+
+        # When: _export is invoked
+        with caplog.at_level("WARNING", logger="galileo.otel"):
+            result = exporter._export(b"fake-serialized-spans", timeout_sec=1.0)
+
+        # Then: a WARNING is emitted with the rejection count and error message, and the
+        # underlying response object is passed through unchanged.
+        assert result is mock_parent_export.return_value
+        assert any(
+            "rejected 2 span(s)" in rec.message and "No GenAI patterns detected" in rec.message
+            for rec in caplog.records
+        )
+
+    @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
+    @patch("galileo.otel.OTLPSpanExporter._export")
+    def test_export_logs_warning_on_protobuf_partial_success(self, mock_parent_export, exporter, caplog):
+        """Logs a WARNING for protobuf partial_success too (forward-compat for a spec-compliant server)."""
+        from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceResponse
+
+        # Given: a spec-compliant server returning protobuf with rejected_spans set
+        response_msg = ExportTraceServiceResponse()
+        response_msg.partial_success.rejected_spans = 3
+        response_msg.partial_success.error_message = "bad spans"
+        mock_parent_export.return_value = self._fake_response(
+            200, response_msg.SerializeToString(), "application/x-protobuf"
+        )
+
+        # When: _export is invoked
+        with caplog.at_level("WARNING", logger="galileo.otel"):
+            exporter._export(b"fake-serialized-spans", timeout_sec=1.0)
+
+        # Then: warning names the rejected count and surfaces the server error message
+        assert any("rejected 3 span(s)" in rec.message and "bad spans" in rec.message for rec in caplog.records)
+
+    @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
+    @patch("galileo.otel.OTLPSpanExporter._export")
+    def test_export_silent_on_full_success(self, mock_parent_export, exporter, caplog):
+        """No WARNING when rejected_spans is zero (full success)."""
+        # Given: a successful response with no rejections
+        body = b'{"partialSuccess":{"rejectedSpans":"0","errorMessage":""}}'
+        mock_parent_export.return_value = self._fake_response(200, body, "application/json")
+
+        # When: _export is invoked
+        with caplog.at_level("WARNING", logger="galileo.otel"):
+            exporter._export(b"fake-serialized-spans", timeout_sec=1.0)
+
+        # Then: no WARNING records are emitted by the partial_success handler
+        assert not [rec for rec in caplog.records if "rejected" in rec.message]
+
+    @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
+    @patch("galileo.otel.OTLPSpanExporter._export")
+    def test_export_silent_on_empty_body(self, mock_parent_export, exporter, caplog):
+        """No WARNING when the response body is empty."""
+        # Given: a 200 with no body (still legal)
+        mock_parent_export.return_value = self._fake_response(200, b"", "application/json")
+
+        # When: _export is invoked
+        with caplog.at_level("WARNING", logger="galileo.otel"):
+            exporter._export(b"fake-serialized-spans", timeout_sec=1.0)
+
+        # Then: nothing is logged at WARNING level from this handler
+        assert not [rec for rec in caplog.records if "rejected" in rec.message]
+
+    @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
+    @patch("galileo.otel.OTLPSpanExporter._export")
+    def test_export_swallows_malformed_body(self, mock_parent_export, exporter, caplog):
+        """Malformed response body does not raise — error is downgraded to DEBUG."""
+        # Given: a 200 with a body that is neither valid JSON-proto nor valid protobuf
+        mock_parent_export.return_value = self._fake_response(200, b"not-a-valid-body", "application/json")
+
+        # When: _export is invoked
+        with caplog.at_level("DEBUG", logger="galileo.otel"):
+            result = exporter._export(b"fake-serialized-spans", timeout_sec=1.0)
+
+        # Then: the response is still returned, no WARNING leaks to the caller
+        assert result is mock_parent_export.return_value
+        assert not [rec for rec in caplog.records if rec.levelname == "WARNING" and "rejected" in rec.message]
+
+    @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
+    @patch("galileo.otel.OTLPSpanExporter._export")
+    def test_export_passes_through_non_2xx(self, mock_parent_export, exporter, caplog):
+        """Non-2xx responses skip parsing — upstream retry logic still handles them."""
+        # Given: a 500 response with nothing useful in the body
+        mock_parent_export.return_value = self._fake_response(500, b"server error", "text/plain")
+
+        # When: _export is invoked
+        with caplog.at_level("WARNING", logger="galileo.otel"):
+            result = exporter._export(b"fake-serialized-spans", timeout_sec=1.0)
+
+        # Then: no WARNING from the partial_success handler, and upstream retry path is unaffected
+        assert result is mock_parent_export.return_value
+        assert not [rec for rec in caplog.records if "rejected" in rec.message]
+
 
 class TestGalileoSpanProcessor:
     """Test suite for GalileoSpanProcessor class."""


### PR DESCRIPTION
# User description
## Summary

The standard Python `OTLPSpanExporter` treats any 2xx response as success and never parses the response body, hiding OTLP `partial_success.rejected_spans` / `error_message` from users. When the Galileo backend rejects spans (e.g. because they don't match any GenAI detector), users see no signal client-side and their traces silently vanish. This PR overrides `GalileoOTLPExporter._export` to parse the response and log a `WARNING` on the `galileo.otel` logger when rejections occur.

Refs: [sc-62612](https://app.shortcut.com/galileo/story/62612)

## What changed

- **`src/galileo/otel.py`** (+36): `GalileoOTLPExporter._export()` wraps the upstream call, parses the response body, and emits a `WARNING` whenever `partial_success.rejected_spans > 0`. Branches on `Content-Type` to handle both JSON (today's Galileo server) and protobuf (forward-compat / spec-compliant servers). Malformed bodies degrade to a DEBUG log so telemetry code never interferes with the user application.
- **`tests/test_otel.py`** (+118): Six new cases covering JSON partial_success, protobuf partial_success, full success (no warning), empty body, malformed body, and non-2xx passthrough. Uses mocked `OTLPSpanExporter._export` to avoid network I/O.
- **`CHANGELOG.md`** (+4): Entry under `Unreleased > Bug Fixes`.

## Why this hook point

The override is on `_export`, not `export`. The upstream `export()` at `opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py:186` discards the response body once it sees `resp.ok`:

```python
resp = self._export(serialized_data, deadline_sec - time())
if resp.ok:
    return SpanExportResult.SUCCESS
```

Only `_export()` still has the raw `requests.Response`. By wrapping it, we inspect the body without touching retry/backoff semantics — the response is returned unchanged and upstream `export()` carries on as before.

## Upstream context

This gap is known upstream: [open-telemetry/opentelemetry-python#4803](https://github.com/open-telemetry/opentelemetry-python/issues/4803) and its draft PR [#4805](https://github.com/open-telemetry/opentelemetry-python/pull/4805). The upstream PR was auto-closed due to inactivity (stale-bot) and targets the gRPC exporter only. Until an upstream fix lands that covers the HTTP exporter, this SDK-side override is the pragmatic path to give Galileo users visibility into server-side rejections.

## Verified end-to-end

Tested against prod (`https://api.galileo.ai`) from an OTel-only demo:

**Undetectable span** (no `gen_ai.*` attrs, no framework marker):
```
WARNING galileo.otel: Galileo OTLP server rejected 1 span(s) via partial_success: Group 0: No GenAI patterns detected in spans. Ensure spans contain standard OTEL GenAI attributes or are from a supported framework.
```

**Valid GenAI span** (with `gen_ai.operation.name`, `gen_ai.input.messages`, `gen_ai.output.messages`): silent — trace ingests normally, no WARNING emitted.

## Test plan

- [ ] CI runs full unit suite for `tests/test_otel.py`
- [ ] Manual: point `GalileoSpanProcessor` at a project and send (a) a span missing `gen_ai.*` attrs — expect a `WARNING`, (b) a span with proper GenAI conventions — expect silence
- [ ] Regression: existing `test_exporter_export_merges_resource_attributes` still passes (this PR does not touch `export()`)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Log Galileo OTLP exporter partial_success responses by parsing the backend reply, warning when spans are rejected while leaving upstream retry behavior untouched. Expand exporter tests and document the new visibility so rejected spans no longer disappear silently.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/551?tool=ast&topic=Exporter+Tests>Exporter Tests</a>
        </td><td>Validate <code>_export</code> warning behavior across JSON/protobuf success, empty or malformed bodies, and non-2xx responses and record the bug fix in the changelog.<details><summary>Modified files (2)</summary><ul><li>CHANGELOG.md</li>
<li>tests/test_otel.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>chore: Migrating remai...</td><td>March 26, 2026</td></tr>
<tr><td>Focadecombate</td><td>fix: move dataset cont...</td><td>March 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/551?tool=ast&topic=Partial+Success+Logs>Partial Success Logs</a>
        </td><td>Log Galileo OTLP partial_success rejections by overriding <code>_export</code> to parse JSON and protobuf bodies, warn on rejected spans, and degrade gracefully on malformed responses without altering the returned result.<details><summary>Modified files (1)</summary><ul><li>src/galileo/otel.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>Focadecombate</td><td>fix: move dataset cont...</td><td>March 13, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/551?tool=ast>(Baz)</a>.