### PR TITLE
fix(experiment): make prompt optional in Experiment.__init__

### DIFF
--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -142,6 +142,20 @@ class Experiment(StateManagementMixin):
             project_name="My AI Project"
         )
         experiment.create()
+
+        # Check results after the run completes
+        experiment.refresh()
+        metrics = experiment.aggregate_metrics
+        print(f"Average correctness: {metrics['average_correctness']}")
+
+        # Re-run with a different name
+        experiment2 = Experiment(
+            name=f"{experiment.name}-rerun-1",
+            dataset_name=experiment.dataset_name,
+            prompt_name=experiment.prompt_name,
+            metrics=experiment.metrics,
+            project_name=experiment.project_name,
+        ).create()
     """
 
     id: str | None
@@ -321,6 +335,11 @@ class Experiment(StateManagementMixin):
 
         # TODO: Delegate the responsibilities to the serializer.
         if prompt is not None:
+            if prompt_name is not None:
+                _logger.warning(
+                    "Experiment.__init__: both 'prompt' and 'prompt_name' were provided; "
+                    "'prompt' takes precedence and 'prompt_name' will be ignored."
+                )
             # Local import to avoid circular dependency
             from galileo.prompt import Prompt
 

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -124,7 +124,7 @@ class Experiment(StateManagementMixin):
 
     Examples
     --------
-        # Create an experiment
+        # Prompt-based experiment
         experiment = Experiment(
             name="ml-expert-evaluation",
             dataset_name="ml-knowledge-dataset",
@@ -132,25 +132,16 @@ class Experiment(StateManagementMixin):
             metrics=["correctness", "completeness"],
             project_name="My AI Project"
         )
-
-        # Create and run
         experiment.create()
-        result = experiment.run()
 
-        # Check results
-        experiment.refresh()
-        metrics = experiment.aggregate_metrics
-        print(f"Average cost: ${metrics['average_cost']}")
-
-        # Re-run with different name
-        experiment2 = Experiment(
-            name=f"{experiment.name}-rerun-1",
-            dataset_name=experiment.dataset_name,
-            prompt_name=experiment.prompt_name,
-            metrics=experiment.metrics,
-            project_name=experiment.project_name
-        ).create()
-        experiment2.run()
+        # Function-based / generated-output experiment (no prompt required)
+        experiment = Experiment(
+            name="otel-trace-eval",
+            dataset_name="trace-dataset",
+            metrics=["correctness"],
+            project_name="My AI Project"
+        )
+        experiment.create()
     """
 
     id: str | None
@@ -188,7 +179,6 @@ class Experiment(StateManagementMixin):
             f"created_at='{self.created_at}')"
         )
 
