### PR TITLE
feat(schema): re-export read-side stub records from galileo-core

### DIFF
--- a/src/galileo/schema/__init__.py
+++ b/src/galileo/schema/__init__.py
@@ -11,3 +11,4 @@ from galileo.schema.logged import (
     TextOrContentBlocks,
 )
 from galileo.schema.message import LoggedMessage
+from galileo.schema.stub_records import StubSpanRecord, StubTraceRecord, is_stub_record

--- a/src/galileo/schema/stub_records.py
+++ b/src/galileo/schema/stub_records.py
@@ -1,0 +1,26 @@
+"""SDK-side re-exports and helpers for read-side stub record types (DT 2.0).
+
+The schemas themselves live in ``galileo_core.schemas.shared.stub_records``,
+which mirrors how ``ContentPart`` (read side) lives in galileo-core while
+``IngestContentBlock`` (write side) lives in the SDK.
+
+This module exists purely so SDK consumers do not have to dig into the core
+namespace, and so that an ``is_stub_record(x)`` helper is available for the
+common pattern-match case.
+"""
+
+from typing import Any
+
+from galileo_core.schemas.shared.stub_records import StubSpanRecord, StubTraceRecord
+
+
+def is_stub_record(record: Any) -> bool:
+    """Return True if ``record`` is a synthesized stub (missing trace or span).
+
+    Useful when iterating over a tree returned by the API and rendering
+    placeholder UI for nodes that have not been ingested yet.
+    """
+    return isinstance(record, StubSpanRecord | StubTraceRecord)
+
+
+__all__ = ["StubSpanRecord", "StubTraceRecord", "is_stub_record"]


### PR DESCRIPTION
## Summary

Adds a thin SDK convenience layer for the new `StubSpanRecord` / `StubTraceRecord` types introduced in galileo-core for the DT 2.0 read path.

- New file `src/galileo/schema/stub_records.py` re-exports the two stub types and adds a small `is_stub_record(x)` helper.
- `src/galileo/schema/__init__.py` surfaces them at `galileo.schema`.

## Layout — why a thin re-export and not a full schema definition

Mirrors the existing `IngestContentBlock` (write) vs `ContentPart` (read) split:

- **Write side** (`IngestContentBlock`) is SDK-constructed, so it's defined in `galileo.schema.content_blocks`.
- **Read side** (`ContentPart`) is server-emitted and part of the API response contract, so it lives in galileo-core; the SDK consumes it via direct core imports.

Stub records are read-side and server-synthesized, so the schemas themselves stay in galileo-core. This module exists purely so SDK users don't have to dig into `galileo_core.schemas.shared.stub_records`, plus the `is_stub_record(x)` helper for the common pattern-match case when iterating over a returned tree.

## Behavioral change

None. Existing read methods (`Traces.get_trace`, `Traces.get_span`) still return raw `dict[str, str]`. A typed-read follow-up will use these unions directly.

## Dependency

Depends on the galileo-core release that adds `galileo_core.schemas.shared.stub_records`. Companion PR: rungalileo/orbit#612.

## Test plan

- [ ] Local import of `from galileo.schema import StubSpanRecord, StubTraceRecord, is_stub_record` works after galileo-core bump
- [ ] Existing tests pass
- [ ] Follow-up PR introduces typed read methods that consume these unions