### PR TITLE
fix(logger): add list[dict] to start_trace input docs

### DIFF
--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -959,8 +959,8 @@ class GalileoLogger(TracesLogger):
     @warn_catch_exception()
     def start_trace(
         self,
-        input: TextOrContentBlocks | dict,
-        redacted_input: TextOrContentBlocks | dict | None = None,
+        input: TextOrContentBlocks | dict | list[dict[str, Any]],
+        redacted_input: TextOrContentBlocks | dict | list[dict[str, Any]] | None = None,
         name: str | None = None,
         duration_ns: int | None = None,
         created_at: datetime | None = None,
@@ -977,15 +977,17 @@ class GalileoLogger(TracesLogger):
 
         Parameters
         ----------
-        input: TextOrContentBlocks | dict
+        input: TextOrContentBlocks | dict | list[dict[str, Any]]
             Input to the node.
-            Expected format: String, dict (auto-converted to JSON),
-            or list of IngestContentBlock objects for multimodal content.
+            Accepted formats: string, dict (auto-converted to JSON string),
+            list of dicts (auto-converted to JSON string),
+            or list of content block objects for multimodal content.
             Examples -
-                - String: "User query: What is the weather today?"
+                - String: `"User query: What is the weather today?"`
                 - Dict: `{"query": "hello", "context": "world"}` (auto-converted to JSON string)
+                - List of dicts: `[{"role": "user", "content": "hello"}]` (auto-converted to JSON string)
                 - Content blocks: `[TextContentBlock(text="Analyze"), DataContentBlock(...)]`
-        redacted_input: Optional[TextOrContentBlocks | dict]
+        redacted_input: Optional[TextOrContentBlocks | dict | list[dict[str, Any]]]
             Input that removes any sensitive information (redacted input).
             Same format as input parameter.
         name: Optional[str]


### PR DESCRIPTION
# User description
## Summary

- Updated `start_trace()` type hints to include `list[dict[str, Any]]` for `input` and `redacted_input` parameters
- Updated the docstring to document all four accepted input formats: string, dict, list of dicts, and list of content blocks
- Added an example for the `list[dict]` format

The `_coerce_trace_input` method already handles `list[dict]` (serializes to JSON string), but neither the type annotation nor the docstring documented this. Since reference docs are auto-generated from docstrings, the published docs were incomplete — which is what was flagged in the ticket re-open.

## Test plan

- [x] Existing tests pass (`tests/test_logger_batch.py` — 86 passed)
- [x] No new mypy errors introduced
- [x] No new ruff lint issues
- [ ] Verify auto-generated docs render correctly on next release

[sc-54367]

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify <code>GalileoLogger.start_trace</code> type annotations and docstring so generated docs list all accepted input formats, aligning documentation with the implementation. Document the list-of-dict example to highlight JSON-serializable inputs.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix: Python SDK tests ...</td><td>April 14, 2026</td></tr>
<tr><td>david@rungalileo.io</td><td>fix: Add session start...</td><td>April 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/565?tool=ast>(Baz)</a>.