### PR TITLE
fix(domain): raise ResourceNotFoundError for missing resources (sc-61954)

### DIFF
--- a/src/galileo/dataset.py
+++ b/src/galileo/dataset.py
@@ -200,7 +200,7 @@ class Dataset(StateManagementMixin):
             raise
 
     @classmethod
-    def get(cls, *, id: str | None = None, name: str | None = None) -> Dataset | None:
+    def get(cls, *, id: str | None = None, name: str | None = None) -> Dataset:
         """
         Get an existing dataset by ID or name.
 
@@ -210,11 +210,12 @@ class Dataset(StateManagementMixin):
 
         Returns
         -------
-            Optional[Dataset]: The dataset if found, None otherwise.
+            Dataset: The dataset if found.
 
         Raises
         ------
-            ValueError: If neither or both id and name are provided.
+            ValueError: If neither id nor name is provided.
+            ResourceNotFoundError: If no dataset matches the given id or name.
 
         Examples
         --------
@@ -235,7 +236,10 @@ class Dataset(StateManagementMixin):
             raise ValueError("Either 'id' or 'name' must be provided")
 
         if retrieved_dataset is None:
-            return None
+            not_found_msg = (
+                f"Dataset with id={id!r} not found" if id is not None else f"Dataset with name={name!r} not found"
+            )
+            raise ResourceNotFoundError(not_found_msg)
 
         return cls._from_api_response(retrieved_dataset)
 
@@ -315,13 +319,17 @@ class Dataset(StateManagementMixin):
             prompt_settings=prompt_settings,
         )
 
-    def get_content(self) -> DatasetContent | None:
+    def get_content(self) -> DatasetContent:
         """
         Get the content of this dataset.
 
         Returns
         -------
-            Optional[DatasetContent]: The dataset content if available.
+            DatasetContent: The dataset content.
+
+        Raises
+        ------
+            ResourceNotFoundError: If the dataset no longer exists on the server.
 
         Examples
         --------
@@ -333,7 +341,7 @@ class Dataset(StateManagementMixin):
         datasets_service = Datasets()
         dataset = datasets_service.get(id=self.id)
         if dataset is None:
-            return None
+            raise ResourceNotFoundError(f"Dataset with id={self.id!r} not found")
         return dataset.get_content()
 
     def add_rows(self, rows: list[dict[str, Any]]) -> Dataset:  # type: ignore[valid-type]
@@ -528,7 +536,8 @@ class Dataset(StateManagementMixin):
 
         Raises
         ------
-            Exception: If the API call fails or the dataset no longer exists.
+            ResourceNotFoundError: If the dataset no longer exists on the server.
+            Exception: If the API call fails for any other reason.
 
         Examples
         --------
@@ -543,7 +552,7 @@ class Dataset(StateManagementMixin):
             retrieved_dataset = datasets_service.get(id=self.id)
 
             if retrieved_dataset is None:
-                raise ValueError(f"Dataset with id '{self.id}' no longer exists")
+                raise ResourceNotFoundError(f"Dataset with id={self.id!r} not found")
 
             # Update all attributes from response
             self.id = retrieved_dataset.id

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -729,7 +729,7 @@ class Experiment(StateManagementMixin):
 
         Raises
         ------
-            ValueError: If the experiment ID or project_id is not set, or if the API returns a validation error.
+            ValueError: If the experiment ID or project_id is not set.
             ResourceNotFoundError: If the experiment no longer exists on the server.
             Exception: If the API call fails for any other reason.
 

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -615,7 +615,7 @@ class Experiment(StateManagementMixin):
         return instance
 
     @classmethod
-    def get(cls, *, name: str, project_id: str | None = None, project_name: str | None = None) -> Experiment | None:
+    def get(cls, *, name: str, project_id: str | None = None, project_name: str | None = None) -> Experiment:
         """
         Get an existing experiment by name.
 
@@ -628,11 +628,12 @@ class Experiment(StateManagementMixin):
 
         Returns
         -------
-            Optional[Experiment]: The experiment if found, None otherwise.
+            Experiment: The experiment if found.
 
         Raises
         ------
-            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback).
+            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback),
+                or if no experiment with the given name exists in the project.
 
         Examples
         --------
@@ -662,7 +663,7 @@ class Experiment(StateManagementMixin):
         retrieved_experiment = experiments_service.get(project_id=project_obj.id, experiment_name=name)
 
         if retrieved_experiment is None:
-            return None
+            raise ResourceNotFoundError(f"Experiment with name={name!r} not found")
 
         instance = cls._from_api_response(retrieved_experiment)
         instance.project_id = project_obj.id
@@ -728,9 +729,9 @@ class Experiment(StateManagementMixin):
 
         Raises
         ------
-            ValueError: If the experiment ID or project_id is not set, or if the experiment no longer exists.
-            NotFoundError: If the experiment does not exist on the server (404 from the API).
-            Exception: If the API call fails.
+            ValueError: If the experiment ID or project_id is not set, or if the API returns a validation error.
+            ResourceNotFoundError: If the experiment no longer exists on the server.
+            Exception: If the API call fails for any other reason.
 
         Examples
         --------
@@ -750,7 +751,9 @@ class Experiment(StateManagementMixin):
                 project_id=self.project_id, experiment_id=self.id, client=config.api_client
             )
 
-            if retrieved_experiment is None or isinstance(retrieved_experiment, HTTPValidationError):
+            if retrieved_experiment is None:
+                raise ResourceNotFoundError(f"Experiment with id={self.id!r} not found")
+            if isinstance(retrieved_experiment, HTTPValidationError):
                 raise ValueError(f"Experiment with id '{self.id}' no longer exists")
 
             # Update all top-level attributes from response

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -751,10 +751,8 @@ class Experiment(StateManagementMixin):
                 project_id=self.project_id, experiment_id=self.id, client=config.api_client
             )
 
-            if retrieved_experiment is None:
+            if retrieved_experiment is None or isinstance(retrieved_experiment, HTTPValidationError):
                 raise ResourceNotFoundError(f"Experiment with id={self.id!r} not found")
-            if isinstance(retrieved_experiment, HTTPValidationError):
-                raise ValueError(f"Experiment with id '{self.id}' no longer exists")
 
             # Update all top-level attributes from response
             self.id = retrieved_experiment.id

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -729,7 +729,8 @@ class Experiment(StateManagementMixin):
 
         Raises
         ------
-            ValueError: If the experiment ID or project_id is not set.
+            ValueError: If the experiment ID or project_id is not set, or if the API
+                returns a 422 validation error (e.g. malformed UUID).
             ResourceNotFoundError: If the experiment no longer exists on the server.
             Exception: If the API call fails for any other reason.
 
@@ -751,8 +752,12 @@ class Experiment(StateManagementMixin):
                 project_id=self.project_id, experiment_id=self.id, client=config.api_client
             )
 
-            if retrieved_experiment is None or isinstance(retrieved_experiment, HTTPValidationError):
+            if retrieved_experiment is None:
                 raise ResourceNotFoundError(f"Experiment with id={self.id!r} not found")
+            if isinstance(retrieved_experiment, HTTPValidationError):
+                raise ValueError(
+                    f"Validation error fetching experiment with id={self.id!r}: {retrieved_experiment.detail}"
+                )
 
             # Update all top-level attributes from response
             self.id = retrieved_experiment.id

--- a/src/galileo/integration.py
+++ b/src/galileo/integration.py
@@ -13,7 +13,7 @@ from galileo.resources.models.integration_db import IntegrationDB
 from galileo.resources.models.integration_name import IntegrationName
 from galileo.resources.types import Unset
 from galileo.shared.base import StateManagementMixin, SyncState
-from galileo.shared.exceptions import APIError, ValidationError
+from galileo.shared.exceptions import APIError, ResourceNotFoundError, ValidationError
 from galileo.shared.utils import classproperty
 from galileo.utils.exceptions import APIException
 
@@ -254,7 +254,9 @@ class Integration(StateManagementMixin):
 
         Raises
         ------
-            APIError: If the API call fails or the integration is not found.
+            ValidationError: If the integration has no ID.
+            ResourceNotFoundError: If the integration no longer exists on the server.
+            APIError: If the API call fails for any other reason.
         """
         if self.id is None:
             error = ValidationError("Cannot refresh integration without an ID")
