### PR TITLE
fix: url

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,8 +3,8 @@ info:
   title: FastAPI
   version: 0.1.0
 servers:
-  - url: http://localhost:8088
-    description: Galileo Client APIs - local
+  - url: https://api.galileo.ai
+    description: Galileo Client APIs - galileo-v2
 paths:
   /healthcheck:
     get:


### PR DESCRIPTION
# User description
replace localhost with remote api client url

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Switch the OpenAPI spec’s server definition to the remote Galileo API base to replace local references. Highlight the remote environment in the server description to align OpenAPI clients with <code>galileo-v2</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>namrata.ghadi@galileo.ai</td><td>fix: the filter schema...</td><td>April 28, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/571?tool=ast>(Baz)</a>.