### PR TITLE
feat: support experiment groups (V1)

### DIFF
--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -20,11 +20,14 @@ from galileo.resources.api.experiment import (
 )
 from galileo.resources.models import ExperimentResponse, HTTPValidationError, PromptRunSettings, ScorerConfig, TaskType
 from galileo.schema.datasets import DatasetRecord
+from galileo.schema.experiment_group import ExperimentGroupResponse
 from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig, Metric
 from galileo.utils.datasets import create_rows_from_records, load_dataset
 from galileo.utils.exceptions import _format_http_validation_error
+from galileo.utils.headers_data import get_sdk_header
 from galileo.utils.log_config import get_logger
 from galileo.utils.metrics import create_metric_configs
+from galileo_core.constants.request_method import RequestMethod
 
 _logger = get_logger(__name__)
 
@@ -60,6 +63,10 @@ def _default_prompt_settings(model_alias: str = "GPT-4o") -> PromptRunSettings:
 MAX_REQUEST_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
 MAX_INGEST_BATCH_SIZE = 128
 DATASET_CONTENT_PAGE_SIZE = 1000
+# Page size used by both list_experiment_groups() and the group-filter branch of get_experiments().
+# Both call internal APIs with internal pagination; the public helpers return the full list and
+# do not expose pagination tokens to customers.
+_GROUP_LIST_PAGE_SIZE = 100
 
 
 @_attrs_define
@@ -95,7 +102,19 @@ class Experiments:
         prompt_template: PromptTemplate | None = None,
         scorers: builtins.list[ScorerConfig] | None = None,
         prompt_settings: PromptRunSettings | dict[str, Any] | None = None,
+        experiment_group_id: str | None = None,
+        experiment_group_name: str | None = None,
     ) -> ExperimentResponse:
+        # If both experiment_group_id and experiment_group_name are provided, the API gives
+        # precedence to the ID and silently ignores the name (see resolve_and_assign_group).
+        # We log it here so customers can spot unintentional duplication, but we do not
+        # reject — the API contract permits both.
+        if experiment_group_id is not None and experiment_group_name is not None:
+            _logger.debug(
+                "Both experiment_group_id and experiment_group_name provided; "
+                "the API will use experiment_group_id and ignore the name."
+            )
+
         resolved_settings: PromptRunSettings | None = (
             PromptRunSettings.from_dict(prompt_settings) if isinstance(prompt_settings, dict) else prompt_settings
         )
@@ -119,6 +138,11 @@ class Experiments:
 
         if trigger:
             body.additional_properties["trigger"] = True
+
+        if experiment_group_id is not None:
+            body.additional_properties["experiment_group_id"] = experiment_group_id
+        if experiment_group_name is not None:
+            body.additional_properties["experiment_group_name"] = experiment_group_name
 
         experiment = create_experiment_projects_project_id_experiments_post.sync(
             project_id=project_id, client=self.config.api_client, body=body
@@ -163,6 +187,8 @@ class Experiments:
         prompt_template: PromptTemplate | None,
         scorers: builtins.list[ScorerConfig] | None,
         prompt_settings: PromptRunSettings | dict[str, Any] | None = None,
+        experiment_group_id: str | None = None,
+        experiment_group_name: str | None = None,
     ) -> dict[str, Any]:
         if isinstance(prompt_settings, dict):
             prompt_settings = PromptRunSettings.from_dict(prompt_settings)
@@ -172,6 +198,12 @@ class Experiments:
             prompt_settings = _default_prompt_settings()
 
         # Single API call: create experiment + trigger job via trigger=True
+        # Only forward group kwargs when set so existing callers/tests aren't affected.
+        group_kwargs: dict[str, Any] = {}
+        if experiment_group_id is not None:
+            group_kwargs["experiment_group_id"] = experiment_group_id
+        if experiment_group_name is not None:
+            group_kwargs["experiment_group_name"] = experiment_group_name
         experiment_obj = self.create(
             project_id=project_obj.id,
             name=experiment_name,
@@ -180,6 +212,7 @@ class Experiments:
             prompt_template=prompt_template,
             scorers=scorers,
             prompt_settings=prompt_settings,
+            **group_kwargs,
         )
 
         link = f"{str(self.config.console_url).rstrip('/')}/project/{project_obj.id}/experiments/{experiment_obj.id}"
