### PR TITLE
fix(log_stream): convert ProjectsAPIException to ResourceNotFoundError in get/list

### DIFF
--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -10,7 +10,7 @@ from galileo.config import GalileoPythonConfig
 from galileo.decorator import galileo_context
 from galileo.export import ExportClient
 from galileo.log_streams import LogStreams
-from galileo.projects import Projects
+from galileo.projects import Projects, ProjectsAPIException
 from galileo.resources.api.trace import (
     sessions_available_columns_projects_project_id_sessions_available_columns_post,
     spans_available_columns_projects_project_id_spans_available_columns_post,
@@ -285,7 +285,10 @@ class LogStream(StateManagementMixin):
             log_stream = LogStream.get(name="Production Logs")
         """
         # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-        project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        try:
+            project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        except ProjectsAPIException:
+            project_obj = None
         if not project_obj:
             raise ResourceNotFoundError(
                 "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
@@ -332,7 +335,10 @@ class LogStream(StateManagementMixin):
             log_streams = LogStream.list()
         """
         # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-        project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        try:
+            project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        except ProjectsAPIException:
+            project_obj = None
         if not project_obj:
             raise ResourceNotFoundError(
                 "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."

--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -10,7 +10,8 @@ from galileo.config import GalileoPythonConfig
 from galileo.decorator import galileo_context
 from galileo.export import ExportClient
 from galileo.log_streams import LogStreams
-from galileo.projects import Projects, ProjectsAPIException
+from galileo.projects import Project as ProjectRecord
+from galileo.projects import ProjectNotFoundError, Projects
 from galileo.resources.api.trace import (
     sessions_available_columns_projects_project_id_sessions_available_columns_post,
     spans_available_columns_projects_project_id_spans_available_columns_post,
@@ -38,6 +39,19 @@ RECORD_TYPE_TO_ROOT_TYPE = {
     RecordType.TRACE: RootType.TRACE,
     RecordType.SESSION: RootType.SESSION,
 }
+
+
+def _resolve_project(project_id: str | None, project_name: str | None) -> ProjectRecord:
+    """Resolve a project from explicit params or env fallbacks, raising ResourceNotFoundError on 404."""
+    try:
+        project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+    except ProjectNotFoundError:
+        project_obj = None
+    if not project_obj:
+        raise ResourceNotFoundError(
+            "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
+        )
+    return project_obj
 
 
 class LogStream(StateManagementMixin):
@@ -284,15 +298,7 @@ class LogStream(StateManagementMixin):
             # Get using GALILEO_PROJECT environment variable
             log_stream = LogStream.get(name="Production Logs")
         """
-        # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-        try:
-            project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
-        except ProjectsAPIException:
-            project_obj = None
-        if not project_obj:
-            raise ResourceNotFoundError(
-                "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
-            )
+        project_obj = _resolve_project(project_id, project_name)
 
         log_streams_service = LogStreams()
         retrieved_log_stream = log_streams_service.get(name=name, project_id=project_obj.id)
@@ -334,15 +340,7 @@ class LogStream(StateManagementMixin):
             # List using GALILEO_PROJECT environment variable
             log_streams = LogStream.list()
         """
-        # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-        try:
-            project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
-        except ProjectsAPIException:
-            project_obj = None
-        if not project_obj:
-            raise ResourceNotFoundError(
-                "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
-            )
+        project_obj = _resolve_project(project_id, project_name)
 
         log_streams_service = LogStreams()
         retrieved_log_streams = log_streams_service.list(project_id=project_obj.id)

--- a/src/galileo/projects.py
+++ b/src/galileo/projects.py
@@ -40,6 +40,10 @@ class ProjectsAPIException(APIException):
     pass
 
 
+class ProjectNotFoundError(ProjectsAPIException):
+    pass
+
+
 class Project:
     """
     Represents a project in the Galileo platform.
@@ -235,6 +239,8 @@ class Projects:
             detailed_response = get_project_projects_project_id_get.sync_detailed(
                 project_id=id, client=self.config.api_client
             )
+            if detailed_response.status_code == httpx.codes.NOT_FOUND:
+                raise ProjectNotFoundError(detailed_response.content)
             if detailed_response.status_code != httpx.codes.OK:
                 raise ProjectsAPIException(detailed_response.content)
 

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import pytest
 
 from galileo.log_stream import LogStream
-from galileo.projects import ProjectsAPIException
+from galileo.projects import ProjectNotFoundError, ProjectsAPIException
 from galileo.resources.models import LLMExportFormat, LogRecordsSortClause, RootType
 from galileo.search import RecordType
 from galileo.shared.base import SyncState
@@ -280,15 +280,29 @@ class TestLogStreamGet:
     def test_get_raises_resource_not_found_when_project_id_unknown(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test get() raises ResourceNotFoundError when project_id lookup raises ProjectsAPIException."""
-        # Given: the projects service raises ProjectsAPIException for an unknown project_id
+        """Test get() raises ResourceNotFoundError when project_id lookup raises ProjectNotFoundError (HTTP 404)."""
+        # Given: the projects service raises ProjectNotFoundError (HTTP 404) for an unknown project_id
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
-        mock_projects_service.get_with_env_fallbacks.side_effect = ProjectsAPIException("not found")
+        mock_projects_service.get_with_env_fallbacks.side_effect = ProjectNotFoundError("not found")
 
         # When/Then: calling get with an unknown project_id raises ResourceNotFoundError
         with pytest.raises(ResourceNotFoundError, match="Project not found"):
             LogStream.get(name="Test Stream", project_id="unknown-id")
+
+    @patch("galileo.log_stream.Projects")
+    def test_get_reraises_non_404_projects_api_exception(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        """Test get() re-raises ProjectsAPIException that is not a 404 (e.g. auth/server error)."""
+        # Given: the projects service raises a generic ProjectsAPIException (e.g. HTTP 403)
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.side_effect = ProjectsAPIException("forbidden")
+
+        # When/Then: non-404 errors propagate unchanged so callers receive the correct exception
+        with pytest.raises(ProjectsAPIException):
+            LogStream.get(name="Test Stream", project_id="some-id")
 
     @patch("galileo.log_stream.LogStreams")
     @patch("galileo.log_stream.Projects")
@@ -416,15 +430,29 @@ class TestLogStreamList:
     def test_list_raises_resource_not_found_when_project_id_unknown(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test list() raises ResourceNotFoundError when project_id lookup raises ProjectsAPIException."""
-        # Given: the projects service raises ProjectsAPIException for an unknown project_id
+        """Test list() raises ResourceNotFoundError when project_id lookup raises ProjectNotFoundError (HTTP 404)."""
+        # Given: the projects service raises ProjectNotFoundError (HTTP 404) for an unknown project_id
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
-        mock_projects_service.get_with_env_fallbacks.side_effect = ProjectsAPIException("not found")
+        mock_projects_service.get_with_env_fallbacks.side_effect = ProjectNotFoundError("not found")
 
         # When/Then: calling list with an unknown project_id raises ResourceNotFoundError
         with pytest.raises(ResourceNotFoundError, match="Project not found"):
             LogStream.list(project_id="unknown-id")
+
+    @patch("galileo.log_stream.Projects")
+    def test_list_reraises_non_404_projects_api_exception(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        """Test list() re-raises ProjectsAPIException that is not a 404 (e.g. auth/server error)."""
+        # Given: the projects service raises a generic ProjectsAPIException (e.g. HTTP 403)
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.side_effect = ProjectsAPIException("forbidden")
+
+        # When/Then: non-404 errors propagate unchanged so callers receive the correct exception
+        with pytest.raises(ProjectsAPIException):
+            LogStream.list(project_id="some-id")
 
     @patch("galileo.log_stream.LogStreams")
     @patch("galileo.log_stream.Projects")

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import pytest
 
 from galileo.log_stream import LogStream
+from galileo.projects import ProjectsAPIException
 from galileo.resources.models import LLMExportFormat, LogRecordsSortClause, RootType
 from galileo.search import RecordType
 from galileo.shared.base import SyncState
@@ -275,6 +276,20 @@ class TestLogStreamGet:
         with pytest.raises(ResourceNotFoundError, match="Project not found"):
             LogStream.get(name="Test Stream")
 
+    @patch("galileo.log_stream.Projects")
+    def test_get_raises_resource_not_found_when_project_id_unknown(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        """Test get() raises ResourceNotFoundError when project_id lookup raises ProjectsAPIException."""
+        # Given: the projects service raises ProjectsAPIException for an unknown project_id
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.side_effect = ProjectsAPIException("not found")
+
+        # When/Then: calling get with an unknown project_id raises ResourceNotFoundError
+        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+            LogStream.get(name="Test Stream", project_id="unknown-id")
+
     @patch("galileo.log_stream.LogStreams")
     @patch("galileo.log_stream.Projects")
     def test_get_uses_env_fallback_when_no_project_specified(
@@ -396,6 +411,20 @@ class TestLogStreamList:
         # When/Then: Calling list raises ResourceNotFoundError
         with pytest.raises(ResourceNotFoundError, match="Project not found"):
             LogStream.list()
+
+    @patch("galileo.log_stream.Projects")
+    def test_list_raises_resource_not_found_when_project_id_unknown(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        """Test list() raises ResourceNotFoundError when project_id lookup raises ProjectsAPIException."""
+        # Given: the projects service raises ProjectsAPIException for an unknown project_id
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.side_effect = ProjectsAPIException("not found")
+
+        # When/Then: calling list with an unknown project_id raises ResourceNotFoundError
+        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+            LogStream.list(project_id="unknown-id")
 
     @patch("galileo.log_stream.LogStreams")
     @patch("galileo.log_stream.Projects")


### PR DESCRIPTION
# User description
**Shortcut:** 

[sc-61783](https://app.shortcut.com/galileo/story/61783)

**Description:**
`LogStream.get()` and `LogStream.list()` both resolve the project via `Projects().get_with_env_fallbacks()`. When a `project_name` is given for a non-existent project, the service returns `None` — which is caught by the `if not project_obj` guard and converted to `ResourceNotFoundError`. However, when a `project_id` is given for a non-existent project, the service raises `ProjectsAPIException` (HTTP 404 propagated from the generated client), which escapes uncaught and surfaces as a different, unexpected exception type to the caller.

Fix: wrap `get_with_env_fallbacks()` in both classmethods with `try/except ProjectsAPIException` and set `project_obj = None` on catch, so the existing `ResourceNotFoundError` guard fires consistently regardless of which lookup path is taken.

**Tests:**
- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Normalize project resolution in <code>LogStream</code> by wrapping <code>Projects().get_with_env_fallbacks</code> to catch <code>ProjectsAPIException</code> and raise <code>ResourceNotFoundError</code> when lookups 404, preventing inconsistent exceptions described in the QA ticket. Update <code>Projects.get</code> so that HTTP 404 responses throw a <code>ProjectNotFoundError</code>, ensuring the centralized helper can distinguish missing projects from other failures.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/561?tool=ast&topic=Lookup+tests>Lookup tests</a>
        </td><td>Add tests covering <code>LogStream.get</code>/<code>list</code> to assert 404 lookups raise <code>ResourceNotFoundError</code> while other <code>ProjectsAPIException</code>s propagate unchanged.<details><summary>Modified files (1)</summary><ul><li>tests/test_log_stream.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>refactor: Move tests f...</td><td>April 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/561?tool=ast&topic=Project+lookup>Project lookup</a>
        </td><td>Wrap <code>_resolve_project</code> around <code>LogStream.get</code>/<code>list</code> so that catching <code>ProjectNotFoundError</code> from the new 404-aware <code>Projects.get</code> remaps missing projects to <code>ResourceNotFoundError</code>, preserving consistent errors when callers pass <code>project_id</code> or env fallbacks.<details><summary>Modified files (2)</summary><ul><li>src/galileo/log_stream.py</li>
<li>src/galileo/projects.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>chore: Migrating remai...</td><td>March 26, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/561?tool=ast>(Baz)</a>.