### PR TITLE
fix(datasets): remap 'output' to 'ground_truth' in get_content() response

### DIFF
--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -44,7 +44,7 @@ from galileo.resources.models.update_dataset_content_request import UpdateDatase
 from galileo.resources.models.update_dataset_request import UpdateDatasetRequest
 from galileo.resources.types import UNSET, File, Unset
 from galileo.schema.datasets import DatasetRecord
-from galileo.utils.datasets import normalize_dataset_rows, validate_dataset_in_project
+from galileo.utils.datasets import normalize_dataset_rows, remap_output_to_ground_truth, validate_dataset_in_project
 from galileo.utils.exceptions import APIException
 from galileo.utils.log_config import get_logger
 from galileo.utils.projects import resolve_project_id
@@ -92,6 +92,7 @@ class Dataset:
             client=self.config.api_client, dataset_id=self.dataset.id, limit=limit, starting_token=starting_token
         )
 
+        content = remap_output_to_ground_truth(content)
         self.content = content
 
         return content

--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -94,6 +94,8 @@ class Dataset:
 
         if isinstance(content, DatasetContent):
             content = remap_output_to_ground_truth(content)
+            if not isinstance(content.column_names, Unset):
+                self.dataset.column_names = list(content.column_names)
         self.content = content
 
         return content

--- a/src/galileo/datasets.py
+++ b/src/galileo/datasets.py
@@ -88,11 +88,12 @@ class Dataset:
         if not self.dataset:
             return None
 