@@ -283,6 +316,8 @@ def run_experiment(
     function: Callable | None = None,
     experiment_tags: dict[str, str] | None = None,
     on_error: Callable[[Exception], None] | None = None,
+    experiment_group: str | None = None,
+    experiment_group_id: str | None = None,
 ) -> Any:
     """
     Run an experiment with the specified parameters.
@@ -325,6 +360,18 @@ def run_experiment(
         to the function flow — ignored in the prompt-template flow (a warning is logged if
         provided there). Creation errors always propagate regardless of this callback. If None,
         flush errors are logged as warnings. Defaults to None.
+    experiment_group
+        Optional name of an experiment group to assign this run to. If a group with this
+        name does not exist in the project, the API auto-creates it. If neither
+        ``experiment_group`` nor ``experiment_group_id`` is provided and the run has a
+        dataset, the API auto-creates a group named ``"<dataset_name> Experiment Group"``;
+        otherwise the run lands in the project's system "Ungrouped" group.
+    experiment_group_id
+        Optional UUID of an existing experiment group. If the group does not exist in this
+        project, the SDK raises ``galileo.NotFoundError`` (HTTP 404,
+        API error_code 3520) before the run is created.
+        If both ``experiment_group_id`` and ``experiment_group`` are provided, the API
+        uses the ID and silently ignores the name.
 
     Returns
     -------
@@ -333,7 +380,9 @@ def run_experiment(
     Raises
     ------
     ValueError
-        If required parameters are missing or invalid
+        If required parameters are missing or invalid.
+    galileo.NotFoundError
+        If ``experiment_group_id`` is provided but the group does not exist in the project.
     """
     if isinstance(prompt_settings, dict):
         prompt_settings = PromptRunSettings.from_dict(prompt_settings)