@@ -268,9 +270,9 @@ class Integration(StateManagementMixin):
             all_integrations = list_integrations_integrations_get.sync(client=config.api_client)
 
             if not all_integrations:
-                api_error = APIError(f"Integration with ID {self.id} not found")
-                self._set_state(SyncState.FAILED_SYNC, api_error)
-                raise api_error
+                err = ResourceNotFoundError(f"Integration with id={self.id!r} not found")
+                self._set_state(SyncState.FAILED_SYNC, err)
+                raise err
 
             # Find this integration in the list
             for integration_data in all_integrations:
@@ -295,9 +297,9 @@ class Integration(StateManagementMixin):
                     return
 
             # If we didn't find it, raise an error
-            api_error = APIError(f"Integration with ID {self.id} not found")
-            self._set_state(SyncState.FAILED_SYNC, api_error)
-            raise api_error
+            err = ResourceNotFoundError(f"Integration with id={self.id!r} not found")
+            self._set_state(SyncState.FAILED_SYNC, err)
+            raise err
 
         except APIException as e:
             error_msg = f"Failed to refresh integration: {e!s}"
@@ -365,6 +367,12 @@ class Integration(StateManagementMixin):
     def _get_integration_by_name(cls, integration_name: str) -> Provider | UnconfiguredProvider:
         """
         Get a configured integration by name.
+
+        Note: This method intentionally returns ``UnconfiguredProvider`` (not ``None`` or
+        ``ResourceNotFoundError``) when no matching integration is found. The caller
+        (e.g., ``Integration.openai``) is a convenience property that should degrade
+        gracefully — raising ``IntegrationNotConfiguredError`` only when the provider
+        is actually used, not when it is merely accessed.
 
         Args:
             integration_name (str): The integration name (e.g., "openai", "azure").

--- a/src/galileo/job_progress.py
+++ b/src/galileo/job_progress.py
@@ -11,6 +11,7 @@ from galileo.resources.api.jobs import (
     get_jobs_for_project_run_projects_project_id_runs_run_id_jobs_get,
 )
 from galileo.resources.models import HTTPValidationError, JobDB
+from galileo.shared.exceptions import ResourceNotFoundError
 from galileo.utils.log_config import get_logger
 from galileo_core.constants.job import JobName, JobStatus
 from galileo_core.constants.scorers import Scorers
@@ -26,7 +27,7 @@ def get_job(job_id: str) -> JobDB:
     if isinstance(response, HTTPValidationError):
         raise ValueError(response.detail)
     if not response:
-        raise ValueError(f"Failed to get job status for job {job_id}")
+        raise ResourceNotFoundError(f"Job with id={job_id!r} not found")
     return response
 
 

--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -248,7 +248,7 @@ class LogStream(StateManagementMixin):
         return instance
 
     @classmethod
-    def get(cls, *, name: str, project_id: str | None = None, project_name: str | None = None) -> LogStream | None:
+    def get(cls, *, name: str, project_id: str | None = None, project_name: str | None = None) -> LogStream:
         """
         Get an existing log stream by name.
 
@@ -261,11 +261,12 @@ class LogStream(StateManagementMixin):
 
         Returns
         -------
-            Optional[LogStream]: The log stream if found, None otherwise.
+            LogStream: The log stream if found.
 
         Raises
         ------
-            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback).
+            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback),
+                or if no log stream with the given name exists in the project.
 
         Examples
         --------
@@ -294,7 +295,7 @@ class LogStream(StateManagementMixin):
         log_streams_service = LogStreams()
         retrieved_log_stream = log_streams_service.get(name=name, project_id=project_obj.id)
         if retrieved_log_stream is None:
-            return None
+            raise ResourceNotFoundError(f"LogStream with name={name!r} not found")
 
         instance = cls._from_api_response(retrieved_log_stream)
         # Set project_name from resolved project
@@ -357,7 +358,8 @@ class LogStream(StateManagementMixin):
         Raises
         ------
             ValueError: If the log stream ID or project_id is not set.
-            Exception: If the API call fails or the log stream no longer exists.
+            ResourceNotFoundError: If the log stream no longer exists on the server.
+            Exception: If the API call fails for any other reason.
 
         Examples
         --------
@@ -376,7 +378,7 @@ class LogStream(StateManagementMixin):
             retrieved_log_stream = log_streams_service.get(id=self.id, project_id=self.project_id)
 
             if retrieved_log_stream is None:
-                raise ValueError(f"Log stream with id '{self.id}' no longer exists")
+                raise ResourceNotFoundError(f"LogStream with id={self.id!r} not found")
 
             # Update all attributes from response
             self.created_at = retrieved_log_stream.created_at
@@ -473,7 +475,7 @@ class LogStream(StateManagementMixin):
             log_streams_service = LogStreams()
             log_stream = log_streams_service.get(name=self.name, project_id=self.project_id)
             if log_stream is None:
-                raise ValueError(f"Log stream '{self.name}' not found")
+                raise ResourceNotFoundError(f"LogStream with name={self.name!r} not found")
             result = log_stream.enable_metrics(metrics)
             # Set state to synced after successful operation
             self._set_state(SyncState.SYNCED)

--- a/src/galileo/metric.py
+++ b/src/galileo/metric.py
@@ -39,7 +39,7 @@ from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig
 from galileo.schema.metrics import Metric as LegacyMetric
 from galileo.scorers import Scorers
 from galileo.shared.base import StateManagementMixin, SyncState
-from galileo.shared.exceptions import APIError, ValidationError
+from galileo.shared.exceptions import APIError, ResourceNotFoundError, ValidationError
 from galileo_core.schemas.logging.span import Span
 from galileo_core.schemas.logging.step import StepType
 from galileo_core.schemas.logging.trace import Trace
@@ -221,7 +221,7 @@ class Metric(StateManagementMixin, ABC):
         return GalileoMetric.__new__(GalileoMetric)
 
     @classmethod