-        content: DatasetContent = get_dataset_content_datasets_dataset_id_content_get.sync(
+        content = get_dataset_content_datasets_dataset_id_content_get.sync(
             client=self.config.api_client, dataset_id=self.dataset.id, limit=limit, starting_token=starting_token
         )
 
-        content = remap_output_to_ground_truth(content)
+        if isinstance(content, DatasetContent):
+            content = remap_output_to_ground_truth(content)
         self.content = content
 
         return content

--- a/src/galileo/utils/datasets.py
+++ b/src/galileo/utils/datasets.py
@@ -15,10 +15,12 @@ def remap_output_to_ground_truth(content: DatasetContent) -> DatasetContent:
     The API stores ground_truth as 'output' internally. This is the inverse of
     normalize_dataset_rows, applied when reading content back out.
     """
-    if not isinstance(content.column_names, Unset) and "output" in content.column_names:
+    has_output_column = not isinstance(content.column_names, Unset) and "output" in content.column_names
+
+    if has_output_column:
         content.column_names = ["ground_truth" if name == "output" else name for name in content.column_names]
 
-    if not isinstance(content.rows, Unset):
+    if has_output_column and not isinstance(content.rows, Unset):
         for row in content.rows:
             props = row.values_dict.additional_properties
             if "output" in props:

--- a/src/galileo/utils/datasets.py
+++ b/src/galileo/utils/datasets.py
@@ -1,10 +1,30 @@
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from galileo.config import GalileoPythonConfig
+from galileo.resources.models.dataset_content import DatasetContent
+from galileo.resources.types import Unset
 from galileo.schema.datasets import DatasetRecord
 
 if TYPE_CHECKING:
     from galileo.datasets import Dataset
+
+
+def remap_output_to_ground_truth(content: DatasetContent) -> DatasetContent:
+    """Renames 'output' back to 'ground_truth' in DatasetContent returned by the API.
+
+    The API stores ground_truth as 'output' internally. This is the inverse of
+    normalize_dataset_rows, applied when reading content back out.
+    """
+    if not isinstance(content.column_names, Unset) and "output" in content.column_names:
+        content.column_names = ["ground_truth" if name == "output" else name for name in content.column_names]
+
+    if not isinstance(content.rows, Unset):
+        for row in content.rows:
+            props = row.values_dict.additional_properties
+            if "output" in props:
+                props["ground_truth"] = props.pop("output")
+
+    return content
 
 
 def normalize_dataset_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/galileo/utils/datasets.py
+++ b/src/galileo/utils/datasets.py
@@ -16,11 +16,14 @@ def remap_output_to_ground_truth(content: DatasetContent) -> DatasetContent:
     normalize_dataset_rows, applied when reading content back out.
     """
     has_output_column = not isinstance(content.column_names, Unset) and "output" in content.column_names
+    # Only skip row remapping when column_names is explicitly present and doesn't contain 'output'.
+    # When column_names is Unset (e.g. paginated responses), always remap rows to avoid mixed keys.
+    columns_explicitly_no_output = not isinstance(content.column_names, Unset) and "output" not in content.column_names
 
     if has_output_column:
         content.column_names = ["ground_truth" if name == "output" else name for name in content.column_names]
 
-    if has_output_column and not isinstance(content.rows, Unset):
+    if not columns_explicitly_no_output and not isinstance(content.rows, Unset):
         for row in content.rows:
             props = row.values_dict.additional_properties
             if "output" in props:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1656,7 +1656,7 @@ def test_add_rows_normalizes_ground_truth_to_output(get_content_mock: Mock, patc
     dataset_id = str(uuid4())
     patch_mock.sync_detailed.return_value = Mock(status_code=HTTPStatus.NO_CONTENT)
     get_content_mock.sync_detailed.return_value = Mock(headers={"ETag": "etag-value"})
-    get_content_mock.sync.return_value = Mock(rows=[])
+    get_content_mock.sync.return_value = DatasetContent(column_names=[], rows=[])
 
     dataset_db = Mock()
     dataset_db.id = dataset_id
@@ -1684,7 +1684,7 @@ def test_add_rows_does_not_mutate_caller_dicts(get_content_mock: Mock, patch_moc
     dataset_id = str(uuid4())
     patch_mock.sync_detailed.return_value = Mock(status_code=HTTPStatus.NO_CONTENT)
     get_content_mock.sync_detailed.return_value = Mock(headers={"ETag": "etag-value"})
-    get_content_mock.sync.return_value = Mock(rows=[])
+    get_content_mock.sync.return_value = DatasetContent(column_names=[], rows=[])
 
     dataset_db = Mock()
     dataset_db.id = dataset_id
@@ -1695,3 +1695,33 @@ def test_add_rows_does_not_mutate_caller_dicts(get_content_mock: Mock, patch_moc
 
     # Then: the original dict is not mutated
     assert original == {"input": "Q1", "ground_truth": "A1"}
+
+
+@patch("galileo.datasets.get_dataset_content_datasets_dataset_id_content_get")
+def test_get_content_remaps_output_to_ground_truth(get_content_mock: Mock) -> None:
+    """Test that get_content() remaps 'output' to 'ground_truth' in column_names and row values."""
+    # Given: the API returns content with 'output' as the column name
+    row = DatasetRow(
+        index=0,
+        values=["Spain", "Europe"],
+        metadata=None,
+        row_id="row-1",
+        values_dict=DatasetRowValuesDict.from_dict({"input": "Spain", "output": "Europe"}),
+    )
+    get_content_mock.sync.return_value = DatasetContent(
+        column_names=["input", "output", "generated_output", "metadata"], rows=[row]
+    )
+    dataset_db = Mock()
+    dataset_db.id = str(uuid4())
+    ds = Dataset(dataset_db=dataset_db)
+
+    # When: getting content
+    content = ds.get_content()
+
+    # Then: 'output' is renamed to 'ground_truth' in column_names
+    assert content.column_names == ["input", "ground_truth", "generated_output", "metadata"]
+    # Then: 'output' is renamed to 'ground_truth' in row values_dict
+    row_values = content.rows[0].values_dict.additional_properties
+    assert "ground_truth" in row_values
+    assert "output" not in row_values
+    assert row_values["ground_truth"] == "Europe"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1714,6 +1714,23 @@ def test_get_content_returns_none_when_api_returns_none(get_content_mock: Mock) 
 
 
 @patch("galileo.datasets.get_dataset_content_datasets_dataset_id_content_get")
+def test_get_content_syncs_dataset_column_names_after_remap(get_content_mock: Mock) -> None:
+    """Test that get_content() updates dataset.column_names to the remapped names."""
+    # Given: the API returns content with 'output' as a column name
+    get_content_mock.sync.return_value = DatasetContent(column_names=["input", "output", "generated_output"], rows=[])
+    dataset_db = Mock()
+    dataset_db.id = str(uuid4())
+    dataset_db.column_names = ["input", "output", "generated_output"]
+    ds = Dataset(dataset_db=dataset_db)
+
+    # When: getting content
+    ds.get_content()
+
+    # Then: dataset.column_names is updated to the remapped names
+    assert ds.dataset.column_names == ["input", "ground_truth", "generated_output"]
+
+
+@patch("galileo.datasets.get_dataset_content_datasets_dataset_id_content_get")
 def test_get_content_remaps_output_to_ground_truth(get_content_mock: Mock) -> None:
     """Test that get_content() remaps 'output' to 'ground_truth' in column_names and row values."""
     # Given: the API returns content with 'output' as the column name

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1698,6 +1698,22 @@ def test_add_rows_does_not_mutate_caller_dicts(get_content_mock: Mock, patch_moc
 
 
 @patch("galileo.datasets.get_dataset_content_datasets_dataset_id_content_get")
+def test_get_content_returns_none_when_api_returns_none(get_content_mock: Mock) -> None:
+    """Test that get_content() handles None API response without crashing."""
+    # Given: the API returns None
+    get_content_mock.sync.return_value = None
+    dataset_db = Mock()
+    dataset_db.id = str(uuid4())
+    ds = Dataset(dataset_db=dataset_db)
+
+    # When: getting content
+    content = ds.get_content()
+
+    # Then: None is returned without raising
+    assert content is None
+
+
+@patch("galileo.datasets.get_dataset_content_datasets_dataset_id_content_get")
 def test_get_content_remaps_output_to_ground_truth(get_content_mock: Mock) -> None:
     """Test that get_content() remaps 'output' to 'ground_truth' in column_names and row values."""
     # Given: the API returns content with 'output' as the column name

--- a/tests/utils/test_datasets.py
+++ b/tests/utils/test_datasets.py
@@ -304,6 +304,27 @@ def test_remap_output_to_ground_truth_no_output_column() -> None:
     assert result.column_names == ["input", "ground_truth", "metadata"]
 
 
+def test_remap_output_to_ground_truth_row_not_renamed_without_output_column() -> None:
+    """Test that row values are not renamed when column_names does not contain 'output'."""
+    # Given: column_names has no 'output', but a row's values_dict does
+    row = DatasetRow(
+        index=0,
+        values=["q", "a"],
+        metadata=None,
+        row_id="r1",
+        values_dict=DatasetRowValuesDict.from_dict({"input": "q", "output": "a"}),
+    )
+    content = DatasetContent(column_names=["input", "ground_truth"], rows=[row])
+
+    # When: remapping
+    remap_output_to_ground_truth(content)
+
+    # Then: row values_dict is left unchanged because column_names had no 'output'
+    props = row.values_dict.additional_properties
+    assert props.get("output") == "a"
+    assert "ground_truth" not in props
+
+
 def test_load_dataset_and_records_no_params() -> None:
     """Test load_dataset_and_records function when no parameters are provided."""
     # Execute and Assert

--- a/tests/utils/test_datasets.py
+++ b/tests/utils/test_datasets.py
@@ -2,12 +2,16 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from galileo.resources.models.dataset_content import DatasetContent
+from galileo.resources.models.dataset_row import DatasetRow
+from galileo.resources.models.dataset_row_values_dict import DatasetRowValuesDict
 from galileo.schema.datasets import DatasetRecord
 from galileo.utils.datasets import (
     create_rows_from_records,
     get_dataset_and_records,
     get_records_for_dataset,
     load_dataset_and_records,
+    remap_output_to_ground_truth,
 )
 
 
@@ -253,6 +257,51 @@ def test_load_dataset_and_records_with_records_list(mockcreate_rows) -> None:
     mockcreate_rows.assert_called_once_with(records_list)
     assert dataset is None
     assert records == mock_records
+
+
+def test_remap_output_to_ground_truth_column_names() -> None:
+    """Test that remap_output_to_ground_truth renames 'output' in column_names."""
+    # Given: content with 'output' in column_names
+    content = DatasetContent(column_names=["input", "output", "generated_output", "metadata"], rows=[])
+
+    # When: remapping
+    result = remap_output_to_ground_truth(content)
+
+    # Then: 'output' is renamed to 'ground_truth', other columns unchanged
+    assert result.column_names == ["input", "ground_truth", "generated_output", "metadata"]
+
+
+def test_remap_output_to_ground_truth_row_values() -> None:
+    """Test that remap_output_to_ground_truth renames 'output' in row values_dict."""
+    # Given: a row with 'output' in values_dict
+    row = DatasetRow(
+        index=0,
+        values=["q", "a"],
+        metadata=None,
+        row_id="r1",
+        values_dict=DatasetRowValuesDict.from_dict({"input": "q", "output": "a"}),
+    )
+    content = DatasetContent(column_names=["input", "output"], rows=[row])
+
+    # When: remapping
+    remap_output_to_ground_truth(content)
+
+    # Then: row values_dict has 'ground_truth', not 'output'
+    props = row.values_dict.additional_properties
+    assert props.get("ground_truth") == "a"
+    assert "output" not in props
+
+
+def test_remap_output_to_ground_truth_no_output_column() -> None:
+    """Test that remap_output_to_ground_truth leaves content unchanged when no 'output' column."""
+    # Given: content with no 'output' column
+    content = DatasetContent(column_names=["input", "ground_truth", "metadata"], rows=[])
+
+    # When: remapping
+    result = remap_output_to_ground_truth(content)
+
+    # Then: column_names are unchanged
+    assert result.column_names == ["input", "ground_truth", "metadata"]
 
 
 def test_load_dataset_and_records_no_params() -> None:

--- a/tests/utils/test_datasets.py
+++ b/tests/utils/test_datasets.py
@@ -325,6 +325,27 @@ def test_remap_output_to_ground_truth_row_not_renamed_without_output_column() ->
     assert "ground_truth" not in props
 
 
+def test_remap_output_to_ground_truth_row_renamed_when_column_names_unset() -> None:
+    """Test that row values are renamed when column_names is Unset (e.g. paginated response)."""
+    # Given: column_names is Unset but a row's values_dict contains 'output'
+    row = DatasetRow(
+        index=0,
+        values=["q", "a"],
+        metadata=None,
+        row_id="r1",
+        values_dict=DatasetRowValuesDict.from_dict({"input": "q", "output": "a"}),
+    )
+    content = DatasetContent(rows=[row])  # column_names defaults to UNSET
+
+    # When: remapping
+    remap_output_to_ground_truth(content)
+
+    # Then: row values_dict is remapped even without column_names
+    props = row.values_dict.additional_properties
+    assert props.get("ground_truth") == "a"
+    assert "output" not in props
+
+
 def test_load_dataset_and_records_no_params() -> None:
     """Test load_dataset_and_records function when no parameters are provided."""
     # Execute and Assert


### PR DESCRIPTION
# User description
**Shortcut:**

[sc-62751](https://app.shortcut.com/galileo/story/62751/qa2-0-newsdk-dataset-column-names-are-incorrect)

**Description:**

- `get_content()` was returning `'output'` in `column_names` and row `values_dict` instead of `'ground_truth'`, because the API stores ground_truth as `output` internally
- Added `remap_output_to_ground_truth()` helper in `utils/datasets.py` that acts as the inverse of `normalize_dataset_rows` — applied after every `get_content()` API call

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix <code>Dataset.get_content</code> and <code>remap_output_to_ground_truth</code> so API-returned <code>output</code> columns are presented as <code>ground_truth</code>, matching dataset expectations. Include focused tests demonstrating column name syncing and row value remapping.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix(dataset): normaliz...</td><td>April 15, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/555?tool=ast>(Baz)</a>.