### PR TITLE
fix: add timezone to created_at datetime

### DIFF
--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -9,7 +9,7 @@ import os
 import time
 import uuid
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Union
 
 import backoff
@@ -452,7 +452,7 @@ class GalileoLogger(TracesLogger):
         stub_trace = LoggedTrace(
             input="",
             name=STUB_TRACE_NAME,
-            created_at=datetime.now(),
+            created_at=datetime.now(timezone.utc),
             id=uuid.UUID(self.trace_id),
             metrics=Metrics(duration_ns=0),
         )
@@ -467,7 +467,7 @@ class GalileoLogger(TracesLogger):
             stub_span = LoggedWorkflowSpan(
                 input="",
                 name="stub_parent_span",
-                created_at=datetime.now(),
+                created_at=datetime.now(timezone.utc),
                 id=uuid.UUID(self.span_id),
                 metrics=Metrics(duration_ns=0),
             )


### PR DESCRIPTION
# User description
**Shortcut:**
related to: https://app.shortcut.com/galileo/story/62805

**Description:**

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update GalileoLogger stub traces and spans to generate timezone-aware timestamps so telemetry uses consistent UTC markers.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix: Python SDK tests ...</td><td>April 14, 2026</td></tr>
<tr><td>david@rungalileo.io</td><td>fix: Add session start...</td><td>April 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/553?tool=ast>(Baz)</a>.