-    def get(cls, *, id: str | None = None, name: str | None = None) -> Metric | None:
+    def get(cls, *, id: str | None = None, name: str | None = None) -> Metric:
         """
         Get an existing metric by ID or name.
 
@@ -233,11 +233,12 @@ class Metric(StateManagementMixin, ABC):
 
         Returns
         -------
-            Optional[Metric]: The metric if found (GalileoMetric, LlmMetric, or CodeMetric), None otherwise.
+            Metric: The metric if found (GalileoMetric, LlmMetric, or CodeMetric).
 
         Raises
         ------
             ValidationError: If neither or both id and name are provided.
+            ResourceNotFoundError: If no metric matches the given id or name.
 
         Examples
         --------
@@ -257,16 +258,16 @@ class Metric(StateManagementMixin, ABC):
         if name is not None:
             scorers = scorers_service.list(name=name)
             if not scorers:
-                return None
+                raise ResourceNotFoundError(f"Metric with name={name!r} not found")
             retrieved_scorer = next((s for s in scorers if s.name == name), None)
             if retrieved_scorer is None:
-                return None
+                raise ResourceNotFoundError(f"Metric with name={name!r} not found")
         else:
             assert id is not None
             scorers = scorers_service.list()
             retrieved_scorer = next((s for s in scorers if s.id == id), None)
             if retrieved_scorer is None:
-                return None
+                raise ResourceNotFoundError(f"Metric with id={id!r} not found")
 
         # Create appropriate subclass instance based on scorer_type
         instance = cls._create_metric_from_type(retrieved_scorer.scorer_type)
@@ -532,8 +533,9 @@ class Metric(StateManagementMixin, ABC):
         Raises
         ------
             ValidationError: If this is a local metric.
-            ValueError: If the metric is not synced.
-            Exception: If the API call fails or the metric no longer exists.
+            ValueError: If the metric ID is not set.
+            ResourceNotFoundError: If the metric no longer exists on the server.
+            Exception: If the API call fails for any other reason.
 
         Examples
         --------
@@ -553,7 +555,7 @@ class Metric(StateManagementMixin, ABC):
             retrieved_scorer = next((s for s in scorers if s.id == self.id), None)
 
             if retrieved_scorer is None:
-                raise ValueError(f"Metric with id '{self.id}' no longer exists")
+                raise ResourceNotFoundError(f"Metric with id={self.id!r} not found")
 
             self._populate_from_scorer_response(retrieved_scorer)
             self._set_state(SyncState.SYNCED)

--- a/src/galileo/project.py
+++ b/src/galileo/project.py
@@ -13,7 +13,7 @@ from galileo.resources.models.http_validation_error import HTTPValidationError
 from galileo.resources.models.project_update import ProjectUpdate
 from galileo.resources.types import Unset
 from galileo.shared.base import StateManagementMixin, SyncState
-from galileo.shared.exceptions import APIError, ValidationError
+from galileo.shared.exceptions import APIError, ResourceNotFoundError, ValidationError
 
 if TYPE_CHECKING:
     from galileo.dataset import Dataset
@@ -230,7 +230,7 @@ class Project(StateManagementMixin):
             raise
 
     @classmethod
-    def get(cls, *, id: str | None = None, name: str | None = None) -> Project | None:
+    def get(cls, *, id: str | None = None, name: str | None = None) -> Project:
         """
         Get an existing project by ID or name.
 
@@ -240,11 +240,12 @@ class Project(StateManagementMixin):
 
         Returns
         -------
-            Optional[Project]: The project if found, None otherwise.
+            Project: The project if found.
 
         Raises
         ------
             ValidationError: If neither or both id and name are provided.
+            ResourceNotFoundError: If no project matches the given id or name.
 
         Examples
         --------
@@ -258,9 +259,14 @@ class Project(StateManagementMixin):
             projects_service = Projects()
             retrieved_project = projects_service.get(id=id, name=name)
             if retrieved_project is None:
-                return None
+                not_found_msg = (
+                    f"Project with id={id!r} not found" if id is not None else f"Project with name={name!r} not found"
+                )
+                raise ResourceNotFoundError(not_found_msg)
 
             return cls._from_api_response(retrieved_project)
+        except (ResourceNotFoundError, ValidationError):
+            raise
         except ValueError as e:
             raise ValidationError(str(e)) from e
         except Exception as e:
@@ -692,7 +698,8 @@ class Project(StateManagementMixin):
 
         Raises
         ------
-            Exception: If the API call fails or the project no longer exists.
+            ResourceNotFoundError: If the project no longer exists on the server.
+            Exception: If the API call fails for any other reason.
 
         Examples
         --------
@@ -707,7 +714,7 @@ class Project(StateManagementMixin):
             retrieved_project = projects_service.get(id=self.id)
 
             if retrieved_project is None:
-                raise ValueError(f"Project with id '{self.id}' no longer exists")
+                raise ResourceNotFoundError(f"Project with id={self.id!r} not found")
 
             # Update all attributes from response without triggering dirty-tracking
             self._sync_attrs(

--- a/src/galileo/prompt.py
+++ b/src/galileo/prompt.py
@@ -373,7 +373,7 @@ class Prompt(StateManagementMixin):
             raise
 
     @classmethod
-    def get(cls, *, id: str | None = None, name: str | None = None) -> Prompt | None:
+    def get(cls, *, id: str | None = None, name: str | None = None) -> Prompt:
         """
         Get an existing prompt by ID or name.
 
@@ -383,11 +383,12 @@ class Prompt(StateManagementMixin):
 
         Returns
         -------
-            Optional[Prompt]: The prompt if found, None otherwise.
+            Prompt: The prompt if found.
 
         Raises
         ------
             ValidationError: If neither or both id and name are provided.
+            ResourceNotFoundError: If no prompt matches the given id or name.
 
         Examples
         --------
@@ -411,7 +412,10 @@ class Prompt(StateManagementMixin):
             retrieved_prompt = prompt_service.get(name=name)
 
         if retrieved_prompt is None:
-            return None
+            not_found_msg = (
+                f"Prompt with id={id!r} not found" if id is not None else f"Prompt with name={name!r} not found"
+            )
+            raise ResourceNotFoundError(not_found_msg)
 
         return cls._from_api_response(retrieved_prompt)
 
@@ -611,7 +615,8 @@ class Prompt(StateManagementMixin):
 
         Raises
         ------
-            Exception: If the API call fails or the prompt no longer exists.
+            ResourceNotFoundError: If the prompt no longer exists on the server.
+            Exception: If the API call fails for any other reason.
 
         Examples
         --------
@@ -626,7 +631,7 @@ class Prompt(StateManagementMixin):
             retrieved_prompt = prompt_service.get(template_id=self.id)
 
             if retrieved_prompt is None:
-                raise ValueError(f"Prompt with id '{self.id}' no longer exists")
+                raise ResourceNotFoundError(f"Prompt with id={self.id!r} not found")
 
             # Update all attributes from response
             self._update_from_api_response(retrieved_prompt)

--- a/src/galileo/provider.py
+++ b/src/galileo/provider.py
@@ -25,7 +25,7 @@ from galileo.resources.models import (
 )
 from galileo.resources.types import Unset
 from galileo.shared.base import StateManagementMixin, SyncState
-from galileo.shared.exceptions import APIError, IntegrationNotConfiguredError, ValidationError
+from galileo.shared.exceptions import APIError, IntegrationNotConfiguredError, ResourceNotFoundError, ValidationError
 from galileo.utils.exceptions import APIException
 
 logger = logging.getLogger(__name__)
@@ -93,8 +93,9 @@ class Provider(StateManagementMixin, ABC):
 
         Raises
         ------
-            APIError: If the API call fails or the integration is not found.
             ValidationError: If the provider has no ID.
+            ResourceNotFoundError: If the provider no longer exists on the server.
+            APIError: If the API call fails for any other reason.
         """
         if self.id is None:
             error = ValidationError("Cannot refresh provider without an ID")
@@ -111,9 +112,9 @@ class Provider(StateManagementMixin, ABC):
             response = get_integration_integrations_name_get.sync(name=integration_name, client=config.api_client)
 
             if response is None or isinstance(response, HTTPValidationError):
-                api_error = APIError(f"Provider with ID {self.id} not found")
-                self._set_state(SyncState.FAILED_SYNC, api_error)
-                raise api_error
+                err = ResourceNotFoundError(f"Provider with id={self.id!r} not found")
+                self._set_state(SyncState.FAILED_SYNC, err)
+                raise err
 
             # Update attributes from response
             self._update_from_api_response(response)

--- a/src/galileo/stages.py
+++ b/src/galileo/stages.py
@@ -14,6 +14,7 @@ from galileo.resources.models.rulesets_mixin import RulesetsMixin as APIRulesets
 from galileo.resources.models.stage_db import StageDB as APIStageDB
 from galileo.resources.models.stage_with_rulesets import StageWithRulesets as APIStageWithRulesets
 from galileo.resources.types import UNSET
+from galileo.shared.exceptions import ResourceNotFoundError
 from galileo_core.schemas.protect.ruleset import Ruleset, RulesetsMixin
 from galileo_core.schemas.protect.stage import StageDB, StageType, StageWithRulesets
 from galileo_core.utils.name import ts_name
@@ -27,7 +28,7 @@ def _get_validated_project_id(project_id: str | UUID4 | None = None, project_nam
 
     project = Projects().get_with_env_fallbacks(name=project_name, id=project_id)
     if not project:
-        raise ValueError(f"Project with name '{project_name}' not found.")
+        raise ResourceNotFoundError(f"Project with name={project_name!r} not found")
     return str(project.id)
 
 
@@ -41,9 +42,8 @@ def _get_stage_id(
     if stage_id:
         return str(stage_id)
     if stage_name:
+        # Stages().get raises ResourceNotFoundError if the stage is missing.
         stage = Stages().get(project_id=project_id, stage_name=stage_name)
-        if not stage:
-            raise ValueError(f"Stage with name '{stage_name}' not found.")
         return str(stage.id)
     raise ValueError("Either stage_id or stage_name must be provided.")
 
@@ -109,6 +109,13 @@ class Stages:
         )
         if isinstance(response, APIStageDB):
             return StageDB.model_validate(response.to_dict())
+        if response is None:
+            not_found_msg = (
+                f"Stage with id={stage_id!r} not found"
+                if stage_id is not None
+                else f"Stage with name={stage_name!r} not found"
+            )
+            raise ResourceNotFoundError(not_found_msg)
         return response
 
     def update(

--- a/src/galileo/stages.py
+++ b/src/galileo/stages.py
@@ -10,6 +10,7 @@ from galileo.resources.api.protect import (
     pause_stage_projects_project_id_stages_stage_id_put,
     update_stage_projects_project_id_stages_stage_id_post,
 )
+from galileo.resources.models.http_validation_error import HTTPValidationError
 from galileo.resources.models.rulesets_mixin import RulesetsMixin as APIRulesetsMixin
 from galileo.resources.models.stage_db import StageDB as APIStageDB
 from galileo.resources.models.stage_with_rulesets import StageWithRulesets as APIStageWithRulesets
@@ -28,7 +29,12 @@ def _get_validated_project_id(project_id: str | UUID4 | None = None, project_nam
 
     project = Projects().get_with_env_fallbacks(name=project_name, id=project_id)
     if not project:
-        raise ResourceNotFoundError(f"Project with name={project_name!r} not found")
+        not_found_msg = (
+            f"Project with id={project_id!r} not found"
+            if project_id is not None
+            else f"Project with name={project_name!r} not found"
+        )
+        raise ResourceNotFoundError(not_found_msg)
     return str(project.id)
 
 
@@ -116,6 +122,8 @@ class Stages:
                 else f"Stage with name={stage_name!r} not found"
             )
             raise ResourceNotFoundError(not_found_msg)
+        if isinstance(response, HTTPValidationError):
+            raise ValueError(f"Validation error looking up stage: {response.detail}")
         return response
 
     def update(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -91,15 +91,36 @@ class TestDatasetGet:
         assert dataset.is_synced()
 
     @patch("galileo.dataset.Datasets")
-    def test_get_returns_none_when_not_found(self, mock_datasets_class: MagicMock, reset_configuration: None) -> None:
-        """Test get() returns None when dataset is not found."""
+    def test_get_raises_resource_not_found_by_name(
+        self, mock_datasets_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: service returns None for the lookup
         mock_service = MagicMock()
         mock_datasets_class.return_value = mock_service
         mock_service.get.return_value = None
 
-        dataset = Dataset.get(name="Nonexistent Dataset")
+        # When/Then: get() raises ResourceNotFoundError with name in message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Dataset.get(name="Nonexistent Dataset")
 
-        assert dataset is None
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "name=" in str(exc_info.value)
+
+    @patch("galileo.dataset.Datasets")
+    def test_get_raises_resource_not_found_by_id(
+        self, mock_datasets_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: service returns None for the lookup
+        mock_service = MagicMock()
+        mock_datasets_class.return_value = mock_service
+        mock_service.get.return_value = None
+
+        # When/Then: get() raises ResourceNotFoundError with id in message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Dataset.get(id="nonexistent-dataset-id")
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
 
     @patch("galileo.dataset.Datasets")
     def test_get_raises_error_without_id_or_name(
@@ -159,6 +180,25 @@ class TestDatasetContent:
 
         assert content == mock_content
         mock_dataset.get_content.assert_called_once()
+
+    @patch("galileo.dataset.Datasets")
+    def test_get_content_raises_resource_not_found_when_dataset_deleted(
+        self, mock_datasets_class: MagicMock, reset_configuration: None, mock_dataset: MagicMock
+    ) -> None:
+        # Given: a synced dataset whose remote record has since been deleted
+        mock_service = MagicMock()
+        mock_datasets_class.return_value = mock_service
+        mock_service.get.side_effect = [mock_dataset, None]
+
+        dataset = Dataset.get(id=mock_dataset.id)
+        assert dataset.is_synced()
+
+        # When/Then: get_content() raises ResourceNotFoundError
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            dataset.get_content()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
 
     @pytest.mark.parametrize(
         "method_name", ["get_content", "add_rows", "get_versions", "get_version_content", "extend"]
@@ -329,6 +369,37 @@ class TestDatasetRefresh:
 
         with pytest.raises(ValueError, match="Dataset ID is not set"):
             dataset.refresh()
+
+    @patch("galileo.dataset.Datasets")
+    def test_refresh_raises_resource_not_found_when_dataset_deleted(
+        self, mock_datasets_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: a synced dataset whose remote record has been deleted
+        mock_service = MagicMock()
+        mock_datasets_class.return_value = mock_service
+
+        dataset_id = str(uuid4())
+        initial = MagicMock()
+        initial.id = dataset_id
+        initial.name = "Test Dataset"
+        initial.created_at = MagicMock()
+        initial.updated_at = MagicMock()
+        initial.num_rows = 10
+        initial.column_names = ["input", "output"]
+        initial.draft = False
+
+        mock_service.get.side_effect = [initial, None]
+
+        dataset = Dataset.get(id=dataset_id)
+        assert dataset.is_synced()
+
+        # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            dataset.refresh()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
+        assert dataset.sync_state == SyncState.FAILED_SYNC
 
 
 class TestDatasetSave:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1013,24 +1013,22 @@ class TestExperimentLifecycle:
 
     @patch("galileo.experiment.GalileoPythonConfig")
     @patch("galileo.experiment.get_experiment_projects_project_id_experiments_experiment_id_get")
-    def test_refresh_raises_resource_not_found_when_api_returns_validation_error(
+    def test_refresh_raises_value_error_when_api_returns_validation_error(
         self,
         mock_get_experiment_api: MagicMock,
         mock_config_class: MagicMock,
         synced_experiment: Experiment,
         reset_configuration: None,
     ) -> None:
-        # Given: a synced experiment and the API returns HTTPValidationError
+        # Given: a synced experiment and the API returns a 422 HTTPValidationError
         mock_config = MagicMock()
         mock_config_class.get.return_value = mock_config
         mock_get_experiment_api.sync.return_value = HTTPValidationError()
 
-        # When/Then: refresh() raises ResourceNotFoundError (not ValueError) and sets FAILED_SYNC
-        with pytest.raises(ResourceNotFoundError) as exc_info:
+        # When/Then: refresh() raises ValueError (not ResourceNotFoundError) and sets FAILED_SYNC
+        with pytest.raises(ValueError, match="Validation error fetching experiment"):
             synced_experiment.refresh()
 
-        assert isinstance(exc_info.value, ResourceNotFoundError)
-        assert "id=" in str(exc_info.value)
         assert synced_experiment.sync_state == SyncState.FAILED_SYNC
 
     @patch("galileo.experiment.GalileoPythonConfig")

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -6,7 +6,7 @@ import pytest
 
 from galileo.exceptions import NotFoundError
 from galileo.experiment import Experiment
-from galileo.resources.models import ExperimentResponse, PromptRunSettings
+from galileo.resources.models import ExperimentResponse, HTTPValidationError, PromptRunSettings
 from galileo.schema.metrics import GalileoMetrics
 from galileo.search import RecordType
 from galileo.shared.base import SyncState
@@ -1004,6 +1004,28 @@ class TestExperimentLifecycle:
         mock_get_experiment_api.sync.return_value = None
 
         # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            synced_experiment.refresh()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
+        assert synced_experiment.sync_state == SyncState.FAILED_SYNC
+
+    @patch("galileo.experiment.GalileoPythonConfig")
+    @patch("galileo.experiment.get_experiment_projects_project_id_experiments_experiment_id_get")
+    def test_refresh_raises_resource_not_found_when_api_returns_validation_error(
+        self,
+        mock_get_experiment_api: MagicMock,
+        mock_config_class: MagicMock,
+        synced_experiment: Experiment,
+        reset_configuration: None,
+    ) -> None:
+        # Given: a synced experiment and the API returns HTTPValidationError
+        mock_config = MagicMock()
+        mock_config_class.get.return_value = mock_config
+        mock_get_experiment_api.sync.return_value = HTTPValidationError()
+
+        # When/Then: refresh() raises ResourceNotFoundError (not ValueError) and sets FAILED_SYNC
         with pytest.raises(ResourceNotFoundError) as exc_info:
             synced_experiment.refresh()
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -625,15 +625,14 @@ class TestExperimentGet:
 
     @patch("galileo.experiment.Projects")
     @patch("galileo.experiment.ExperimentsService")
-    def test_get_returns_none_when_not_found(
+    def test_get_raises_resource_not_found_when_not_found(
         self,
         mock_experiments_class: MagicMock,
         mock_projects_class: MagicMock,
         reset_configuration: None,
         mock_project: MagicMock,
     ) -> None:
-        """Test get() returns None when experiment is not found."""
-        # Setup mocks
+        # Given: the project resolves but the experiment does not exist
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = mock_project
@@ -642,11 +641,12 @@ class TestExperimentGet:
         mock_experiments_class.return_value = mock_experiments_service
         mock_experiments_service.get.return_value = None
 
-        # Get experiment
-        experiment = Experiment.get(name="Nonexistent", project_name="Test Project")
+        # When/Then: get() raises ResourceNotFoundError with name in message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Experiment.get(name="Nonexistent", project_name="Test Project")
 
-        # Verify
-        assert experiment is None
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "name=" in str(exc_info.value)
 
 
 class TestExperimentList:
@@ -987,6 +987,28 @@ class TestExperimentLifecycle:
         with pytest.raises(NotFoundError):
             synced_experiment.refresh()
 
+        assert synced_experiment.sync_state == SyncState.FAILED_SYNC
+
+    @patch("galileo.experiment.GalileoPythonConfig")
+    @patch("galileo.experiment.get_experiment_projects_project_id_experiments_experiment_id_get")
+    def test_refresh_raises_resource_not_found_when_api_returns_none(
+        self,
+        mock_get_experiment_api: MagicMock,
+        mock_config_class: MagicMock,
+        synced_experiment: Experiment,
+        reset_configuration: None,
+    ) -> None:
+        # Given: a synced experiment and the API returns None (no record)
+        mock_config = MagicMock()
+        mock_config_class.get.return_value = mock_config
+        mock_get_experiment_api.sync.return_value = None
+
+        # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            synced_experiment.refresh()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
         assert synced_experiment.sync_state == SyncState.FAILED_SYNC
 
     @patch("galileo.experiment.GalileoPythonConfig")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,8 @@ from galileo.provider import (
 from galileo.resources.models.available_integrations import AvailableIntegrations
 from galileo.resources.models.integration_db import IntegrationDB
 from galileo.resources.models.integration_name import IntegrationName
-from galileo.shared.exceptions import IntegrationNotConfiguredError, ValidationError
+from galileo.shared.base import SyncState
+from galileo.shared.exceptions import IntegrationNotConfiguredError, ResourceNotFoundError, ValidationError
 
 # Test data
 INTEGRATION_TYPES = [
@@ -139,6 +140,41 @@ class TestIntegrationRefresh:
 
         with pytest.raises(ValidationError, match="Cannot refresh integration without an ID"):
             integration.refresh()
+
+    @patch("galileo.integration.GalileoPythonConfig.get")
+    @patch("galileo.integration.list_integrations_integrations_get")
+    def test_refresh_raises_resource_not_found_when_integration_deleted_empty_list(self, mock_list, mock_config):
+        # Given: a known integration whose remote record has been deleted (empty list returned)
+        mock_integration = create_mock_integration(IntegrationName.OPENAI)
+        integration = Integration._from_api_response(mock_integration)
+        mock_list.sync.return_value = []
+
+        # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            integration.refresh()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
+        assert integration.sync_state == SyncState.FAILED_SYNC
+
+    @patch("galileo.integration.GalileoPythonConfig.get")
+    @patch("galileo.integration.list_integrations_integrations_get")
+    def test_refresh_raises_resource_not_found_when_integration_not_in_list(self, mock_list, mock_config):
+        # Given: a known integration whose id is not found in the returned list
+        mock_integration = create_mock_integration(IntegrationName.OPENAI)
+        integration = Integration._from_api_response(mock_integration)
+
+        # Different integration in the list — not a match
+        other_integration = create_mock_integration(IntegrationName.ANTHROPIC)
+        mock_list.sync.return_value = [other_integration]
+
+        # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            integration.refresh()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
+        assert integration.sync_state == SyncState.FAILED_SYNC
 
 
 class TestIntegrationConvenienceProperties:

--- a/tests/test_job_progress.py
+++ b/tests/test_job_progress.py
@@ -8,6 +8,7 @@ from pytest import CaptureFixture, LogCaptureFixture
 
 from galileo.job_progress import job_progress, scorer_jobs_status
 from galileo.resources.models import HTTPValidationError, JobDB, ValidationError
+from galileo.shared.exceptions import ResourceNotFoundError
 from galileo_core.constants.job import JobStatus
 
 FIXED_PROJECT_ID = str(uuid4())
@@ -65,11 +66,16 @@ class TestJobProgress:
         mock_get_job.assert_called_with(client=ANY, job_id=FIXED_JOB_ID)
 
     @patch("galileo.job_progress.get_job_jobs_job_id_get.sync")
-    def test_get_job_fails(self, mock_get_job: Mock):
+    def test_get_job_raises_resource_not_found_when_response_is_none(self, mock_get_job: Mock):
+        # Given: the API returns None for the job
         mock_get_job.return_value = None
 
-        with pytest.raises(ValueError, match=f"Failed to get job status for job {FIXED_JOB_ID}"):
+        # When/Then: ResourceNotFoundError is raised with id in the message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
             job_progress(job_id=FIXED_JOB_ID, project_id=FIXED_PROJECT_ID, run_id=FIXED_RUN_ID)
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
         mock_get_job.assert_called_with(client=ANY, job_id=FIXED_JOB_ID)
 
     @patch("galileo.job_progress.get_job_jobs_job_id_get.sync")

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -239,10 +239,9 @@ class TestLogStreamGet:
 
     @patch("galileo.log_stream.LogStreams")
     @patch("galileo.log_stream.Projects")
-    def test_get_returns_none_when_not_found(
+    def test_get_raises_resource_not_found_when_not_found(
         self, mock_projects_class: MagicMock, mock_logstreams_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test get() returns None when log stream is not found."""
         # Given: project is resolved but log stream not found
         mock_project = MagicMock()
         mock_project.id = "test-project-id"
@@ -255,11 +254,12 @@ class TestLogStreamGet:
         mock_logstreams_class.return_value = mock_service
         mock_service.get.return_value = None
 
-        # When: calling get
-        log_stream = LogStream.get(name="Nonexistent Stream", project_id="test-project-id")
+        # When/Then: get() raises ResourceNotFoundError with name in the message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            LogStream.get(name="Nonexistent Stream", project_id="test-project-id")
 
-        # Then: None is returned
-        assert log_stream is None
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "name=" in str(exc_info.value)
 
     @patch("galileo.log_stream.Projects")
     def test_get_raises_error_without_project_info_and_no_env_fallback(
@@ -479,7 +479,7 @@ class TestLogStreamRefresh:
 
     @patch("galileo.log_stream.Projects")
     @patch("galileo.log_stream.LogStreams")
-    def test_refresh_raises_error_if_log_stream_no_longer_exists(
+    def test_refresh_raises_resource_not_found_if_log_stream_no_longer_exists(
         self,
         mock_logstreams_class: MagicMock,
         mock_projects_class: MagicMock,
@@ -487,7 +487,7 @@ class TestLogStreamRefresh:
         mock_logstream: MagicMock,
         mock_project: MagicMock,
     ) -> None:
-        """Test refresh() raises ValueError if log stream no longer exists."""
+        # Given: a synced log stream whose remote record has been deleted
         mock_projects_class.return_value.get_with_env_fallbacks.return_value = mock_project
         mock_service = MagicMock()
         mock_logstreams_class.return_value = mock_service
@@ -495,9 +495,12 @@ class TestLogStreamRefresh:
 
         log_stream = LogStream.get(name="Test Stream", project_id="test-project-id")
 
-        with pytest.raises(ValueError, match="no longer exists"):
+        # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
             log_stream.refresh()
 
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
         assert log_stream.sync_state == SyncState.FAILED_SYNC
 
     @patch("galileo.log_stream.LogStreams")
@@ -927,3 +930,30 @@ class TestLogStreamMethods:
         assert "test-id-123" in repr(log_stream)
         assert "test-project-id" in repr(log_stream)
         assert "2024-01-01 12:00:00" in repr(log_stream)
+
+
+class TestLogStreamSetMetrics:
+    """Test suite for LogStream.set_metrics() not-found path."""
+
+    @patch("galileo.log_stream.LogStreams")
+    def test_set_metrics_raises_resource_not_found_when_log_stream_deleted(
+        self, mock_logstreams_class: MagicMock, reset_configuration: None, mock_logstream: MagicMock
+    ) -> None:
+        # Given: an instance whose remote log stream cannot be found by name
+        mock_service = MagicMock()
+        mock_logstreams_class.return_value = mock_service
+        mock_service.get.return_value = None
+
+        log_stream = LogStream._create_empty()
+        log_stream.id = str(uuid4())
+        log_stream.name = "Missing Stream"
+        log_stream.project_id = "test-project-id"
+        log_stream._set_state(SyncState.SYNCED)
+
+        # When/Then: set_metrics() raises ResourceNotFoundError with name in the message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            log_stream.set_metrics([])
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "name=" in str(exc_info.value)
+        assert log_stream.sync_state == SyncState.FAILED_SYNC

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -10,7 +10,7 @@ from galileo.resources.models import HTTPValidationError, OutputTypeEnum, Scorer
 from galileo.resources.models.invalid_result import InvalidResult
 from galileo.resources.models.task_result_status import TaskResultStatus
 from galileo.shared.base import SyncState
-from galileo.shared.exceptions import APIError, ValidationError
+from galileo.shared.exceptions import APIError, ResourceNotFoundError, ValidationError
 from galileo_core.schemas.logging.step import StepType
 
 # Test fixtures and helper functions
@@ -315,15 +315,54 @@ class TestMetricGet:
         assert metric.is_synced()
 
     @patch("galileo.metric.Scorers")
-    def test_get_returns_none_when_not_found(self, mock_scorers_class: MagicMock, reset_configuration: None) -> None:
-        """Test get() returns None when metric is not found."""
+    def test_get_raises_resource_not_found_by_name_empty_list(
+        self, mock_scorers_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: the scorers service returns an empty list (name not matched)
         mock_service = MagicMock()
         mock_scorers_class.return_value = mock_service
         mock_service.list.return_value = []
 
-        metric = Metric.get(name="Nonexistent Metric")
+        # When/Then: get() raises ResourceNotFoundError with name in the message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Metric.get(name="Nonexistent Metric")
 
-        assert metric is None
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "name=" in str(exc_info.value)
+
+    @patch("galileo.metric.Scorers")
+    def test_get_raises_resource_not_found_by_name_no_exact_match(
+        self, mock_scorers_class: MagicMock, reset_configuration: None, mock_scorer_response: MagicMock
+    ) -> None:
+        # Given: the service returns results but none have the exact name
+        mock_service = MagicMock()
+        mock_scorers_class.return_value = mock_service
+        scorer = mock_scorer_response(scorer_id=str(uuid4()), name="other-metric")
+        mock_service.list.return_value = [scorer]
+
+        # When/Then: get() raises ResourceNotFoundError with name in the message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Metric.get(name="Nonexistent Metric")
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "name=" in str(exc_info.value)
+
+    @patch("galileo.metric.Scorers")
+    def test_get_raises_resource_not_found_by_id(
+        self, mock_scorers_class: MagicMock, reset_configuration: None, mock_scorer_response: MagicMock
+    ) -> None:
+        # Given: the service returns all scorers but none match the requested id
+        mock_service = MagicMock()
+        mock_scorers_class.return_value = mock_service
+        scorer = mock_scorer_response(scorer_id=str(uuid4()), name="some-metric")
+        mock_service.list.return_value = [scorer]
+
+        # When/Then: get() raises ResourceNotFoundError with id in the message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Metric.get(id="nonexistent-metric-id")
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
 
     @pytest.mark.parametrize(
         "kwargs,expected_error",
@@ -521,10 +560,10 @@ class TestMetricRefresh:
             metric.refresh()
 
     @patch("galileo.metric.Scorers")
-    def test_refresh_raises_error_when_metric_no_longer_exists(
+    def test_refresh_raises_resource_not_found_when_metric_deleted(
         self, mock_scorers_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test refresh() raises error when metric no longer exists."""
+        # Given: a synced metric whose remote record has been deleted (list returns empty on second call)
         mock_service = MagicMock()
         mock_scorers_class.return_value = mock_service
 
@@ -542,13 +581,19 @@ class TestMetricRefresh:
         mock_scorer.defaults = MagicMock()
         mock_scorer.scoreable_node_types = []
 
-        # First call returns the metric, second returns empty list (deleted)
+        # First call (get) returns the metric; second call (refresh) returns empty list
         mock_service.list.side_effect = [[mock_scorer], []]
 
         metric = Metric.get(id=metric_id)
+        assert metric.is_synced()
 
-        with pytest.raises(ValueError, match="no longer exists"):
+        # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
             metric.refresh()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
+        assert metric.sync_state == SyncState.FAILED_SYNC
 
 
 class TestMetricUpdate:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -7,7 +7,7 @@ import pytest
 from galileo.collaborator import Collaborator, CollaboratorRole
 from galileo.project import Project
 from galileo.shared.base import SyncState
-from galileo.shared.exceptions import APIError, ValidationError
+from galileo.shared.exceptions import APIError, ResourceNotFoundError, ValidationError
 
 
 class TestProjectInitialization:
@@ -86,15 +86,36 @@ class TestProjectGet:
         assert project.is_synced()
 
     @patch("galileo.project.Projects")
-    def test_get_returns_none_when_not_found(self, mock_projects_class: MagicMock, reset_configuration: None) -> None:
-        """Test get() returns None when project is not found."""
+    def test_get_raises_resource_not_found_by_name(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: the service returns None for the lookup
         mock_service = MagicMock()
         mock_projects_class.return_value = mock_service
         mock_service.get.return_value = None
 
-        project = Project.get(name="Nonexistent Project")
+        # When/Then: get() raises ResourceNotFoundError with the name in the message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Project.get(name="Nonexistent Project")
 
-        assert project is None
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "name=" in str(exc_info.value)
+
+    @patch("galileo.project.Projects")
+    def test_get_raises_resource_not_found_by_id(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: the service returns None for the lookup
+        mock_service = MagicMock()
+        mock_projects_class.return_value = mock_service
+        mock_service.get.return_value = None
+
+        # When/Then: get() raises ResourceNotFoundError with the id in the message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Project.get(id="nonexistent-id-123")
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
 
     @patch("galileo.project.Projects")
     def test_get_raises_error_for_api_failure(self, mock_projects_class: MagicMock, reset_configuration: None) -> None:
@@ -420,6 +441,33 @@ class TestProjectCollaborators:
 
         with pytest.raises(ValueError, match="Project ID is not set"):
             project.remove_collaborator(user_id="user-123")
+
+
+class TestProjectRefresh:
+    """Test suite for Project.refresh() method."""
+
+    @patch("galileo.project.Projects")
+    def test_refresh_raises_resource_not_found_when_project_deleted(
+        self, mock_projects_class: MagicMock, reset_configuration: None, mock_project: MagicMock
+    ) -> None:
+        # Given: a synced project whose remote record has been deleted
+        mock_service = MagicMock()
+        mock_projects_class.return_value = mock_service
+        mock_service.get.return_value = mock_project
+
+        project = Project.get(id=mock_project.id)
+        assert project.is_synced()
+
+        # Simulate remote deletion
+        mock_service.get.return_value = None
+
+        # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            project.refresh()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
+        assert project.sync_state == SyncState.FAILED_SYNC
 
 
 class TestCollaborator:

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -202,15 +202,36 @@ class TestPromptGet:
         assert prompt.is_synced()
 
     @patch("galileo.prompt.GlobalPromptTemplates")
-    def test_get_returns_none_when_not_found(self, mock_templates_class: MagicMock, reset_configuration: None) -> None:
-        """Test get() returns None when prompt is not found."""
+    def test_get_raises_resource_not_found_by_name(
+        self, mock_templates_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: service returns None for the name lookup
         mock_service = MagicMock()
         mock_templates_class.return_value = mock_service
         mock_service.get.return_value = None
 
-        prompt = Prompt.get(name="Nonexistent Prompt")
+        # When/Then: get() raises ResourceNotFoundError with name in message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Prompt.get(name="Nonexistent Prompt")
 
-        assert prompt is None
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "name=" in str(exc_info.value)
+
+    @patch("galileo.prompt.GlobalPromptTemplates")
+    def test_get_raises_resource_not_found_by_id(
+        self, mock_templates_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: service returns None for the id lookup
+        mock_service = MagicMock()
+        mock_templates_class.return_value = mock_service
+        mock_service.get.return_value = None
+
+        # When/Then: get() raises ResourceNotFoundError with id in message
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            Prompt.get(id="nonexistent-id-123")
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
 
     @pytest.mark.parametrize(
         "kwargs,expected_error",
@@ -380,6 +401,26 @@ class TestPromptRefresh:
 
         with pytest.raises(ValueError, match="Prompt ID is not set"):
             prompt.refresh()
+
+    @patch("galileo.prompt.GlobalPromptTemplates")
+    def test_refresh_raises_resource_not_found_when_prompt_deleted(
+        self, mock_templates_class: MagicMock, reset_configuration: None, mock_prompt: MagicMock
+    ) -> None:
+        # Given: a synced prompt whose remote record has been deleted
+        mock_service = MagicMock()
+        mock_templates_class.return_value = mock_service
+        mock_service.get.side_effect = [mock_prompt, None]
+
+        prompt = Prompt.get(id=mock_prompt.id)
+        assert prompt.is_synced()
+
+        # When/Then: refresh() raises ResourceNotFoundError and sets FAILED_SYNC
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            prompt.refresh()
+
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+        assert "id=" in str(exc_info.value)
+        assert prompt.sync_state == SyncState.FAILED_SYNC
 
 
 class TestPromptMethods:

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -6,6 +6,7 @@ from pydantic import UUID4
 
 from galileo.resources.models import HTTPValidationError
 from galileo.resources.models.stage_db import StageDB as APIStageDB
+from galileo.shared.exceptions import ResourceNotFoundError
 from galileo.stages import (
     create_protect_stage,
     get_protect_stage,
@@ -340,3 +341,42 @@ def test_stage_creation_with_project_name_and_project_id_env_var(mock_api: Mock,
         assert api_rule.operator.lower() == rule.operator.value.lower()
         assert api_rule.target_value == rule.target_value
     assert "rulesets" not in body.additional_properties
+
+
+@patch("galileo.stages.Projects")
+def test_get_validated_project_id_raises_resource_not_found(mock_projects_cls: Mock) -> None:
+    # Given: project lookup returns None (project does not exist)
+    mock_projects_cls.return_value.get_with_env_fallbacks.return_value = None
+
+    # When/Then: ResourceNotFoundError is raised with name in the message
+    with pytest.raises(ResourceNotFoundError) as exc_info:
+        get_protect_stage(project_name="nonexistent-project", stage_id=FIXED_STAGE_ID)
+
+    assert isinstance(exc_info.value, ResourceNotFoundError)
+    assert "name=" in str(exc_info.value)
+
+
+@patch("galileo.stages.get_stage_projects_project_id_stages_get.sync")
+def test_get_stage_by_name_raises_resource_not_found_when_stage_missing(mock_api: Mock) -> None:
+    # Given: the project is found (autouse fixture) but the API returns None for the stage
+    mock_api.return_value = None
+
+    # When/Then: ResourceNotFoundError is raised with name in the message
+    with pytest.raises(ResourceNotFoundError) as exc_info:
+        get_protect_stage(project_id=FIXED_PROJECT_ID, stage_name="missing-stage")
+
+    assert isinstance(exc_info.value, ResourceNotFoundError)
+    assert "name=" in str(exc_info.value)
+
+
+@patch("galileo.stages.get_stage_projects_project_id_stages_get.sync")
+def test_get_stage_by_id_raises_resource_not_found_when_stage_missing(mock_api: Mock) -> None:
+    # Given: the project is found (autouse fixture) but the API returns None for the stage
+    mock_api.return_value = None
+
+    # When/Then: ResourceNotFoundError is raised with id in the message
+    with pytest.raises(ResourceNotFoundError) as exc_info:
+        get_protect_stage(project_id=FIXED_PROJECT_ID, stage_id=FIXED_STAGE_ID)
+
+    assert isinstance(exc_info.value, ResourceNotFoundError)
+    assert "id=" in str(exc_info.value)

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -344,16 +344,31 @@ def test_stage_creation_with_project_name_and_project_id_env_var(mock_api: Mock,
 
 
 @patch("galileo.stages.Projects")
-def test_get_validated_project_id_raises_resource_not_found(mock_projects_cls: Mock) -> None:
-    # Given: project lookup returns None (project does not exist)
+def test_get_validated_project_id_raises_resource_not_found_by_name(mock_projects_cls: Mock) -> None:
+    # Given: project lookup by name returns None
     mock_projects_cls.return_value.get_with_env_fallbacks.return_value = None
 
-    # When/Then: ResourceNotFoundError is raised with name in the message
+    # When/Then: ResourceNotFoundError references the name, not id=None
     with pytest.raises(ResourceNotFoundError) as exc_info:
         get_protect_stage(project_name="nonexistent-project", stage_id=FIXED_STAGE_ID)
 
     assert isinstance(exc_info.value, ResourceNotFoundError)
     assert "name=" in str(exc_info.value)
+    assert "None" not in str(exc_info.value)
+
+
+@patch("galileo.stages.Projects")
+def test_get_validated_project_id_raises_resource_not_found_by_id(mock_projects_cls: Mock) -> None:
+    # Given: project lookup by id returns None
+    mock_projects_cls.return_value.get_with_env_fallbacks.return_value = None
+
+    # When/Then: ResourceNotFoundError references the id, not name=None
+    with pytest.raises(ResourceNotFoundError) as exc_info:
+        get_protect_stage(project_id=FIXED_PROJECT_ID, stage_id=FIXED_STAGE_ID)
+
+    assert isinstance(exc_info.value, ResourceNotFoundError)
+    assert "id=" in str(exc_info.value)
+    assert "name=" not in str(exc_info.value)
 
 
 @patch("galileo.stages.get_stage_projects_project_id_stages_get.sync")
@@ -380,3 +395,15 @@ def test_get_stage_by_id_raises_resource_not_found_when_stage_missing(mock_api: 
 
     assert isinstance(exc_info.value, ResourceNotFoundError)
     assert "id=" in str(exc_info.value)
+
+
+@patch("galileo.stages.get_stage_projects_project_id_stages_get.sync")
+def test_get_stage_raises_value_error_on_http_validation_error(mock_api: Mock) -> None:
+    # Given: the API returns an HTTPValidationError instead of a stage
+    validation_error = HTTPValidationError()
+    validation_error.detail = [{"msg": "invalid stage"}]
+    mock_api.return_value = validation_error
+
+    # When/Then: ValueError is raised rather than silently returning the error object
+    with pytest.raises(ValueError, match="Validation error looking up stage"):
+        get_protect_stage(project_id=FIXED_PROJECT_ID, stage_id=FIXED_STAGE_ID)


### PR DESCRIPTION
# User description
## Summary

Standardize not-found error handling across root-level domain objects. Every get-by-unique-key operation now raises `ResourceNotFoundError` with a uniform message format (`f"{Class} with {key}={value!r} not found"`) instead of returning `None` or raising `ValueError`/`APIError`.

Ticket: [sc-61954](https://app.shortcut.com/galileo/story/61954)

## Scope (4 tiers)

### Tier 1 — `.get()` classmethods now raise (breaking change)
`Project.get`, `Dataset.get`, `Experiment.get`, `LogStream.get`, `Prompt.get`, `Metric.get` previously returned `None` when the record was missing. They now raise `ResourceNotFoundError`. Return type annotations tightened from `X | None` to `X`. Docstrings updated.

> **Breaking change:** callers doing `if obj := Project.get(name="..."):` must now catch `ResourceNotFoundError` instead.

### Tier 2 — `refresh()` methods
`Project`, `Dataset`, `Experiment`, `LogStream`, `Prompt`, `Metric`, `Integration`, `Provider` `refresh()` methods now raise `ResourceNotFoundError` (previously `ValueError` or `APIError`). The surrounding `_set_state(FAILED_SYNC)` flow is preserved — a `refresh()` that discovers the remote object is gone still sets `FAILED_SYNC` before re-raising.

### Tier 3 — helpers and write methods
- `stages._get_validated_project_id` / `stages._get_stage_id`: `ValueError` → `ResourceNotFoundError`
- `Stages.get()`: added `None`-guard on generated-client passthrough
- `LogStream.set_metrics`: `ValueError` → `ResourceNotFoundError`

### Tier 4 — the "missed spot"
`Dataset.get_content()` was silently returning `None` when the backing dataset no longer existed, even though its siblings `get_versions()` and `get_version_content()` already raised. Now aligned.

### Also in scope
`job_progress.get_job`: `ValueError` → `ResourceNotFoundError` (ticket lists "jobs").

## Explicitly NOT in scope

- `Integration._get_integration_by_name` continues to return `UnconfiguredProvider` — this intentionally supports the `Integration.openai.create_openai(...)` fluent chain. A comment documents the design.
- A pre-existing `Dataset.refresh()` dirty-tracking bug (`self.id = ...` instead of `object.__setattr__`) is out of scope and left alone for a follow-up ticket.

## Test plan

- [x] 363 tests across 9 affected test files pass (`tests/test_{project,dataset,experiment,log_stream,prompt,metric,stages,integration,job_progress}.py`)
- [x] Every new raise path has a test using Given/When/Then structure
- [x] `refresh()` not-found tests assert both `ResourceNotFoundError` AND `FAILED_SYNC` state
- [x] `Metric.get()` three branches covered (empty-list by name, no-match by name, no-match by id)
- [x] New test added for `Dataset.get_content()` not-found path (Tier 4)
- [x] `ruff check`, `ruff format --check`, `mypy` — no new violations introduced
- [x] Pre-commit hooks pass

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enforce <code>ResourceNotFoundError</code> across domain getters such as <code>Project.get</code>, <code>Dataset.get</code>, <code>Experiment.get</code>, <code>LogStream.get</code>, <code>Prompt.get</code>, and <code>Metric.get</code> so missing records surface with a uniform “{Class} with {key}={value!r} not found” message instead of returning <code>None</code>. Document and test the new behavior while extending the same error handling to refresh flows, jobs, integrations, providers, and stage helpers so every single-record lookup guarantees the expected exception.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/560?tool=ast&topic=Helper+flows>Helper flows</a>
        </td><td>Align support helpers (integrations, providers, stages helpers) with the same not-found semantics and ensure tests exercise the new <code>ResourceNotFoundError</code> messages.<details><summary>Modified files (5)</summary><ul><li>src/galileo/integration.py</li>
<li>src/galileo/provider.py</li>
<li>src/galileo/stages.py</li>
<li>tests/test_integration.py</li>
<li>tests/test_stages.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>chore: Migrating remai...</td><td>March 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/560?tool=ast&topic=Getters+raising+errors>Getters raising errors</a>
        </td><td>Harden domain getters and refresh flows to raise <code>ResourceNotFoundError</code> for missing projects, datasets, experiments, log streams, prompts, metrics, and jobs while updating their sync states/tests to reflect the new contract.<details><summary>Modified files (14)</summary><ul><li>src/galileo/dataset.py</li>
<li>src/galileo/experiment.py</li>
<li>src/galileo/job_progress.py</li>
<li>src/galileo/log_stream.py</li>
<li>src/galileo/metric.py</li>
<li>src/galileo/project.py</li>
<li>src/galileo/prompt.py</li>
<li>tests/test_dataset.py</li>
<li>tests/test_experiment.py</li>
<li>tests/test_job_progress.py</li>
<li>tests/test_log_stream.py</li>
<li>tests/test_metric.py</li>
<li>tests/test_project.py</li>
<li>tests/test_prompt.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix(dataset): extend n...</td><td>April 17, 2026</td></tr>
<tr><td>vamaq@users.noreply.gi...</td><td>fix: Define explicit e...</td><td>February 03, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/560?tool=ast>(Baz)</a>.