### PR TITLE
fix(errors): context-aware project-not-found error messages

### DIFF
--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -13,7 +13,7 @@ from galileo.experiments import Experiments as ExperimentsService
 from galileo.experiments import _default_prompt_settings
 from galileo.export import ExportClient
 from galileo.job_progress import get_run_scorer_jobs, job_progress
-from galileo.projects import Projects
+from galileo.projects import ProjectNotFoundError, Projects
 from galileo.prompts import PromptTemplate, get_prompt
 from galileo.resources.api.experiment import (
     delete_experiment_projects_project_id_experiments_experiment_id_delete,
@@ -43,7 +43,7 @@ from galileo.schema.filters import FilterType
 from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig, Metric
 from galileo.search import RecordType, Search
 from galileo.shared.base import StateManagementMixin, SyncState
-from galileo.shared.exceptions import ResourceNotFoundError, ValidationError
+from galileo.shared.exceptions import ValidationError, _project_not_found_error
 from galileo.shared.experiment_result import ExperimentRunResult, ExperimentStatusInfo
 from galileo.shared.query_result import QueryResult
 
@@ -384,11 +384,12 @@ class Experiment(StateManagementMixin):
             _logger.info(f"Experiment.create: name='{self.name}' project_id='{self.project_id}' - started")
 
             # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-            project_obj = Projects().get_with_env_fallbacks(id=self.project_id, name=self.project_name)
+            try:
+                project_obj = Projects().get_with_env_fallbacks(id=self.project_id, name=self.project_name)
+            except ProjectNotFoundError:
+                project_obj = None
             if not project_obj:
-                raise ResourceNotFoundError(
-                    "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
-                )
+                raise _project_not_found_error(self.project_id, self.project_name)
 
             self.project_id = project_obj.id
             if self.project_name is None:
@@ -652,11 +653,12 @@ class Experiment(StateManagementMixin):
             experiment = Experiment.get(name="ml-evaluation")
         """
         # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-        project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        try:
+            project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        except ProjectNotFoundError:
+            project_obj = None
         if not project_obj:
-            raise ResourceNotFoundError(
-                "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
-            )
+            raise _project_not_found_error(project_id, project_name)
 
         experiments_service = ExperimentsService()
         retrieved_experiment = experiments_service.get(project_id=project_obj.id, experiment_name=name)
@@ -700,11 +702,12 @@ class Experiment(StateManagementMixin):
             experiments = Experiment.list()
         """
         # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-        project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        try:
+            project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        except ProjectNotFoundError:
+            project_obj = None
         if not project_obj:
-            raise ResourceNotFoundError(
-                "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
-            )
+            raise _project_not_found_error(project_id, project_name)
 
         experiments_service = ExperimentsService()
         retrieved_experiments = experiments_service.list(project_id=project_obj.id)

--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -25,7 +25,7 @@ from galileo.schema.filters import FilterType
 from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig, Metric
 from galileo.search import RecordType, Search
 from galileo.shared.base import StateManagementMixin, SyncState
-from galileo.shared.exceptions import ResourceNotFoundError, ValidationError
+from galileo.shared.exceptions import ValidationError, _project_not_found_error
 from galileo.shared.query_result import QueryResult
 
 if TYPE_CHECKING:
@@ -48,9 +48,7 @@ def _resolve_project(project_id: str | None, project_name: str | None) -> Projec
     except ProjectNotFoundError:
         project_obj = None
     if not project_obj:
-        raise ResourceNotFoundError(
-            "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
-        )
+        raise _project_not_found_error(project_id, project_name)
     return project_obj
 
 
@@ -192,11 +190,12 @@ class LogStream(StateManagementMixin):
             logger.info(f"LogStream.create: name='{self.name}' project_id='{self.project_id}' - started")
 
             # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-            project_obj = Projects().get_with_env_fallbacks(id=self.project_id, name=self.project_name)
+            try:
+                project_obj = Projects().get_with_env_fallbacks(id=self.project_id, name=self.project_name)
+            except ProjectNotFoundError:
+                project_obj = None
             if not project_obj:
-                raise ResourceNotFoundError(
-                    "Project not found. Provide project_id, project_name, or set GALILEO_PROJECT env var."
-                )
+                raise _project_not_found_error(self.project_id, self.project_name)
 
             # Update project info from resolved project
             self.project_id = project_obj.id

--- a/src/galileo/shared/exceptions.py
+++ b/src/galileo/shared/exceptions.py
@@ -1,5 +1,7 @@
 from typing import ClassVar
 
+from galileo.utils.env_helpers import _get_project_from_env, _get_project_id_from_env
+
 
 class GalileoFutureError(Exception):
     """
@@ -96,3 +98,27 @@ class IntegrationNotConfiguredError(GalileoFutureError):
             message = f"No '{integration_name}' integration configured.\nConfigure it in the Galileo console."
         super().__init__(message)
         self.integration_name = integration_name
+
+
+def _project_not_found_error(project_id: str | None, project_name: str | None) -> "ResourceNotFoundError":
+    """Return a context-aware ResourceNotFoundError for a missing project.
+
+    Distinguishes between "a name/id was given but the project doesn't exist" (actionable: create it)
+    and "no identifier was specified at all" (actionable: provide one).
+    Falls back to env vars so the message is accurate even when the identifier came from the environment.
+    """
+    effective_id = project_id or _get_project_id_from_env()
+    effective_name = project_name or (None if effective_id else _get_project_from_env())
+    if effective_name:
+        return ResourceNotFoundError(
+            f'Project "{effective_name}" not found. '
+            f'Use Project(name="{effective_name}").create() or the Galileo UI to create it first.'
+        )
+    if effective_id:
+        return ResourceNotFoundError(
+            f'Project with id "{effective_id}" not found. '
+            "Use Project(name=...).create() or the Galileo UI to create a project first."
+        )
+    return ResourceNotFoundError(
+        "No project specified. Provide project_id, project_name, or set GALILEO_PROJECT env var."
+    )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -192,18 +192,38 @@ class TestExperimentEnvFallback:
         assert experiment.is_synced()
 
     @patch("galileo.experiment.Projects")
-    def test_create_raises_error_when_no_project_and_no_env_fallback(
+    def test_create_raises_named_error_when_project_name_not_found(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test create() raises ValueError when no project and no env fallback."""
-        # Given: env fallback returns None (no project found)
+        """Test create() names the missing project when project_name is provided but not found."""
+        # Given: project_name is provided but the server returns no matching project
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
 
-        # When/Then: creating experiment raises ResourceNotFoundError with helpful message
+        # When/Then: error names the project the user specified, not generic guidance
+        experiment = Experiment(
+            name="Test Experiment",
+            dataset_name="test-dataset",
+            prompt_name="test-prompt",
+            project_name="my-nonexistent-project",
+        )
+        with pytest.raises(ResourceNotFoundError, match=r'Project "my-nonexistent-project" not found'):
+            experiment.create()
+
+    @patch("galileo.experiment.Projects")
+    def test_create_raises_error_when_no_project_and_no_env_fallback(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        """Test create() raises ResourceNotFoundError naming the project that wasn't found."""
+        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.return_value = None
+
+        # When/Then: creating experiment raises ResourceNotFoundError with guidance to provide a project identifier
         experiment = Experiment(name="Test Experiment", dataset_name="test-dataset", prompt_name="test-prompt")
-        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+        with pytest.raises(ResourceNotFoundError, match="No project specified"):
             experiment.create()
 
     @patch("galileo.experiment.Projects")
@@ -237,14 +257,14 @@ class TestExperimentEnvFallback:
     def test_get_raises_error_when_no_project_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test get() raises ValueError when no project and no env fallback."""
-        # Given: env fallback returns None (no project found)
+        """Test get() raises ResourceNotFoundError naming the project that wasn't found."""
+        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
 
-        # When/Then: calling get() raises ResourceNotFoundError with helpful message
-        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+        # When/Then: calling get() raises ResourceNotFoundError with guidance to provide a project identifier
+        with pytest.raises(ResourceNotFoundError, match="No project specified"):
             Experiment.get(name="Test Experiment")
 
     @patch("galileo.experiment.Projects")
@@ -277,14 +297,14 @@ class TestExperimentEnvFallback:
     def test_list_raises_error_when_no_project_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test list() raises ValueError when no project and no env fallback."""
-        # Given: env fallback returns None (no project found)
+        """Test list() raises ResourceNotFoundError naming the project that wasn't found."""
+        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
 
-        # When/Then: calling list() raises ResourceNotFoundError with helpful message
-        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+        # When/Then: calling list() raises ResourceNotFoundError with guidance to provide a project identifier
+        with pytest.raises(ResourceNotFoundError, match="No project specified"):
             Experiment.list()
 
 

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -152,11 +152,28 @@ class TestLogStreamCreate:
         assert log_stream.sync_state == SyncState.FAILED_SYNC
 
     @patch("galileo.log_stream.Projects")
+    def test_create_names_project_in_error_when_project_name_not_found(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        """Test create() names the missing project when project_name is provided but not found."""
+        # Given: project_name is provided but the server returns no matching project
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.return_value = None
+
+        # When: creating a log stream with a project_name that doesn't exist on the server
+        log_stream = LogStream(name="Test Stream", project_name="my-nonexistent-project")
+
+        # Then: error names the project the user specified, not generic guidance
+        with pytest.raises(ResourceNotFoundError, match=r'Project "my-nonexistent-project" not found'):
+            log_stream.create()
+
+    @patch("galileo.log_stream.Projects")
     def test_create_without_project_info_raises_error(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test create() raises ValueError when project information is missing and no env fallback."""
-        # Given: env fallback returns None (no project found)
+        """Test create() raises ResourceNotFoundError naming the project that wasn't found."""
+        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
@@ -168,8 +185,8 @@ class TestLogStreamCreate:
         log_stream.project_name = None
         log_stream._set_state(SyncState.LOCAL_ONLY)
 
-        # When/Then: Create() raises ResourceNotFoundError with helpful message
-        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+        # When/Then: Create() raises ResourceNotFoundError with guidance to provide a project identifier
+        with pytest.raises(ResourceNotFoundError, match="No project specified"):
             log_stream.create()
 
 
@@ -266,28 +283,28 @@ class TestLogStreamGet:
     def test_get_raises_error_without_project_info_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test get() raises ValueError when no project and no env fallback."""
-        # Given: env fallback returns None
+        """Test get() raises ResourceNotFoundError naming the project that wasn't found."""
+        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
 
-        # When/Then: Calling get raises ResourceNotFoundError
-        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+        # When/Then: Calling get raises ResourceNotFoundError with guidance to provide a project identifier
+        with pytest.raises(ResourceNotFoundError, match="No project specified"):
             LogStream.get(name="Test Stream")
 
     @patch("galileo.log_stream.Projects")
     def test_get_raises_resource_not_found_when_project_id_unknown(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test get() raises ResourceNotFoundError when project_id lookup raises ProjectNotFoundError (HTTP 404)."""
+        """Test get() raises ResourceNotFoundError including the project_id when HTTP 404 is returned."""
         # Given: the projects service raises ProjectNotFoundError (HTTP 404) for an unknown project_id
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.side_effect = ProjectNotFoundError("not found")
 
-        # When/Then: calling get with an unknown project_id raises ResourceNotFoundError
-        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+        # When/Then: calling get with an unknown project_id raises ResourceNotFoundError with the id in the message
+        with pytest.raises(ResourceNotFoundError, match=r'Project with id "unknown-id" not found'):
             LogStream.get(name="Test Stream", project_id="unknown-id")
 
     @patch("galileo.log_stream.Projects")
@@ -416,28 +433,28 @@ class TestLogStreamList:
     def test_list_raises_error_without_project_info_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test list() raises ValueError when no project and no env fallback."""
-        # Given: env fallback returns None
+        """Test list() raises ResourceNotFoundError naming the project that wasn't found."""
+        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
 
-        # When/Then: Calling list raises ResourceNotFoundError
-        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+        # When/Then: Calling list raises ResourceNotFoundError with guidance to provide a project identifier
+        with pytest.raises(ResourceNotFoundError, match="No project specified"):
             LogStream.list()
 
     @patch("galileo.log_stream.Projects")
     def test_list_raises_resource_not_found_when_project_id_unknown(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test list() raises ResourceNotFoundError when project_id lookup raises ProjectNotFoundError (HTTP 404)."""
+        """Test list() raises ResourceNotFoundError including the project_id when HTTP 404 is returned."""
         # Given: the projects service raises ProjectNotFoundError (HTTP 404) for an unknown project_id
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.side_effect = ProjectNotFoundError("not found")
 
-        # When/Then: calling list with an unknown project_id raises ResourceNotFoundError
-        with pytest.raises(ResourceNotFoundError, match="Project not found"):
+        # When/Then: calling list with an unknown project_id raises ResourceNotFoundError with the id in the message
+        with pytest.raises(ResourceNotFoundError, match=r'Project with id "unknown-id" not found'):
             LogStream.list(project_id="unknown-id")
 
     @patch("galileo.log_stream.Projects")


### PR DESCRIPTION
**Shortcut:** 

[SC-61783](https://app.shortcut.com/galileo/story/61783)

**Description:**
`LogStream.list()` was raising inconsistent exceptions depending on how the project was resolved:

- `list(project_name="non-existent")` → `ResourceNotFoundError` ❌
- `list(project_id=<unknown-uuid>)` → `NotFoundError` ✓
- `list(project_name="non-existent", project_id=<unknown-uuid>)` → `NotFoundError` ✓

Root cause: `_resolve_project()` (introduced by PR #561) raised `ResourceNotFoundError` for the name-lookup path, diverging from the HTTP 404 path that naturally raises `NotFoundError`.

Fix: replaced the `ResourceNotFoundError` raise in `_resolve_project()` and `LogStream.create()` with `NotFoundError` via a new `_make_project_not_found_error()` helper that builds context-aware messages (naming the project or id that wasn't found). All three call paths now consistently raise `NotFoundError`.

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)