-    @require_exactly_one("prompt", "prompt_name")  # TODO: For function-based experiments, prompt is optional.
     def __init__(
         self,
         name: str,
@@ -201,8 +191,6 @@ class Experiment(StateManagementMixin):
         metrics: builtins.list[GalileoMetrics | Metric | LocalMetricConfig | str] | None = None,
         project_id: str | None = None,
         project_name: str | None = None,
-        # TODO: Function-based experiments are temporarily disabled. Need to validate implementation and fix decorator logic.
-        # function: Callable | None = None,
         prompt_settings: PromptRunSettings | None = None,
     ) -> None:
         """
@@ -217,8 +205,9 @@ class Experiment(StateManagementMixin):
                     but required when running the experiment with a prompt template.
             dataset_name: Name of the dataset (alternative to dataset parameter). Optional at creation,
                          but required when running the experiment with a prompt template.
-            prompt: Prompt object, prompt name, or legacy PromptTemplate object.
-            prompt_name: Name of the prompt template (alternative to prompt parameter).
+            prompt: Prompt object, prompt name, or legacy PromptTemplate object. Optional — omit
+                   for function-based or generated-output experiments that don't use a prompt template.
+            prompt_name: Name of the prompt template (alternative to prompt parameter). Optional.
             model: Model object or model alias string to use for the experiment.
                   This will be used to configure the prompt_settings when running the experiment.
             metrics: List of metrics to evaluate.
@@ -236,11 +225,19 @@ class Experiment(StateManagementMixin):
 
         Examples
         --------
-            # Create by project name with dataset and prompt names
+            # Create a prompt-based experiment
             experiment = Experiment(
                 name="ml-evaluation",
                 dataset_name="ml-dataset",
                 prompt_name="ml-prompt",
+                project_name="My AI Project"
+            )
+
+            # Create a function-based experiment (no prompt required)
+            experiment = Experiment(
+                name="otel-trace-eval",
+                dataset_name="trace-dataset",
+                metrics=["correctness"],
                 project_name="My AI Project"
             )
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -168,6 +169,30 @@ class TestExperimentInitialization:
         assert experiment.prompt_name is None
         assert experiment.dataset_name is None
         assert experiment.sync_state == SyncState.LOCAL_ONLY
+
+    def test_init_with_both_prompt_and_prompt_name_warns_and_prompt_wins(
+        self, reset_configuration: None, caplog: pytest.LogCaptureFixture, enable_galileo_logging: None
+    ) -> None:
+        """Test that providing both 'prompt' and 'prompt_name' logs a warning and 'prompt' takes precedence."""
+        # Given: both prompt and prompt_name provided
+        # When: creating an experiment while capturing warnings on the experiment logger
+        with caplog.at_level(logging.WARNING, logger="galileo.experiment"):
+            experiment = Experiment(
+                name="Test Experiment",
+                dataset_name="test-dataset",
+                prompt="winning-prompt",
+                prompt_name="losing-prompt",
+                project_name="Test Project",
+            )
+
+        # Then: a warning is logged and 'prompt' takes precedence over 'prompt_name'
+        assert any(
+            record.levelno == logging.WARNING
+            and "both 'prompt' and 'prompt_name' were provided" in record.message
+            and "'prompt' takes precedence" in record.message
+            for record in caplog.records
+        )
+        assert experiment.prompt_name == "winning-prompt"
 
 
 class TestExperimentEnvFallback:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -146,6 +146,29 @@ class TestExperimentInitialization:
         assert experiment.project_id == "test-id"
         assert experiment.project_name == "Test Project"
 
+    def test_init_without_prompt_succeeds(self, reset_configuration: None) -> None:
+        """Test that prompt is optional — omitting it creates a valid LOCAL_ONLY experiment."""
+        # Given: no prompt or prompt_name provided (function-based / generated-output flow)
+        # When: creating an experiment
+        experiment = Experiment(name="otel-trace-eval", dataset_name="trace-dataset", project_name="My AI Project")
+
+        # Then: experiment is created with no prompt fields set
+        assert experiment.prompt_name is None
+        assert experiment.prompt_id is None
+        assert experiment._prompt_template is None
+        assert experiment.sync_state == SyncState.LOCAL_ONLY
+
+    def test_init_without_prompt_or_dataset_succeeds(self, reset_configuration: None) -> None:
+        """Test that a bare experiment with only a name and project is valid locally."""
+        # Given: only name and project provided
+        # When: creating an experiment
+        experiment = Experiment(name="metadata-only", project_name="My Project")
+
+        # Then: experiment is created with no prompt or dataset
+        assert experiment.prompt_name is None
+        assert experiment.dataset_name is None
+        assert experiment.sync_state == SyncState.LOCAL_ONLY
+
 
 class TestExperimentEnvFallback:
     """Test suite for Experiment environment variable fallback behavior."""
@@ -205,6 +228,46 @@ class TestExperimentEnvFallback:
         experiment = Experiment(name="Test Experiment", dataset_name="test-dataset", prompt_name="test-prompt")
         with pytest.raises(ResourceNotFoundError, match="Project not found"):
             experiment.create()
+
+    @patch("galileo.experiment.create_metric_configs")
+    @patch("galileo.experiment.load_dataset_and_records")
+    @patch("galileo.experiment.Projects")
+    @patch("galileo.experiment.ExperimentsService")
+    def test_create_without_prompt_succeeds(
+        self,
+        mock_experiments_class: MagicMock,
+        mock_projects_class: MagicMock,
+        mock_load_dataset: MagicMock,
+        mock_create_metrics: MagicMock,
+        reset_configuration: None,
+        mock_experiment_response: MagicMock,
+        mock_project: MagicMock,
+    ) -> None:
+        """Test create() succeeds when no prompt is provided (function-based / generated-output flow)."""
+        # Given: a project and dataset but no prompt
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.return_value = mock_project
+
+        mock_dataset = MagicMock()
+        mock_load_dataset.return_value = (mock_dataset, [])
+        mock_create_metrics.return_value = (None, [])
+
+        mock_experiments_service = MagicMock()
+        mock_experiments_class.return_value = mock_experiments_service
+        mock_experiments_service.get.side_effect = NotFoundError(404, b"Not Found")
+        mock_experiments_service.create.return_value = mock_experiment_response
+
+        # When: creating experiment without any prompt parameter
+        experiment = Experiment(
+            name="otel-trace-eval", dataset_name="trace-dataset", project_name="My AI Project"
+        ).create()
+
+        # Then: experiment is created and synced, no prompt_template passed to service
+        assert experiment.is_synced()
+        assert experiment.project_id == mock_project.id
+        _, kwargs = mock_experiments_service.create.call_args
+        assert kwargs.get("prompt_template") is None
 
     @patch("galileo.experiment.Projects")
     @patch("galileo.experiment.ExperimentsService")

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -263,11 +263,12 @@ class TestExperimentEnvFallback:
             name="otel-trace-eval", dataset_name="trace-dataset", project_name="My AI Project"
         ).create()
 
-        # Then: experiment is created and synced, no prompt_template passed to service
+        # Then: experiment is created and synced, no prompt_template or prompt_settings passed to service
         assert experiment.is_synced()
         assert experiment.project_id == mock_project.id
         _, kwargs = mock_experiments_service.create.call_args
         assert kwargs.get("prompt_template") is None
+        assert kwargs.get("prompt_settings") is None
 
     @patch("galileo.experiment.Projects")
     @patch("galileo.experiment.ExperimentsService")


### PR DESCRIPTION
# User description
**Shortcut:** 
[SC-62412](https://app.shortcut.com/galileo/story/62412)

**Description:**

`Experiment.__init__` was decorated with `@require_exactly_one("prompt", "prompt_name")`, which forced every caller to supply a prompt template — even for function-based or generated-output flows where the API doesn't require one.

This blocked use cases like OTel→traces→experiments (Verizon's flow) where an experiment shell is created without any prompt template.

The fix removes the `@require_exactly_one` decorator so that `Experiment` follows the same validation rules as the legacy `create_experiment()` function: prompt is optional, and `create()` already handles `prompt_template=None` correctly by passing it through to the service as-is.

Changes:
- Remove `@require_exactly_one("prompt", "prompt_name")` from `Experiment.__init__`
- Update docstring: mark `prompt` / `prompt_name` as optional; add a prompt-free example in both the class docstring and `__init__` docstring
- Add `test_init_without_prompt_succeeds`, `test_init_without_prompt_or_dataset_succeeds`, and `test_create_without_prompt_succeeds` to cover the new code path

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Allow Experiment initialization to omit a prompt template by removing the strict decorator, aligning <code>Experiment.__init__</code> with the legacy <code>create_experiment()</code> validation so function-driven flows work without a prompt. Update docstrings to highlight when prompts are optional and add tests that create prompt-free experiments to prove <code>create()</code> and initialization paths support the new behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/563?tool=ast&topic=Prompt+optionality>Prompt optionality</a>
        </td><td>Allow Experiment initialization to accept prompt-free configurations by removing the decorator, clarifying docstrings, and warning when both prompt inputs are supplied so shell experiments match the legacy validation.<details><summary>Modified files (1)</summary><ul><li>src/galileo/experiment.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix(experiment): prese...</td><td>April 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/563?tool=ast&topic=Test+coverage>Test coverage</a>
        </td><td>Add unit tests covering prompt-free initialization and creation so <code>Experiment.create()</code> behaves like the legacy flow when no prompt is provided.<details><summary>Modified files (1)</summary><ul><li>tests/test_experiment.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix(experiment): prese...</td><td>April 14, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/563?tool=ast>(Baz)</a>.