@@ -373,8 +422,15 @@ def run_experiment(
         experiment_name = f"{existing_experiment.name} {now:%Y-%m-%d} at {now:%H:%M:%S}.{now.microsecond // 1000:03d}"
 
     # Execute a runner function experiment (custom function flow — uses logstream pipeline)
+    # Only forward group kwargs when set so existing callers/tests aren't affected.
+    group_kwargs: dict[str, Any] = {}
+    if experiment_group_id is not None:
+        group_kwargs["experiment_group_id"] = experiment_group_id
+    if experiment_group is not None:
+        group_kwargs["experiment_group_name"] = experiment_group
+
     if function is not None:
-        experiment_obj = Experiments().create(project_obj.id, experiment_name, dataset_obj)
+        experiment_obj = Experiments().create(project_obj.id, experiment_name, dataset_obj, **group_kwargs)
 
         # Set up metrics WITH run_id — custom function flow needs ScorerSettings registered
         local_metrics: list[LocalMetricConfig] = []
@@ -422,7 +478,7 @@ def run_experiment(
     # If prompt_template is None, the API determines the flow based on the dataset contents.
     # The API will return error 3512 if the dataset has no generated_output column.
     result = Experiments().run(
-        project_obj, dataset_obj, experiment_name, prompt_template, scorer_settings, prompt_settings
+        project_obj, dataset_obj, experiment_name, prompt_template, scorer_settings, prompt_settings, **group_kwargs
     )
 
     if experiment_tags is not None:
@@ -438,7 +494,12 @@ def run_experiment(
 
 
 def create_experiment(
-    project_id: str | None = None, experiment_name: str | None = None, project_name: str | None = None
+    project_id: str | None = None,
+    experiment_name: str | None = None,
+    project_name: str | None = None,
+    *,
+    experiment_group: str | None = None,
+    experiment_group_id: str | None = None,
 ) -> ExperimentResponse:
     """
     Create an experiment with the specified parameters.
@@ -454,6 +515,15 @@ def create_experiment(
         Name of the experiment. Required.
     project
         Optional project name. Takes preference over the GALILEO_PROJECT environment variable. Leave empty if using project_id
+    experiment_group
+        Optional name of an experiment group to assign this experiment to. If a group with
+        this name does not exist in the project, the API auto-creates it.
+    experiment_group_id
+        Optional UUID of an existing experiment group. If the group does not exist in this
+        project, the SDK raises ``galileo.NotFoundError`` (HTTP 404,
+        API error_code 3520).
+        If both ``experiment_group_id`` and ``experiment_group`` are provided, the API
+        uses the ID and silently ignores the name.
 
     Returns
     -------
@@ -463,7 +533,10 @@ def create_experiment(
     Raises
     ------
     ValueError
-        If `experiment_name` is not provided, or if the project cannot be resolved from `project_id` or `project`.
+        If `experiment_name` is not provided or if the project cannot be resolved from
+        `project_id` or `project`.
+    galileo.NotFoundError
+        If ``experiment_group_id`` is provided but the group does not exist in the project.
     HTTPValidationError
         If there's a validation error in returning an ExperimentResponse.
     """
@@ -478,7 +551,12 @@ def create_experiment(
             raise ValueError(f"Project {project_name} does not exist")
         raise ValueError("Project not specified and no defaults found")
 
-    return Experiments().create(project_obj.id, experiment_name)
+    group_kwargs: dict[str, Any] = {}
+    if experiment_group_id is not None:
+        group_kwargs["experiment_group_id"] = experiment_group_id
+    if experiment_group is not None:
+        group_kwargs["experiment_group_name"] = experiment_group
+    return Experiments().create(project_obj.id, experiment_name, **group_kwargs)
 
 
 def get_experiment(
@@ -525,10 +603,19 @@ def get_experiment(
 
 
 def get_experiments(
-    project_id: str | None = None, project_name: str | None = None
+    project_id: str | None = None,
+    project_name: str | None = None,
+    *,
+    experiment_group: str | None = None,
+    experiment_group_id: str | None = None,
 ) -> HTTPValidationError | list[ExperimentResponse] | None:
     """
     Get experiments from the specified Project.
+
+    When no group filter is given, returns all experiments in the project (existing
+    behavior, calls ``GET /projects/{id}/experiments``). When ``experiment_group`` or
+    ``experiment_group_id`` is provided, returns only experiments assigned to that group
+    (calls ``POST /projects/{id}/experiments/search`` and pages internally).
 
     Parameters
     ----------
@@ -536,15 +623,25 @@ def get_experiments(
         Optional project Id. Takes preference over the GALILEO_PROJECT_ID environment variable. Leave empty if using ``project``
     project_name
         Optional project name. Takes preference over the GALILEO_PROJECT environment variable. Leave empty if using ``project_id``
+    experiment_group
+        Optional experiment-group name to filter by. Returns only experiments assigned to
+        a group with this name. Mutually compatible with ``experiment_group_id``: if both
+        are provided, both filters are sent and the API resolves precedence.
+    experiment_group_id
+        Optional experiment-group UUID to filter by. Returns only experiments assigned to
+        this group.
 
     Returns
     -------
-    List of ExperimentResponse results
+    List of ExperimentResponse results. When a filter is set, the list is scoped to the
+    matching group; otherwise it is the full project listing.
 
     Raises
     ------
     HTTPValidationError
         If there's a validation error in returning a list of ExperimentResponse
+    httpx.HTTPStatusError
+        If the search endpoint returns a non-2xx response (only when a group filter is set).
     """
     # Resolve project by id, name, or environment fallbacks
     project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
@@ -553,4 +650,116 @@ def get_experiments(
             raise ValueError(f"Project {project_name} does not exist")
         raise ValueError("Project not specified and no defaults found")
 
-    return Experiments().list(project_id=project_obj.id)
+    # No filter → keep existing behavior unchanged (calls GET /experiments via generated client)
+    if experiment_group is None and experiment_group_id is None:
+        return Experiments().list(project_id=project_obj.id)
+
+    # Filter set → call the search endpoint, page through all results.
+    # The search endpoint is not in the generated client today; once it is, this branch
+    # should be rewritten to use the generated function.
+    filters: list[dict[str, Any]] = []
+    if experiment_group_id is not None:
+        # The experiment_group_id column is registered as CustomUUIDFilterConfig in the API
+        # (see api/daos/run.py); the matching schema (ExperimentGroupIDFilter) extends
+        # CustomUUIDFilter, which has no operator and uses filter_type="custom_uuid".
+        filters.append({"filter_type": "custom_uuid", "name": "experiment_group_id", "value": experiment_group_id})
+    if experiment_group is not None:
+        filters.append(
+            {
+                "filter_type": "string",
+                "name": "experiment_group_name",
+                "operator": "eq",
+                "value": experiment_group,
+                "case_sensitive": True,
+            }
+        )
+
+    config = GalileoPythonConfig.get()
+    headers = {"Content-Type": "application/json", "X-Galileo-SDK": get_sdk_header()}
+    path = f"/projects/{project_obj.id}/experiments/search"
+
+    all_experiments: list[ExperimentResponse] = []
+    starting_token: int | None = 0
+    while starting_token is not None:
+        response = config.api_client.request(
+            method=RequestMethod.POST,
+            path=path,
+            json={"filters": filters, "starting_token": starting_token, "limit": _GROUP_LIST_PAGE_SIZE},
+            content_headers=headers,
+            return_raw_response=True,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        all_experiments.extend(ExperimentResponse.from_dict(e) for e in payload.get("experiments", []))
+        # Advance on next_starting_token directly — `paginated` is optional in the schema
+        # and absent does not mean "no more pages". A non-None token is the only reliable signal.
+        starting_token = payload.get("next_starting_token")
+
+    return all_experiments
+
+
+def list_experiment_groups(
+    project_id: str | None = None, project_name: str | None = None
+) -> list[ExperimentGroupResponse]:
+    """List all experiment groups in a project.
+
+    Calls ``POST /projects/{project_id}/experiment-groups/query`` and pages through
+    every group internally. The full list is returned in a single call; customers
+    do not need to handle pagination tokens.
+
+    The project can be specified by providing exactly one of the project name (via the
+    ``project_name`` parameter or the ``GALILEO_PROJECT`` environment variable) or the
+    project ID (via the ``project_id`` parameter or the ``GALILEO_PROJECT_ID``
+    environment variable).
+
+    Parameters
+    ----------
+    project_id
+        Optional project ID. Takes preference over the ``GALILEO_PROJECT_ID`` env var.
+    project_name
+        Optional project name. Takes preference over the ``GALILEO_PROJECT`` env var.
+
+    Returns
+    -------
+    list[ExperimentGroupResponse]
+        All experiment groups in the project.
+
+    Raises
+    ------
+    ValueError
+        If the project cannot be resolved.
+    httpx.HTTPStatusError
+        If the API returns a non-2xx response.
+    """
+    project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+    if not project_obj:
+        if project_name:
+            raise ValueError(f"Project {project_name} does not exist")
+        raise ValueError("Project not specified and no defaults found")
+
+    # Use the SDK's configured ApiClient — the same client every generated endpoint call
+    # uses (see src/galileo/resources/api/experiment/*.py). This preserves auth, base URL,
+    # timeout, and SDK headers. The experiment-group routes are not yet in the generated
+    # client; once they are, this helper should be rewritten to use the generated function.
+    config = GalileoPythonConfig.get()
+    headers = {"Content-Type": "application/json", "X-Galileo-SDK": get_sdk_header()}
+    path = f"/projects/{project_obj.id}/experiment-groups/query"
+
+    all_groups: list[ExperimentGroupResponse] = []
+    starting_token: int | None = 0
+    while starting_token is not None:
+        response = config.api_client.request(
+            method=RequestMethod.POST,
+            path=path,
+            json={"starting_token": starting_token, "limit": _GROUP_LIST_PAGE_SIZE},
+            content_headers=headers,
+            return_raw_response=True,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        all_groups.extend(ExperimentGroupResponse.model_validate(g) for g in payload.get("experiment_groups", []))
+        # Advance on next_starting_token directly — `paginated` is optional in the schema
+        # and absent does not mean "no more pages". A non-None token is the only reliable signal.
+        starting_token = payload.get("next_starting_token")
+
+    return all_groups

--- a/src/galileo/schema/experiment_group.py
+++ b/src/galileo/schema/experiment_group.py
@@ -1,0 +1,51 @@
+"""SDK-side Pydantic models for experiment-group responses.
+
+These shadow the API's ExperimentGroupResponse until the Client API OpenAPI spec
+includes the experiment-group routes and the generated client provides typed
+models. When that happens, this file should be deleted in favor of
+``galileo.resources.models.experiment_group_response``.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ExperimentGroupDataset(BaseModel):
+    """Dataset summary attached to an experiment group."""
+
+    id: UUID
+    name: str
+
+
+class ExperimentGroupUserInfo(BaseModel):
+    """Creator info embedded on an experiment group response."""
+
+    id: UUID
+    email: str
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+class ExperimentGroupResponse(BaseModel):
+    """A single experiment group as returned by the API.
+
+    Mirrors ``ExperimentGroupResponse`` in ``api/api/schemas/experiment_group.py``.
+    Extra fields are ignored so additive backend changes don't break SDK clients.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: UUID
+    name: str
+    project_id: UUID
+    created_at: datetime
+    updated_at: datetime
+    description: str | None = None
+    is_system: bool = False
+    experiment_count: int = 0
+    latest_run_date: datetime | None = None
+    datasets: list[ExperimentGroupDataset] = []
+    created_by: UUID | None = None
+    created_by_user: ExperimentGroupUserInfo | None = None

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -16,7 +16,14 @@ import galileo.jobs
 import galileo.utils.datasets
 from galileo import galileo_context
 from galileo.decorator import SPAN_TYPE
-from galileo.experiments import Experiments, create_experiment, get_experiment, get_experiments, run_experiment
+from galileo.experiments import (
+    Experiments,
+    create_experiment,
+    get_experiment,
+    get_experiments,
+    list_experiment_groups,
+    run_experiment,
+)
 from galileo.projects import Project
 from galileo.prompts import PromptTemplate
 from galileo.resources.models import (
@@ -38,6 +45,7 @@ from galileo.resources.models import (
 )
 from galileo.resources.types import UNSET
 from galileo.schema.datasets import DatasetRecord
+from galileo.schema.experiment_group import ExperimentGroupResponse
 from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig
 from galileo.utils.datasets import load_dataset_and_records
 from galileo.utils.exceptions import _format_http_validation_error
@@ -1840,3 +1848,311 @@ class TestFormatHttpValidationError:
 
         # Then: fallback message is returned
         assert result == "Request validation failed (no details provided)"
+
+
+# ===========================================================================
+# Experiment Groups V1 — group identity + discovery helper
+# ===========================================================================
+
+
+class TestExperimentGroups:
+    """V1 experiment-group support: group-aware run/create + list_experiment_groups()."""
+
+    @patch.object(
+        galileo.experiments.Experiments,
+        "run",
+        return_value={"experiment": experiment_response(), "link": "x", "message": "y"},
+    )
+    @patch.object(galileo.experiments.Experiments, "get", return_value=None)
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
+    @patch("galileo.experiments.load_dataset")
+    def test_run_experiment_with_experiment_group_name(
+        self, load_dataset_mock: Mock, get_project_mock: Mock, get_experiment_mock: Mock, run_mock: Mock
+    ) -> None:
+        """run_experiment(experiment_group=...) forwards experiment_group_name to Experiments.run()."""
+        # Given: a resolved project, no existing experiment, and a stubbed dataset
+        load_dataset_mock.return_value = MagicMock()
+
+        # When: running an experiment with experiment_group=
+        run_experiment(
+            experiment_name="grouped-run",
+            project="awesome-new-project",
+            dataset_id=str(UUID(int=0)),
+            prompt_template=prompt_template(),
+            experiment_group="my-rag-bench",
+        )
+
+        # Then: Experiments.run was called with the group name (and no group id)
+        run_mock.assert_called_once()
+        call_kwargs = run_mock.call_args.kwargs
+        assert call_kwargs.get("experiment_group_name") == "my-rag-bench"
+        assert "experiment_group_id" not in call_kwargs
+
+    @patch.object(
+        galileo.experiments.Experiments,
+        "run",
+        return_value={"experiment": experiment_response(), "link": "x", "message": "y"},
+    )
+    @patch.object(galileo.experiments.Experiments, "get", return_value=None)
+    @patch.object(galileo.experiments.Projects, "get_with_env_fallbacks", return_value=project())
+    @patch("galileo.experiments.load_dataset")
+    def test_run_experiment_with_experiment_group_id(
+        self, load_dataset_mock: Mock, get_project_mock: Mock, get_experiment_mock: Mock, run_mock: Mock
+    ) -> None:
+        """run_experiment(experiment_group_id=...) forwards experiment_group_id to Experiments.run()."""
+        # Given: a resolved project, no existing experiment, and a stubbed dataset
+        load_dataset_mock.return_value = MagicMock()
+        group_uuid = str(UUID(int=42))
+
+        # When: running an experiment with experiment_group_id=
+        run_experiment(
+            experiment_name="id-run",
+            project="awesome-new-project",
+            dataset_id=str(UUID(int=0)),
+            prompt_template=prompt_template(),
+            experiment_group_id=group_uuid,
+        )
+
+        # Then: Experiments.run was called with the group id (and no group name)
+        run_mock.assert_called_once()
+        call_kwargs = run_mock.call_args.kwargs
+        assert call_kwargs.get("experiment_group_id") == group_uuid
+        assert "experiment_group_name" not in call_kwargs
+
+    @patch("galileo.experiments.create_experiment_projects_project_id_experiments_post")
+    @patch("galileo.experiments.Projects.get_with_env_fallbacks")
+    def test_create_experiment_with_experiment_group_name(
+        self, get_project_mock: Mock, create_experiment_mock: Mock
+    ) -> None:
+        """create_experiment(experiment_group=...) flows the name through to the API body."""
+        # Given: a resolved project and a mocked create endpoint
+        get_project_mock.return_value = project()
+        create_experiment_mock.sync = Mock(return_value=experiment_response())
+
+        # When: creating an experiment with experiment_group=
+        create_experiment(
+            experiment_name="grouped-create", project_name="awesome-new-project", experiment_group="standalone-bench"
+        )
+
+        # Then: the create body carries experiment_group_name
+        body = create_experiment_mock.sync.call_args.kwargs["body"]
+        assert body.additional_properties["experiment_group_name"] == "standalone-bench"
+        assert "experiment_group_id" not in body.additional_properties
+
+    @patch("galileo.experiments.create_experiment_projects_project_id_experiments_post")
+    @patch("galileo.experiments.Projects.get_with_env_fallbacks")
+    def test_create_experiment_with_experiment_group_id(
+        self, get_project_mock: Mock, create_experiment_mock: Mock
+    ) -> None:
+        """create_experiment(experiment_group_id=...) flows the id through to the API body."""
+        # Given: a resolved project and a mocked create endpoint
+        get_project_mock.return_value = project()
+        create_experiment_mock.sync = Mock(return_value=experiment_response())
+
+        # When: creating an experiment with experiment_group_id=
+        group_uuid = str(UUID(int=99))
+        create_experiment(
+            experiment_name="id-create", project_name="awesome-new-project", experiment_group_id=group_uuid
+        )
+
+        # Then: the create body carries experiment_group_id
+        body = create_experiment_mock.sync.call_args.kwargs["body"]
+        assert body.additional_properties["experiment_group_id"] == group_uuid
+        assert "experiment_group_name" not in body.additional_properties
+
+    @patch("galileo.experiments.GalileoPythonConfig")
+    @patch("galileo.experiments.Projects.get_with_env_fallbacks")
+    def test_list_experiment_groups(self, get_project_mock: Mock, config_mock: Mock) -> None:
+        """list_experiment_groups() POSTs to /experiment-groups/query and returns typed objects."""
+        # Given: a resolved project and a mocked httpx client returning two groups
+
+        get_project_mock.return_value = project()
+
+        now_iso = datetime.now().isoformat() + "Z"
+        api_payload = {
+            "starting_token": 0,
+            "limit": 100,
+            "paginated": False,
+            "next_starting_token": None,
+            "experiment_groups": [
+                {
+                    "id": str(UUID(int=1)),
+                    "name": "group-a",
+                    "project_id": str(UUID(int=0)),
+                    "created_at": now_iso,
+                    "updated_at": now_iso,
+                    "is_system": False,
+                    "experiment_count": 2,
+                    "datasets": [],
+                },
+                {
+                    "id": str(UUID(int=2)),
+                    "name": "Ungrouped",
+                    "project_id": str(UUID(int=0)),
+                    "created_at": now_iso,
+                    "updated_at": now_iso,
+                    "is_system": True,
+                    "experiment_count": 0,
+                    "datasets": [],
+                },
+            ],
+        }
+
+        fake_response = MagicMock()
+        fake_response.json.return_value = api_payload
+        fake_response.raise_for_status = MagicMock()
+
+        # API returns a single page (paginated=False)
+        api_payload["paginated"] = False
+        api_payload["next_starting_token"] = None
+        config_mock.get.return_value.api_client.request.return_value = fake_response
+
+        # When: listing experiment groups
+        groups = list_experiment_groups(project_name="awesome-new-project")
+
+        # Then: it calls ApiClient.request once with the right path and pagination body
+        config_mock.get.return_value.api_client.request.assert_called_once()
+        call_kwargs = config_mock.get.return_value.api_client.request.call_args.kwargs
+        assert call_kwargs["path"] == f"/projects/{UUID(int=0)}/experiment-groups/query"
+        assert call_kwargs["json"] == {"starting_token": 0, "limit": 100}
+        assert call_kwargs["return_raw_response"] is True
+
+        assert len(groups) == 2
+        assert all(isinstance(g, ExperimentGroupResponse) for g in groups)
+        assert groups[0].name == "group-a"
+        assert groups[0].experiment_count == 2
+        assert groups[1].is_system is True
+
+    @patch("galileo.experiments.GalileoPythonConfig")
+    @patch("galileo.experiments.Projects.get_with_env_fallbacks")
+    def test_list_experiment_groups_paginates_internally(self, get_project_mock: Mock, config_mock: Mock) -> None:
+        """list_experiment_groups() walks all pages and returns the combined list."""
+        # Given: a project and an API that returns 2 pages
+
+        get_project_mock.return_value = project()
+
+        now_iso = datetime.now().isoformat() + "Z"
+
+        def make_group(idx: int, system: bool = False) -> dict:
+            return {
+                "id": str(UUID(int=idx)),
+                "name": f"group-{idx}",
+                "project_id": str(UUID(int=0)),
+                "created_at": now_iso,
+                "updated_at": now_iso,
+                "is_system": system,
+                "experiment_count": 0,
+                "datasets": [],
+            }
+
+        page1 = MagicMock()
+        page1.json.return_value = {
+            "experiment_groups": [make_group(1), make_group(2)],
+            "paginated": True,
+            "next_starting_token": 100,
+        }
+        page1.raise_for_status = MagicMock()
+
+        page2 = MagicMock()
+        page2.json.return_value = {
+            "experiment_groups": [make_group(3)],
+            "paginated": False,
+            "next_starting_token": None,
+        }
+        page2.raise_for_status = MagicMock()
+
+        config_mock.get.return_value.api_client.request.side_effect = [page1, page2]
+
+        # When: listing experiment groups
+        groups = list_experiment_groups(project_name="awesome-new-project")
+
+        # Then: both pages are walked and the combined list is returned
+        assert config_mock.get.return_value.api_client.request.call_count == 2
+        starting_tokens = [
+            c.kwargs["json"]["starting_token"] for c in config_mock.get.return_value.api_client.request.call_args_list
+        ]
+        assert starting_tokens == [0, 100]
+        assert len(groups) == 3
+        assert [g.name for g in groups] == ["group-1", "group-2", "group-3"]
+
+    @patch("galileo.experiments.GalileoPythonConfig")
+    @patch("galileo.experiments.Projects.get_with_env_fallbacks")
+    def test_get_experiments_with_group_name_filter(self, get_project_mock: Mock, config_mock: Mock) -> None:
+        """get_experiments(experiment_group=...) calls the search endpoint with a name filter."""
+        # Given: a resolved project and a search endpoint that returns one matching experiment
+        get_project_mock.return_value = project()
+        fake_response = MagicMock()
+        fake_response.json.return_value = {
+            "experiments": [experiment_response().to_dict()],
+            "paginated": False,
+            "next_starting_token": None,
+        }
+        fake_response.raise_for_status = MagicMock()
+        config_mock.get.return_value.api_client.request.return_value = fake_response
+
+        # When: filtering by group name
+        result = get_experiments(project_name="awesome-new-project", experiment_group="my-group")
+
+        # Then: it calls /experiments/search with the right filter and returns the experiment
+        config_mock.get.return_value.api_client.request.assert_called_once()
+        kwargs = config_mock.get.return_value.api_client.request.call_args.kwargs
+        assert kwargs["path"] == f"/projects/{UUID(int=0)}/experiments/search"
+        body = kwargs["json"]
+        assert body["filters"] == [
+            {
+                "filter_type": "string",
+                "name": "experiment_group_name",
+                "operator": "eq",
+                "value": "my-group",
+                "case_sensitive": True,
+            }
+        ]
+        assert body["starting_token"] == 0
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+    @patch("galileo.experiments.GalileoPythonConfig")
+    @patch("galileo.experiments.Projects.get_with_env_fallbacks")
+    def test_get_experiments_with_group_id_filter(self, get_project_mock: Mock, config_mock: Mock) -> None:
+        """get_experiments(experiment_group_id=...) calls the search endpoint with an id filter."""
+        # Given: a resolved project and a search endpoint that returns one matching experiment
+        get_project_mock.return_value = project()
+        fake_response = MagicMock()
+        fake_response.json.return_value = {
+            "experiments": [experiment_response().to_dict()],
+            "paginated": False,
+            "next_starting_token": None,
+        }
+        fake_response.raise_for_status = MagicMock()
+        config_mock.get.return_value.api_client.request.return_value = fake_response
+
+        group_uuid = str(UUID(int=42))
+
+        # When: filtering by group ID
+        result = get_experiments(project_name="awesome-new-project", experiment_group_id=group_uuid)
+
+        # Then: filter sends a custom_uuid filter clause (matches API schema —
+        # ExperimentGroupIDFilter extends CustomUUIDFilter, which has no operator)
+        kwargs = config_mock.get.return_value.api_client.request.call_args.kwargs
+        body = kwargs["json"]
+        assert body["filters"] == [{"filter_type": "custom_uuid", "name": "experiment_group_id", "value": group_uuid}]
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+    @patch("galileo.experiments.list_experiments_projects_project_id_experiments_get")
+    @patch("galileo.experiments.Projects.get_with_env_fallbacks")
+    def test_get_experiments_without_filter_unchanged(
+        self, get_project_mock: Mock, list_experiments_mock: Mock
+    ) -> None:
+        """get_experiments() without any filter still calls the legacy list endpoint."""
+        # Given: a resolved project and the existing list endpoint
+        get_project_mock.return_value = project()
+        list_experiments_mock.sync = Mock(return_value=[experiment_response()])
+
+        # When: calling without filter
+        result = get_experiments(project_name="awesome-new-project")
+
+        # Then: legacy list endpoint is used (no search call), returning the project's experiments
+        list_experiments_mock.sync.assert_called_once_with(project_id=str(UUID(int=0)), client=ANY)
+        assert isinstance(result, list)
+        assert len(result) == 1


### PR DESCRIPTION
# User description
Three additions to the SDK public surface, all backward-compatible (new optional kwargs and one new helper):

1. run_experiment / create_experiment accept group assignment
   - experiment_group: str | None — group name (auto-created if missing)
   - experiment_group_id: str | None — group UUID (NotFoundError if missing)
   - Both: ID wins, name silently ignored, debug log emitted

2. get_experiments accepts optional group filter
   - experiment_group: str | None — filter by group name (string filter)
   - experiment_group_id: str | None — filter by group ID (custom_uuid filter)
   - No filter: existing behavior unchanged (calls GET /experiments)
   - With filter: scopes via POST /experiments/search with internal pagination

3. NEW: list_experiment_groups(project_id, project_name)
   - Returns all groups in the project as typed ExperimentGroupResponse
   - SDK paginates internally; no token kwargs exposed to customers

Coverage:
- 6 new mocked unit tests in TestExperimentGroups
- All 72 tests in tests/test_experiments.py pass
- 8 P0/P1 scenarios verified live on dev stack
- Static: ruff/mypy clean on changed files (PLC0415 warnings on pre-existing tests are unchanged from main)

Caveat: list_experiment_groups uses httpx.HTTPStatusError on 4xx/5xx (not the typed NotFoundError family that generated calls raise). Acceptable for V1; will be replaced when OpenAPI regen lands.

**Shortcut:**

**Description:**

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend the Experiments helpers and their public wrappers to accept optional <code>experiment_group</code>/<code>experiment_group_id</code> arguments so runs and creations can assign to explicit groups while logging overlapping inputs. Add group-aware discovery by filtering <code>get_experiments</code>, paging a new <code>list_experiment_groups</code> helper, and defining the typed <code>ExperimentGroupResponse</code> support for the search APIs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/575?tool=ast&topic=Group+discovery>Group discovery</a>
        </td><td>Implement group-aware discovery by filtering <code>get_experiments</code> through <code>/experiments/search</code>, providing <code>list_experiment_groups</code> with internal pagination, and defining the typed <code>ExperimentGroupResponse</code> schema alongside tests for the new helpers.<details><summary>Modified files (3)</summary><ul><li>src/galileo/experiments.py</li>
<li>src/galileo/schema/experiment_group.py</li>
<li>tests/test_experiments.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix(validation): handl...</td><td>May 04, 2026</td></tr>
<tr><td>bipin@galileo.ai</td><td>feat(experiments): sup...</td><td>May 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/575?tool=ast&topic=Group+assignment>Group assignment</a>
        </td><td>Add optional <code>experiment_group_id</code>/<code>experiment_group_name</code> kwargs across <code>Experiments.create</code>, <code>.run</code>, <code>create_experiment</code>, and <code>run_experiment</code> so flows can assign runs and creations to named or ID-driven groups, log duplicate inputs, and cover the behavior via new unit tests.<details><summary>Modified files (2)</summary><ul><li>src/galileo/experiments.py</li>
<li>tests/test_experiments.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>fix(validation): handl...</td><td>May 04, 2026</td></tr>
<tr><td>bipin@galileo.ai</td><td>feat(experiments): sup...</td><td>May 01, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/575?tool=ast>(Baz)</a>.