### PR TITLE
fix: get card fixes

### DIFF
--- a/galileo-a2a/README.md
+++ b/galileo-a2a/README.md
@@ -183,11 +183,16 @@ class ResearcherExecutor(AgentExecutor):
 
 class State(TypedDict):
     user_query: str
+    skills: list[str]
     research_query: str
     response: str
     plan: str
 
 def build_orchestrator(client):
+    async def discover(state: State) -> dict:
+        card = await client.get_card()
+        return {"skills": [s.name for s in card.skills]}
+
     async def plan(state: State) -> dict:
         result = await create_agent(llm,
             system_prompt="Formulate a travel research question. Reply with ONLY the question.",
@@ -211,10 +216,12 @@ def build_orchestrator(client):
         return {"plan": result["messages"][-1].content}
 
     graph = StateGraph(State)
+    graph.add_node("discover", discover)
     graph.add_node("plan", plan)
     graph.add_node("delegate", delegate)
     graph.add_node("synthesize", synthesize)
-    graph.add_edge(START, "plan")
+    graph.add_edge(START, "discover")
+    graph.add_edge("discover", "plan")
     graph.add_edge("plan", "delegate")
     graph.add_edge("delegate", "synthesize")
     graph.add_edge("synthesize", END)
@@ -239,7 +246,7 @@ async def main():
         config=ClientConfig(streaming=True, httpx_client=httpx.AsyncClient(timeout=httpx.Timeout(120))),
     ).create(CARD)
     result = await build_orchestrator(client).ainvoke(
-        {"user_query": "Plan a 3-day trip to Paris", "research_query": "", "response": "", "plan": ""},
+        {"user_query": "Plan a 3-day trip to Paris", "skills": [], "research_query": "", "response": "", "plan": ""},
     )
     print(result["plan"])
 

--- a/galileo-a2a/examples/two_agent_demo.py
+++ b/galileo-a2a/examples/two_agent_demo.py
@@ -135,12 +135,17 @@ class ResearcherExecutor(AgentExecutor):
 
 class OrchestratorState(TypedDict):
     user_query: str
+    skills: list[str]
     research_query: str
     response: str
     plan: str
 
 
 def build_orchestrator(client):
+    async def discover(state: OrchestratorState) -> dict:
+        card = await client.get_card()
+        return {"skills": [s.name for s in card.skills]}
+
     async def plan(state: OrchestratorState) -> dict:
         result = await create_agent(
             llm,
@@ -170,10 +175,12 @@ def build_orchestrator(client):
         return {"plan": result["messages"][-1].content}
 
     graph = StateGraph(OrchestratorState)
+    graph.add_node("discover", discover)
     graph.add_node("plan", plan)
     graph.add_node("delegate", delegate)
     graph.add_node("synthesize", synthesize)
-    graph.add_edge(START, "plan")
+    graph.add_edge(START, "discover")
+    graph.add_edge("discover", "plan")
     graph.add_edge("plan", "delegate")
     graph.add_edge("delegate", "synthesize")
     graph.add_edge("synthesize", END)
@@ -200,12 +207,12 @@ async def main():
     server_task = asyncio.create_task(server.serve())
     await asyncio.sleep(1)
 
-    # Run orchestrator
+    # Run orchestrator (discover → plan → delegate → synthesize)
     client = ClientFactory(
         config=ClientConfig(streaming=True, httpx_client=httpx.AsyncClient(timeout=httpx.Timeout(120))),
     ).create(CARD)
     result = await build_orchestrator(client).ainvoke(
-        {"user_query": "Plan a 3-day trip to Paris", "research_query": "", "response": "", "plan": ""},
+        {"user_query": "Plan a 3-day trip to Paris", "skills": [], "research_query": "", "response": "", "plan": ""},
     )
     print(result["plan"])
 


### PR DESCRIPTION
# User description
**Shortcut:**
https://app.shortcut.com/galileo/story/61854/create-pipelines-for-galileo-a2a

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce a discover step that retrieves the agent card via the client and records its skill names before generating the research plan. Update the orchestrator graph and state to require the skill list in order, tying discover into the run sequence.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sankar@galileo.ai</td><td>feat: harden a2a distr...</td><td>April 14, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/552?tool=ast>(Baz)</a>.