### PR TITLE
fix(ci): improve review-enforcement reliability

### DIFF
--- a/.github/workflows/review-enforcement.yml
+++ b/.github/workflows/review-enforcement.yml
@@ -13,6 +13,9 @@ jobs:
   enforce-review:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
+    concurrency:
+      group: enforce-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       pull-requests: write
     steps:
@@ -54,7 +57,10 @@ jobs:
               }
             }
 
-            // Fetch reviews with retry for eventual consistency
+            // Fetch reviews with retry for eventual consistency.
+            // On pull_request_review events, retry until we see a valid approval — not just
+            // any review — because a stale dismissed review would otherwise cause an immediate
+            // break before the newly submitted APPROVED review propagates through the API.
             let reviews;
             let attempts = 0;
             while (attempts < 3) {
@@ -65,15 +71,22 @@ jobs:
               });
               reviews = result.data;
 
-              // If we have reviews or this is not a review event, stop retrying
-              if (reviews.length > 0 || event !== 'pull_request_review') {
+              const hasApproval = reviews.some(
+                r => r.state === 'APPROVED' &&
+                     r.user?.login !== 'baz-reviewer' &&
+                     r.user?.type === 'User'
+              );
+
+              // For non-review events, stop immediately. For review events, keep retrying
+              // until we see a valid approval (covers eventual consistency after dismiss+re-approve).
+              if (event !== 'pull_request_review' || hasApproval) {
                 break;
               }
 
               // Wait before retry
               attempts++;
               if (attempts < 3) {
-                core.info(`No reviews found yet (attempt ${attempts}/3) - retrying...`);
+                core.info(`No valid approval found yet (attempt ${attempts}/3) - retrying...`);
                 await new Promise(resolve => setTimeout(resolve, 1000));
               }
             }
@@ -192,8 +205,10 @@ jobs:
               } catch (error) {
                 if (error.message?.includes('already enabled')) {
                   core.info(`Auto-merge already enabled for PR #${prNumber} - skipping.`);
-                } else if (error.message?.includes('in clean status')) {
-                  core.info(`PR #${prNumber} became clean during processing - merging directly.`);
+                } else if (error.message?.includes('in clean status') || error.message?.includes('unstable status')) {
+                  // 'in clean status': PR became clean while we were processing
+                  // 'unstable status': cancelled/superseded check runs make auto-merge reject, but mergeable===true so we can merge directly
+                  core.info(`PR #${prNumber} is mergeable despite ${mergeablePr.mergeable_state} state - merging directly.`);
                   await github.rest.pulls.merge({
                     owner: context.repo.owner,
                     repo: context.repo.repo,


### PR DESCRIPTION
# User description
Three fixes to the shared `review-enforcement.yml` workflow:

1. **`enforce-review` concurrency**: Cancels in-progress synchronize check runs when an approval event fires, preventing a race condition where the synchronize job completes last and overwrites a passing approval status.

2. **Retry logic fix**: Previously the retry broke out as soon as `reviews.length > 0`, even if all existing reviews were dismissed. Now it retries until a valid non-baz human approval appears, covering eventual consistency after a dismiss→re-approve sequence.

3. **Dependabot auto-merge `unstable status` fix**: GitHub rejects `enablePullRequestAutoMerge` for PRs with cancelled check runs (`mergeable_state=unstable`). The error was unhandled and crashed the job. Now falls back to a direct merge when `mergeable===true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align the review enforcement workflow to cancel concurrent runs and retry listing reviews until a valid non-baz approval appears so synchronize jobs no longer race with approvals. Handle dependabot auto-merge failures by catching unstable status rejections and directly merging when the PR remains mergeable.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/576?tool=ast&topic=Dependabot+merge>Dependabot merge</a>
        </td><td>Handle dependabot auto-merge unstable status by falling back to a direct merge when <code>enablePullRequestAutoMerge</code> is rejected but <code>mergeable === true</code>.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/review-enforcement.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>jweiler@galileo.ai</td><td>fix(ci): improve revie...</td><td>May 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/576?tool=ast&topic=Review+enforcement>Review enforcement</a>
        </td><td>Fix review enforcement concurrency and retry handling so approval events cancel in-progress synchronize checks and review polling waits for a valid non-baz approval before enforcing the requirement.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/review-enforcement.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>jweiler@galileo.ai</td><td>fix(ci): improve revie...</td><td>May 04, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/576?tool=ast>(Baz)</a>.