### PR TITLE
fix(logger): add explicit str to start_trace input type hints and docstrings

### DIFF
--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -959,8 +959,8 @@ class GalileoLogger(TracesLogger):
     @warn_catch_exception()
     def start_trace(
         self,
-        input: TextOrContentBlocks | dict | list[dict[str, Any]],
-        redacted_input: TextOrContentBlocks | dict | list[dict[str, Any]] | None = None,
+        input: str | TextOrContentBlocks | dict | list[dict[str, Any]],
+        redacted_input: str | TextOrContentBlocks | dict | list[dict[str, Any]] | None = None,
         name: str | None = None,
         duration_ns: int | None = None,
         created_at: datetime | None = None,
@@ -977,7 +977,7 @@ class GalileoLogger(TracesLogger):
 
         Parameters
         ----------
-        input: TextOrContentBlocks | dict | list[dict[str, Any]]
+        input: str | TextOrContentBlocks | dict | list[dict[str, Any]]
             Input to the node.
             Accepted formats: string, dict (auto-converted to JSON string),
             list of dicts (auto-converted to JSON string),
@@ -987,7 +987,7 @@ class GalileoLogger(TracesLogger):
                 - Dict: `{"query": "hello", "context": "world"}` (auto-converted to JSON string)
                 - List of dicts: `[{"role": "user", "content": "hello"}]` (auto-converted to JSON string)
                 - Content blocks: `[TextContentBlock(text="Analyze"), DataContentBlock(...)]`
-        redacted_input: Optional[TextOrContentBlocks | dict | list[dict[str, Any]]]
+        redacted_input: Optional[str | TextOrContentBlocks | dict | list[dict[str, Any]]]
             Input that removes any sensitive information (redacted input).
             Same format as input parameter.
         name: Optional[str]


### PR DESCRIPTION
# User description
**Shortcut:** https://app.shortcut.com/galileo/story/54367

**Description:**

The auto-generated docs for `start_trace` showed `TextOrContentBlocks | dict | list[dict[str, Any]]` as the input type, but `TextOrContentBlocks` is an alias for `str | list[IngestContentBlock]` — so `str` was not visible to users reading the docs.

This adds an explicit `str |` to both the type hints and docstrings for the `input` and `redacted_input` parameters of `start_trace`, so the generated docs clearly show that plain strings are accepted.

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

> Docstring/type-hint-only change — no runtime behavior change, no tests needed.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the <code>start_trace</code> inputs by extending <code>GalileoLogger</code>'s type hints and docstrings to list strings explicitly alongside other supported formats. Ensure the generated docs accurately reflect that both <code>input</code> and <code>redacted_input</code> accept plain strings, dicts, lists, or content blocks so users understand all valid options.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Focadecombate</td><td>fix(logger): add list[...</td><td>April 24, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix: Python SDK tests ...</td><td>April 14, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/574?tool=ast>(Baz)</a>.