### PR TITLE
fix(metrics): handle new Metric types in set_metrics and HTTPValidationError string detail

### DIFF
--- a/src/galileo/metric.py
+++ b/src/galileo/metric.py
@@ -40,6 +40,7 @@ from galileo.schema.metrics import Metric as LegacyMetric
 from galileo.scorers import Scorers
 from galileo.shared.base import StateManagementMixin, SyncState
 from galileo.shared.exceptions import APIError, ValidationError
+from galileo.utils.exceptions import _format_http_validation_error
 from galileo_core.schemas.logging.span import Span
 from galileo_core.schemas.logging.step import StepType
 from galileo_core.schemas.logging.trace import Trace
@@ -1086,6 +1087,9 @@ class CodeMetric(Metric):
             if scorer_response is None:
                 logger.debug("CodeMetric.create: No response from create_scorers_post")
                 raise ValueError("Failed to create code-based metric: No response from API")
+
+            if isinstance(scorer_response, HTTPValidationError):
+                raise ValidationError(_format_http_validation_error(scorer_response))
 
             # Step 3: Create the code scorer version with file upload and validation result
             # Convert the code string to bytes for file upload

--- a/src/galileo/resources/models/http_validation_error.py
+++ b/src/galileo/resources/models/http_validation_error.py
@@ -45,12 +45,17 @@ class HTTPValidationError:
         from ..models.validation_error import ValidationError
 
         d = dict(src_dict)
-        detail = []
+        detail: Union[Unset, list["ValidationError"]] = UNSET
         _detail = d.pop("detail", UNSET)
-        for detail_item_data in _detail or []:
-            detail_item = ValidationError.from_dict(detail_item_data)
-
-            detail.append(detail_item)
+        if isinstance(_detail, list):
+            detail = []
+            for detail_item_data in _detail:
+                detail_item = ValidationError.from_dict(detail_item_data)
+                detail.append(detail_item)
+        elif isinstance(_detail, str):
+            # The API may return a plain string detail (e.g. from GalileoServerException)
+            # instead of the standard list-of-ValidationError shape.
+            detail = [ValidationError(loc=[], msg=_detail, type_="server_error")]
 
         http_validation_error = cls(detail=detail)
 

--- a/src/galileo/utils/metrics.py
+++ b/src/galileo/utils/metrics.py
@@ -1,6 +1,7 @@
 import builtins
 from uuid import UUID
 
+from galileo.metric import Metric as MetricV2
 from galileo.resources.models.scorer_config import ScorerConfig
 from galileo.resources.models.scorer_response import ScorerResponse
 from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig, Metric
@@ -89,6 +90,11 @@ def create_metric_configs(
     for metric in metrics:
         if isinstance(metric, GalileoMetrics):
             label_searches.append((metric.value, None))
+        elif isinstance(metric, MetricV2):
+            if metric.id:
+                scorer_ids.append(metric.id)
+            else:
+                label_searches.append((metric.name, metric.version))
         elif isinstance(metric, Metric):
             label_searches.append((metric.name, metric.version))
         elif isinstance(metric, LocalMetricConfig):


### PR DESCRIPTION
# User description
## Summary

- **`LogStream.set_metrics()` crashes with `Metric.get()` objects**: `create_metric_configs` checked `isinstance` against the legacy `galileo.schema.metrics.Metric`, but `Metric.get()` returns `galileo.metric.Metric` subclasses (`LlmMetric`, `CodeMetric`). Added a check for the new type, routing by `.id` when available.
- **`HTTPValidationError.from_dict` crashes on string `detail`**: The API returns `{"detail": "some string"}` from `GalileoServerException`, but the parser iterated `detail` assuming it was a list of dicts — iterating characters instead. Added a guard for string detail.
- **`CodeMetric.create()` doesn't handle `HTTPValidationError` response**: Added `isinstance` check and raises `ValidationError` with a formatted message (same pattern as `jobs.py` and `experiments.py`).

Fixes sc-62865

## Test plan

- [ ] `LogStream.set_metrics([Metric.get(name="Conciseness")])` no longer raises `ValueError`
- [ ] `CodeMetric(name="existing_name", ...).create()` raises `ValidationError("already exists")` instead of crashing
- [ ] Existing tests pass

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>create_metric_configs</code> used by <code>LogStream.set_metrics</code> to recognize new <code>galileo.metric.Metric</code> subclasses and route requests by <code>id</code> or name/version. Normalize <code>HTTPValidationError</code> parsing and <code>CodeMetric.create</code> error handling so string <code>detail</code> payloads become <code>ValidationError</code>s with formatted messages.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/554?tool=ast&topic=Validation+guards>Validation guards</a>
        </td><td>Guard <code>HTTPValidationError.from_dict</code> against string <code>detail</code> payloads and have <code>CodeMetric.create</code> raise formatted <code>ValidationError</code>s when the API responds with validation errors.<details><summary>Modified files (2)</summary><ul><li>src/galileo/metric.py</li>
<li>src/galileo/resources/models/http_validation_error.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>chore: Migrating remai...</td><td>March 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/554?tool=ast&topic=Metric+routing>Metric routing</a>
        </td><td>Handle <code>LogStream.set_metrics</code> routes by supporting <code>galileo.metric.Metric</code> instances in <code>create_metric_configs</code>, routing via <code>.id</code> when present and falling back to name/version searches.<details><summary>Modified files (1)</summary><ul><li>src/galileo/utils/metrics.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/554?tool=ast>(Baz)</a>.