### PR TITLE
fix: adjust LogStream.list() to throw NotFoundError when project is unknown

### DIFF
--- a/src/galileo/exceptions.py
+++ b/src/galileo/exceptions.py
@@ -1,5 +1,7 @@
 """Galileo SDK exceptions."""
 
+from typing import overload
+
 __all__ = [
     "AuthenticationError",
     "BadRequestError",
@@ -62,11 +64,23 @@ class ForbiddenError(GalileoAPIError):
 class NotFoundError(GalileoAPIError):
     """HTTP 404 - Resource not found.
 
-    Accepts either an HTTP response (status_code, content) or a plain string message for
-    SDK-level lookups where no HTTP response is available.
+    Two construction paths:
+
+    - ``NotFoundError(status_code, content)`` — built from an HTTP 404 response by the
+      generated client. Uses the standard "Resource not found..." message.
+    - ``NotFoundError(message)`` — built from an SDK-level lookup that has no HTTP
+      response (e.g. resolving a project from env vars). The string is the full message.
+
+    The two paths are exposed via ``@overload`` so type checkers see the right shape
+    for each call site instead of an opaque ``int | str`` parameter.
     """
 
-    def __init__(self, status_code_or_message: int | str, content: bytes = b""):
+    @overload
+    def __init__(self, message: str) -> None: ...
+    @overload
+    def __init__(self, status_code: int, content: bytes) -> None: ...
+
+    def __init__(self, status_code_or_message: int | str, content: bytes = b"") -> None:
         if isinstance(status_code_or_message, str):
             self.status_code = 404
             self.content = b""

--- a/src/galileo/exceptions.py
+++ b/src/galileo/exceptions.py
@@ -1,6 +1,6 @@
 """Galileo SDK exceptions."""
 
-from typing import overload
+from typing import Any, overload
 
 __all__ = [
     "AuthenticationError",
@@ -13,6 +13,10 @@ __all__ = [
     "RateLimitError",
     "ServerError",
 ]
+
+# Sentinel for "argument not provided" so the message overload of NotFoundError can
+# reject _any_ explicit second argument (including ``b""``), not just non-empty bytes.
+_UNSET: Any = object()
 
 
 class GalileoLoggerException(Exception):
@@ -62,19 +66,40 @@ class ForbiddenError(GalileoAPIError):
 
 
 class NotFoundError(GalileoAPIError):
-    """HTTP 404 - Resource not found.
+    r"""HTTP 404 - Resource not found.
 
-    Two construction paths:
+    Parameters
+    ----------
+    status_code_or_message : int | str
+        Either an HTTP status code (``int``, paired with ``content``) or a
+        full message string (``str``, used on its own).
+    content : bytes, optional
+        Raw response body. Only valid alongside an ``int`` status code; on the
+        message path it must be omitted.
 
-    - ``NotFoundError(status_code, content)`` — built from an HTTP 404 response by the
-      generated client. Uses the standard "Resource not found..." message.
-    - ``NotFoundError(message)`` — built from an SDK-level lookup that has no HTTP
-      response (e.g. resolving a project from env vars). The string is the full message.
+    Notes
+    -----
+    Two construction paths are supported, exposed via ``@overload`` so type
+    checkers see the right shape per call site:
 
-    The two paths are exposed via ``@overload`` so type checkers see the right shape
-    for each call site instead of an opaque ``int | str`` parameter. The runtime
-    constructor also enforces the contract: mixing the two shapes
-    (e.g. ``NotFoundError("msg", b"body")``) or passing ``None`` raises ``TypeError``.
+    - ``NotFoundError(status_code, content)`` — built from an HTTP 404 response
+      by the generated client. Uses the standard "Resource not found…" message.
+    - ``NotFoundError(message)`` — built from an SDK-level lookup that has no
+      HTTP response (e.g. resolving a project from env vars). The string is the
+      full message; no ``content`` argument is accepted.
+
+    The runtime constructor also enforces the contract. The following all raise
+    ``TypeError`` instead of producing nonsensical state:
+
+    - Mixing shapes: ``NotFoundError("msg", b"")`` / ``NotFoundError("msg", b"body")``
+    - Passing ``None``: ``NotFoundError(None)``
+    - Passing ``bool``: ``NotFoundError(True, b"x")`` (``bool`` is technically an
+      ``int`` subclass but is rejected explicitly to avoid silent acceptance)
+
+    Examples
+    --------
+    >>> NotFoundError(404, b"{\\"detail\\": ...}")  # HTTP response path
+    >>> NotFoundError("Project \\"foo\\" not found.")  # SDK lookup path
     """
 
     @overload
@@ -82,9 +107,9 @@ class NotFoundError(GalileoAPIError):
     @overload
     def __init__(self, status_code: int, content: bytes) -> None: ...
 
-    def __init__(self, status_code_or_message: int | str, content: bytes = b"") -> None:
+    def __init__(self, status_code_or_message: int | str, content: bytes = _UNSET) -> None:
         if isinstance(status_code_or_message, str):
-            if content != b"":
+            if content is not _UNSET:
                 raise TypeError(
                     "NotFoundError(message) does not accept a content argument. "
                     "Use NotFoundError(status_code, content) for HTTP-style construction."
@@ -93,10 +118,16 @@ class NotFoundError(GalileoAPIError):
             self.content = b""
             self.message = status_code_or_message
             Exception.__init__(self, status_code_or_message)
-        elif isinstance(status_code_or_message, int):
+        # mypy narrows to ``int`` here from the ``int | str`` annotation, so the
+        # ``not isinstance(..., bool)`` half looks redundant statically — but at
+        # runtime ``bool`` is an ``int`` subclass, so this guard is real
+        # protection against callers passing ``True``/``False`` accidentally.
+        elif isinstance(status_code_or_message, int) and not isinstance(  # type: ignore[redundant-expr]
+            status_code_or_message, bool
+        ):
             super().__init__(
                 status_code_or_message,
-                content,
+                b"" if content is _UNSET else content,
                 "Resource not found. The requested project, dataset, or resource doesn't exist. "
                 "Verify the ID or name is correct.",
             )

--- a/src/galileo/exceptions.py
+++ b/src/galileo/exceptions.py
@@ -72,7 +72,9 @@ class NotFoundError(GalileoAPIError):
       response (e.g. resolving a project from env vars). The string is the full message.
 
     The two paths are exposed via ``@overload`` so type checkers see the right shape
-    for each call site instead of an opaque ``int | str`` parameter.
+    for each call site instead of an opaque ``int | str`` parameter. The runtime
+    constructor also enforces the contract: mixing the two shapes
+    (e.g. ``NotFoundError("msg", b"body")``) or passing ``None`` raises ``TypeError``.
     """
 
     @overload
@@ -82,16 +84,26 @@ class NotFoundError(GalileoAPIError):
 
     def __init__(self, status_code_or_message: int | str, content: bytes = b"") -> None:
         if isinstance(status_code_or_message, str):
+            if content != b"":
+                raise TypeError(
+                    "NotFoundError(message) does not accept a content argument. "
+                    "Use NotFoundError(status_code, content) for HTTP-style construction."
+                )
             self.status_code = 404
             self.content = b""
             self.message = status_code_or_message
             Exception.__init__(self, status_code_or_message)
-        else:
+        elif isinstance(status_code_or_message, int):
             super().__init__(
                 status_code_or_message,
                 content,
                 "Resource not found. The requested project, dataset, or resource doesn't exist. "
                 "Verify the ID or name is correct.",
+            )
+        else:
+            raise TypeError(
+                "NotFoundError requires either (status_code: int, content: bytes) "
+                f"or (message: str); got {type(status_code_or_message).__name__}."
             )
 
 

--- a/src/galileo/exceptions.py
+++ b/src/galileo/exceptions.py
@@ -60,15 +60,25 @@ class ForbiddenError(GalileoAPIError):
 
 
 class NotFoundError(GalileoAPIError):
-    """HTTP 404 - Resource not found."""
+    """HTTP 404 - Resource not found.
 
-    def __init__(self, status_code: int, content: bytes):
-        super().__init__(
-            status_code,
-            content,
-            "Resource not found. The requested project, dataset, or resource doesn't exist. "
-            "Verify the ID or name is correct.",
-        )
+    Accepts either an HTTP response (status_code, content) or a plain string message for
+    SDK-level lookups where no HTTP response is available.
+    """
+
+    def __init__(self, status_code_or_message: int | str, content: bytes = b""):
+        if isinstance(status_code_or_message, str):
+            self.status_code = 404
+            self.content = b""
+            self.message = status_code_or_message
+            Exception.__init__(self, status_code_or_message)
+        else:
+            super().__init__(
+                status_code_or_message,
+                content,
+                "Resource not found. The requested project, dataset, or resource doesn't exist. "
+                "Verify the ID or name is correct.",
+            )
 
 
 class ConflictError(GalileoAPIError):

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -14,7 +14,6 @@ from galileo.experiments import Experiments as ExperimentsService
 from galileo.experiments import _default_prompt_settings
 from galileo.export import ExportClient
 from galileo.job_progress import get_run_scorer_jobs, job_progress
-from galileo.projects import ProjectNotFoundError, Projects
 from galileo.prompts import PromptTemplate, get_prompt
 from galileo.resources.api.experiment import (
     delete_experiment_projects_project_id_experiments_experiment_id_delete,
@@ -46,8 +45,9 @@ from galileo.schema.filters import FilterType
 from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig, Metric
 from galileo.search import RecordType, Search
 from galileo.shared.base import StateManagementMixin, SyncState
-from galileo.shared.exceptions import ValidationError, _project_not_found_error
+from galileo.shared.exceptions import ValidationError
 from galileo.shared.experiment_result import ExperimentRunResult, ExperimentStatusInfo
+from galileo.shared.project_resolver import _resolve_project
 from galileo.shared.query_result import QueryResult
 
 # TODO: get_records_for_dataset needed for function-based experiments
@@ -383,7 +383,7 @@ class Experiment(StateManagementMixin):
 
         Raises
         ------
-            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback).
+            NotFoundError: If the project cannot be found (no explicit param and no env fallback).
             Exception: If the API call fails.
 
         Examples
@@ -398,19 +398,15 @@ class Experiment(StateManagementMixin):
         if not self.name:
             raise ValueError("Experiment name is not set. Cannot create experiment without a name.")
 
-        # Note: project_id and project_name can both be None here - resolution happens below
-        # via Projects().get_with_env_fallbacks() which reads from env vars
+        # Note: project_id and project_name can both be None here — resolution happens below
+        # via _resolve_project, which reads GALILEO_PROJECT_ID / GALILEO_PROJECT env vars.
 
         try:
             _logger.info(f"Experiment.create: name='{self.name}' project_id='{self.project_id}' - started")
 
-            # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-            try:
-                project_obj = Projects().get_with_env_fallbacks(id=self.project_id, name=self.project_name)
-            except ProjectNotFoundError:
-                project_obj = None
-            if not project_obj:
-                raise _project_not_found_error(self.project_id, self.project_name)
+            # _resolve_project raises NotFoundError when no project can be found, matching
+            # the contract of Experiment.get() and Experiment.list().
+            project_obj = _resolve_project(self.project_id, self.project_name)
 
             self.project_id = project_obj.id
             if self.project_name is None:
@@ -654,7 +650,7 @@ class Experiment(StateManagementMixin):
 
         Raises
         ------
-            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback).
+            NotFoundError: If the project cannot be found (no explicit param and no env fallback).
 
         Examples
         --------
@@ -673,13 +669,7 @@ class Experiment(StateManagementMixin):
             # Get using GALILEO_PROJECT environment variable
             experiment = Experiment.get(name="ml-evaluation")
         """
-        # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-        try:
-            project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
-        except ProjectNotFoundError:
-            project_obj = None
-        if not project_obj:
-            raise _project_not_found_error(project_id, project_name)
+        project_obj = _resolve_project(project_id, project_name)
 
         experiments_service = ExperimentsService()
         retrieved_experiment = experiments_service.get(project_id=project_obj.id, experiment_name=name)
@@ -709,7 +699,7 @@ class Experiment(StateManagementMixin):
 
         Raises
         ------
-            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback).
+            NotFoundError: If the project cannot be found (no explicit param and no env fallback).
 
         Examples
         --------
@@ -722,13 +712,7 @@ class Experiment(StateManagementMixin):
             # List using GALILEO_PROJECT environment variable
             experiments = Experiment.list()
         """
-        # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-        try:
-            project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
-        except ProjectNotFoundError:
-            project_obj = None
-        if not project_obj:
-            raise _project_not_found_error(project_id, project_name)
+        project_obj = _resolve_project(project_id, project_name)
 
         experiments_service = ExperimentsService()
         retrieved_experiments = experiments_service.list(project_id=project_obj.id)

--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -42,10 +42,14 @@ RECORD_TYPE_TO_ROOT_TYPE = {
 
 
 def _resolve_project(project_id: str | None, project_name: str | None) -> ProjectRecord:
-    """Resolve a project from explicit params or env fallbacks, raising NotFoundError on 404."""
+    """Resolve a project from explicit params or env fallbacks, raising ResourceNotFoundError on 404.
+
+    Catches ``ValueError`` from ``Projects.get(id=None, name=None)`` so callers that pass nothing
+    and have no env fallback get the documented not-found error instead of a generic ValueError.
+    """
     try:
         project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
-    except ProjectNotFoundError:
+    except (ProjectNotFoundError, ValueError):
         project_obj = None
     if not project_obj:
         raise _project_not_found_error(project_id, project_name)
@@ -189,13 +193,10 @@ class LogStream(StateManagementMixin):
         try:
             logger.info(f"LogStream.create: name='{self.name}' project_id='{self.project_id}' - started")
 
-            # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
-            try:
-                project_obj = Projects().get_with_env_fallbacks(id=self.project_id, name=self.project_name)
-            except ProjectNotFoundError:
-                project_obj = None
-            if not project_obj:
-                raise _project_not_found_error(self.project_id, self.project_name)
+            # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT).
+            # _resolve_project raises ResourceNotFoundError when no project can be found, matching
+            # the contract of LogStream.get() and LogStream.list().
+            project_obj = _resolve_project(self.project_id, self.project_name)
 
             # Update project info from resolved project
             self.project_id = project_obj.id

--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -10,8 +10,6 @@ from galileo.config import GalileoPythonConfig
 from galileo.decorator import galileo_context
 from galileo.export import ExportClient
 from galileo.log_streams import LogStreams
-from galileo.projects import Project as ProjectRecord
-from galileo.projects import ProjectNotFoundError, Projects
 from galileo.resources.api.trace import (
     sessions_available_columns_projects_project_id_sessions_available_columns_post,
     spans_available_columns_projects_project_id_spans_available_columns_post,
@@ -25,7 +23,8 @@ from galileo.schema.filters import FilterType
 from galileo.schema.metrics import GalileoMetrics, LocalMetricConfig, Metric
 from galileo.search import RecordType, Search
 from galileo.shared.base import StateManagementMixin, SyncState
-from galileo.shared.exceptions import ValidationError, _project_not_found_error
+from galileo.shared.exceptions import ValidationError
+from galileo.shared.project_resolver import _resolve_project
 from galileo.shared.query_result import QueryResult
 
 if TYPE_CHECKING:
@@ -39,21 +38,6 @@ RECORD_TYPE_TO_ROOT_TYPE = {
     RecordType.TRACE: RootType.TRACE,
     RecordType.SESSION: RootType.SESSION,
 }
-
-
-def _resolve_project(project_id: str | None, project_name: str | None) -> ProjectRecord:
-    """Resolve a project from explicit params or env fallbacks, raising ResourceNotFoundError on 404.
-
-    Catches ``ValueError`` from ``Projects.get(id=None, name=None)`` so callers that pass nothing
-    and have no env fallback get the documented not-found error instead of a generic ValueError.
-    """
-    try:
-        project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
-    except (ProjectNotFoundError, ValueError):
-        project_obj = None
-    if not project_obj:
-        raise _project_not_found_error(project_id, project_name)
-    return project_obj
 
 
 class LogStream(StateManagementMixin):
@@ -187,14 +171,13 @@ class LogStream(StateManagementMixin):
         if not self.name:
             raise ValueError("Log stream name is not set. Cannot create log stream without a name.")
 
-        # Note: project_id and project_name can both be None here - resolution happens below
-        # via Projects().get_with_env_fallbacks() which reads from env vars
+        # Note: project_id and project_name can both be None here — resolution happens below
+        # via _resolve_project, which reads GALILEO_PROJECT_ID / GALILEO_PROJECT env vars.
 
         try:
             logger.info(f"LogStream.create: name='{self.name}' project_id='{self.project_id}' - started")
 
-            # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT).
-            # _resolve_project raises ResourceNotFoundError when no project can be found, matching
+            # _resolve_project raises NotFoundError when no project can be found, matching
             # the contract of LogStream.get() and LogStream.list().
             project_obj = _resolve_project(self.project_id, self.project_name)
 

--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -42,7 +42,7 @@ RECORD_TYPE_TO_ROOT_TYPE = {
 
 
 def _resolve_project(project_id: str | None, project_name: str | None) -> ProjectRecord:
-    """Resolve a project from explicit params or env fallbacks, raising ResourceNotFoundError on 404."""
+    """Resolve a project from explicit params or env fallbacks, raising NotFoundError on 404."""
     try:
         project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
     except ProjectNotFoundError:
@@ -172,7 +172,7 @@ class LogStream(StateManagementMixin):
 
         Raises
         ------
-            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback).
+            NotFoundError: If the project cannot be found (no explicit param and no env fallback).
             Exception: If the API call fails.
 
         Examples
@@ -278,7 +278,7 @@ class LogStream(StateManagementMixin):
 
         Raises
         ------
-            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback).
+            NotFoundError: If the project cannot be found (no explicit param and no env fallback).
 
         Examples
         --------
@@ -326,7 +326,7 @@ class LogStream(StateManagementMixin):
 
         Raises
         ------
-            ResourceNotFoundError: If the project cannot be found (no explicit param and no env fallback).
+            NotFoundError: If the project cannot be found (no explicit param and no env fallback).
 
         Examples
         --------

--- a/src/galileo/shared/exceptions.py
+++ b/src/galileo/shared/exceptions.py
@@ -112,11 +112,22 @@ def _project_not_found_error(project_id: str | None, project_name: str | None) -
     and "no identifier was specified at all" (actionable: provide one).
     Falls back to env vars so the message is accurate even when the identifier came from the environment.
 
+    Whitespace-only values (explicit kwargs or env vars) are normalized to ``None`` so callers
+    get the actionable "No project specified" message instead of an empty-quoted identifier
+    like ``Project "   " not found``.
+
     Returns ``ResourceNotFoundError`` (a subclass of :class:`NotFoundError`) so callers using either
     ``except NotFoundError`` or ``except ResourceNotFoundError`` continue to work.
     """
-    effective_id = project_id or _get_project_id_from_env()
-    effective_name = project_name or (None if effective_id else _get_project_from_env())
+
+    def _normalize(value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    effective_id = _normalize(project_id) or _normalize(_get_project_id_from_env())
+    effective_name = _normalize(project_name) or (None if effective_id else _normalize(_get_project_from_env()))
     if effective_name:
         return ResourceNotFoundError(
             f'Project "{effective_name}" not found. '

--- a/src/galileo/shared/exceptions.py
+++ b/src/galileo/shared/exceptions.py
@@ -110,13 +110,43 @@ def _normalize_identifier(value: str | None) -> str | None:
 
     Mirrors the trimming :meth:`galileo.projects.Projects.get` does internally,
     so callers that pre-check identifiers see the same "effectively empty"
-    values the API client would see. Shared by :func:`_project_not_found_error`
-    and :func:`galileo.shared.project_resolver._resolve_project`.
+    values the API client would see.
     """
     if value is None:
         return None
     stripped = value.strip()
     return stripped or None
+
+
+def _resolve_project_identifiers(project_id: str | None, project_name: str | None) -> tuple[str | None, str | None]:
+    """Apply env-fallback precedence to produce a normalized ``(id, name)`` tuple.
+
+    Matches the precedence documented by :meth:`galileo.projects.Projects.get_with_env_fallbacks`
+    exactly: explicit ``project_id`` > explicit ``project_name`` > ``GALILEO_PROJECT_ID``
+    > ``GALILEO_PROJECT``. Once an id is chosen, name is dropped; once a name is chosen,
+    env-id is *not* consulted (an explicit name suppresses env-id fallback).
+
+    Whitespace-only values (explicit kwargs or env vars) are treated as missing, so
+    ``" "`` follows the same path as ``None`` instead of leaking a raw ``ValueError``
+    from the API client's internal strip-and-validate.
+
+    Shared by :func:`_project_not_found_error` (uses the result for error-message
+    context) and :func:`galileo.shared.project_resolver._resolve_project` (uses the
+    result for both the pre-check and the actual API call).
+    """
+    explicit_id = _normalize_identifier(project_id)
+    if explicit_id:
+        return explicit_id, None
+    explicit_name = _normalize_identifier(project_name)
+    if explicit_name:
+        return None, explicit_name
+    env_id = _normalize_identifier(_get_project_id_from_env())
+    if env_id:
+        return env_id, None
+    env_name = _normalize_identifier(_get_project_from_env())
+    if env_name:
+        return None, env_name
+    return None, None
 
 
 def _project_not_found_error(project_id: str | None, project_name: str | None) -> "ResourceNotFoundError":
@@ -133,10 +163,7 @@ def _project_not_found_error(project_id: str | None, project_name: str | None) -
     Returns ``ResourceNotFoundError`` (a subclass of :class:`NotFoundError`) so callers using either
     ``except NotFoundError`` or ``except ResourceNotFoundError`` continue to work.
     """
-    effective_id = _normalize_identifier(project_id) or _normalize_identifier(_get_project_id_from_env())
-    effective_name = _normalize_identifier(project_name) or (
-        None if effective_id else _normalize_identifier(_get_project_from_env())
-    )
+    effective_id, effective_name = _resolve_project_identifiers(project_id, project_name)
     if effective_name:
         return ResourceNotFoundError(
             f'Project "{effective_name}" not found. '

--- a/src/galileo/shared/exceptions.py
+++ b/src/galileo/shared/exceptions.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from galileo.exceptions import NotFoundError
 from galileo.utils.env_helpers import _get_project_from_env, _get_project_id_from_env
 
 
@@ -29,12 +30,16 @@ class ValidationError(GalileoFutureError):
     """
 
 
-class ResourceNotFoundError(GalileoFutureError):
+class ResourceNotFoundError(NotFoundError, GalileoFutureError):
     """
-    Raised when a requested resource cannot be found.
+    Backward-compatible alias for NotFoundError.
 
-    This includes projects, datasets, prompts, or log streams that don't exist.
+    Raised when a requested resource cannot be found.
+    New code should catch NotFoundError instead.
     """
+
+    def __init__(self, message: str):
+        NotFoundError.__init__(self, message)
 
 
 class ResourceConflictError(GalileoFutureError):
@@ -100,8 +105,8 @@ class IntegrationNotConfiguredError(GalileoFutureError):
         self.integration_name = integration_name
 
 
-def _project_not_found_error(project_id: str | None, project_name: str | None) -> "ResourceNotFoundError":
-    """Return a context-aware ResourceNotFoundError for a missing project.
+def _project_not_found_error(project_id: str | None, project_name: str | None) -> "NotFoundError":
+    """Return a context-aware NotFoundError for a missing project.
 
     Distinguishes between "a name/id was given but the project doesn't exist" (actionable: create it)
     and "no identifier was specified at all" (actionable: provide one).
@@ -110,15 +115,13 @@ def _project_not_found_error(project_id: str | None, project_name: str | None) -
     effective_id = project_id or _get_project_id_from_env()
     effective_name = project_name or (None if effective_id else _get_project_from_env())
     if effective_name:
-        return ResourceNotFoundError(
+        return NotFoundError(
             f'Project "{effective_name}" not found. '
             f'Use Project(name="{effective_name}").create() or the Galileo UI to create it first.'
         )
     if effective_id:
-        return ResourceNotFoundError(
+        return NotFoundError(
             f'Project with id "{effective_id}" not found. '
             "Use Project(name=...).create() or the Galileo UI to create a project first."
         )
-    return ResourceNotFoundError(
-        "No project specified. Provide project_id, project_name, or set GALILEO_PROJECT env var."
-    )
+    return NotFoundError("No project specified. Provide project_id, project_name, or set GALILEO_PROJECT env var.")

--- a/src/galileo/shared/exceptions.py
+++ b/src/galileo/shared/exceptions.py
@@ -105,23 +105,28 @@ class IntegrationNotConfiguredError(GalileoFutureError):
         self.integration_name = integration_name
 
 
-def _project_not_found_error(project_id: str | None, project_name: str | None) -> "NotFoundError":
-    """Return a context-aware NotFoundError for a missing project.
+def _project_not_found_error(project_id: str | None, project_name: str | None) -> "ResourceNotFoundError":
+    """Return a context-aware ResourceNotFoundError for a missing project.
 
     Distinguishes between "a name/id was given but the project doesn't exist" (actionable: create it)
     and "no identifier was specified at all" (actionable: provide one).
     Falls back to env vars so the message is accurate even when the identifier came from the environment.
+
+    Returns ``ResourceNotFoundError`` (a subclass of :class:`NotFoundError`) so callers using either
+    ``except NotFoundError`` or ``except ResourceNotFoundError`` continue to work.
     """
     effective_id = project_id or _get_project_id_from_env()
     effective_name = project_name or (None if effective_id else _get_project_from_env())
     if effective_name:
-        return NotFoundError(
+        return ResourceNotFoundError(
             f'Project "{effective_name}" not found. '
             f'Use Project(name="{effective_name}").create() or the Galileo UI to create it first.'
         )
     if effective_id:
-        return NotFoundError(
+        return ResourceNotFoundError(
             f'Project with id "{effective_id}" not found. '
             "Use Project(name=...).create() or the Galileo UI to create a project first."
         )
-    return NotFoundError("No project specified. Provide project_id, project_name, or set GALILEO_PROJECT env var.")
+    return ResourceNotFoundError(
+        "No project specified. Provide project_id, project_name, or set GALILEO_PROJECT env var."
+    )

--- a/src/galileo/shared/exceptions.py
+++ b/src/galileo/shared/exceptions.py
@@ -105,6 +105,20 @@ class IntegrationNotConfiguredError(GalileoFutureError):
         self.integration_name = integration_name
 
 
+def _normalize_identifier(value: str | None) -> str | None:
+    """Strip and return ``None`` for empty/whitespace-only inputs.
+
+    Mirrors the trimming :meth:`galileo.projects.Projects.get` does internally,
+    so callers that pre-check identifiers see the same "effectively empty"
+    values the API client would see. Shared by :func:`_project_not_found_error`
+    and :func:`galileo.shared.project_resolver._resolve_project`.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def _project_not_found_error(project_id: str | None, project_name: str | None) -> "ResourceNotFoundError":
     """Return a context-aware ResourceNotFoundError for a missing project.
 
@@ -119,15 +133,10 @@ def _project_not_found_error(project_id: str | None, project_name: str | None) -
     Returns ``ResourceNotFoundError`` (a subclass of :class:`NotFoundError`) so callers using either
     ``except NotFoundError`` or ``except ResourceNotFoundError`` continue to work.
     """
-
-    def _normalize(value: str | None) -> str | None:
-        if value is None:
-            return None
-        stripped = value.strip()
-        return stripped or None
-
-    effective_id = _normalize(project_id) or _normalize(_get_project_id_from_env())
-    effective_name = _normalize(project_name) or (None if effective_id else _normalize(_get_project_from_env()))
+    effective_id = _normalize_identifier(project_id) or _normalize_identifier(_get_project_id_from_env())
+    effective_name = _normalize_identifier(project_name) or (
+        None if effective_id else _normalize_identifier(_get_project_from_env())
+    )
     if effective_name:
         return ResourceNotFoundError(
             f'Project "{effective_name}" not found. '

--- a/src/galileo/shared/project_resolver.py
+++ b/src/galileo/shared/project_resolver.py
@@ -1,0 +1,44 @@
+"""Shared helper for resolving a project from explicit params or env fallbacks.
+
+Lives alongside :func:`galileo.shared.exceptions._project_not_found_error` so the
+two helpers — "how to find a project" and "what error to raise when you can't" —
+sit in one place and can be reused by every ``__future__`` domain object
+(LogStream, Experiment, …) instead of being duplicated per-class.
+"""
+
+from __future__ import annotations
+
+from galileo.projects import Project as ProjectRecord
+from galileo.projects import ProjectNotFoundError, Projects
+from galileo.shared.exceptions import _project_not_found_error
+from galileo.utils.env_helpers import _get_project_from_env, _get_project_id_from_env
+
+
+def _resolve_project(project_id: str | None, project_name: str | None) -> ProjectRecord:
+    """Resolve a project from explicit params or env fallbacks.
+
+    Resolution order matches :meth:`galileo.projects.Projects.get_with_env_fallbacks`:
+    explicit ``project_id`` > ``GALILEO_PROJECT_ID`` > explicit ``project_name``
+    > ``GALILEO_PROJECT``.
+
+    Raises ``NotFoundError`` (specifically the ``ResourceNotFoundError`` subclass for
+    backward compat) when no project can be located. Catching either type works.
+
+    The helper pre-checks "no identifier anywhere" so it never relies on the
+    ``ValueError`` ``Projects.get(id=None, name=None)`` raises in that one case —
+    unrelated ``ValueError``s from the API client surface unchanged.
+    """
+    # Pre-check before delegating: when no identifier is available anywhere,
+    # surface the documented not-found error directly instead of going through
+    # the API client (whose only ValueError source for this call is exactly
+    # "neither id nor name available", which we already know).
+    if not project_id and not project_name and not _get_project_id_from_env() and not _get_project_from_env():
+        raise _project_not_found_error(None, None)
+
+    try:
+        project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+    except ProjectNotFoundError:
+        project_obj = None
+    if not project_obj:
+        raise _project_not_found_error(project_id, project_name)
+    return project_obj

--- a/src/galileo/shared/project_resolver.py
+++ b/src/galileo/shared/project_resolver.py
@@ -10,43 +10,32 @@ from __future__ import annotations
 
 from galileo.projects import Project as ProjectRecord
 from galileo.projects import ProjectNotFoundError, Projects
-from galileo.shared.exceptions import _normalize_identifier, _project_not_found_error
-from galileo.utils.env_helpers import _get_project_from_env, _get_project_id_from_env
+from galileo.shared.exceptions import _project_not_found_error, _resolve_project_identifiers
 
 
 def _resolve_project(project_id: str | None, project_name: str | None) -> ProjectRecord:
     """Resolve a project from explicit params or env fallbacks.
 
-    Resolution order matches :meth:`galileo.projects.Projects.get_with_env_fallbacks`:
-    explicit ``project_id`` > ``GALILEO_PROJECT_ID`` > explicit ``project_name``
-    > ``GALILEO_PROJECT``.
+    Identifier precedence and whitespace handling are delegated to
+    :func:`galileo.shared.exceptions._resolve_project_identifiers`, which matches
+    the contract of :meth:`galileo.projects.Projects.get_with_env_fallbacks`.
 
     Raises ``NotFoundError`` (specifically the ``ResourceNotFoundError`` subclass for
     backward compat) when no project can be located. Catching either type works.
 
     The helper pre-checks "no identifier anywhere" so it never relies on the
     ``ValueError`` ``Projects.get(id=None, name=None)`` raises in that one case —
-    unrelated ``ValueError``s from the API client surface unchanged. Inputs are
-    trimmed before the pre-check so whitespace-only values follow the same
-    not-found path as missing values instead of leaking a client ``ValueError``.
+    unrelated ``ValueError``s from the API client surface unchanged.
     """
-    # Normalize before the pre-check so whitespace-only values (e.g. ``" "``)
-    # are treated as missing — otherwise ``Projects.get`` strips them and raises
-    # the unrelated "Exactly one of 'id' or 'name'" ValueError downstream.
-    normalized_id = _normalize_identifier(project_id) or _normalize_identifier(_get_project_id_from_env())
-    normalized_name = (
-        None
-        if normalized_id
-        else (_normalize_identifier(project_name) or _normalize_identifier(_get_project_from_env()))
-    )
+    resolved_id, resolved_name = _resolve_project_identifiers(project_id, project_name)
 
-    if not normalized_id and not normalized_name:
+    if not resolved_id and not resolved_name:
         raise _project_not_found_error(None, None)
 
     try:
-        project_obj = Projects().get_with_env_fallbacks(id=normalized_id, name=normalized_name)
+        project_obj = Projects().get_with_env_fallbacks(id=resolved_id, name=resolved_name)
     except ProjectNotFoundError:
         project_obj = None
     if not project_obj:
-        raise _project_not_found_error(normalized_id, normalized_name)
+        raise _project_not_found_error(resolved_id, resolved_name)
     return project_obj

--- a/src/galileo/shared/project_resolver.py
+++ b/src/galileo/shared/project_resolver.py
@@ -14,6 +14,19 @@ from galileo.shared.exceptions import _project_not_found_error
 from galileo.utils.env_helpers import _get_project_from_env, _get_project_id_from_env
 
 
+def _normalize(value: str | None) -> str | None:
+    """Strip and return ``None`` for empty/whitespace-only inputs.
+
+    Mirrors the trimming :meth:`galileo.projects.Projects.get` does internally,
+    so the pre-check below sees the same "effectively empty" value the API
+    client would see.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def _resolve_project(project_id: str | None, project_name: str | None) -> ProjectRecord:
     """Resolve a project from explicit params or env fallbacks.
 
@@ -26,19 +39,23 @@ def _resolve_project(project_id: str | None, project_name: str | None) -> Projec
 
     The helper pre-checks "no identifier anywhere" so it never relies on the
     ``ValueError`` ``Projects.get(id=None, name=None)`` raises in that one case —
-    unrelated ``ValueError``s from the API client surface unchanged.
+    unrelated ``ValueError``s from the API client surface unchanged. Inputs are
+    trimmed before the pre-check so whitespace-only values follow the same
+    not-found path as missing values instead of leaking a client ``ValueError``.
     """
-    # Pre-check before delegating: when no identifier is available anywhere,
-    # surface the documented not-found error directly instead of going through
-    # the API client (whose only ValueError source for this call is exactly
-    # "neither id nor name available", which we already know).
-    if not project_id and not project_name and not _get_project_id_from_env() and not _get_project_from_env():
+    # Normalize before the pre-check so whitespace-only values (e.g. ``" "``)
+    # are treated as missing — otherwise ``Projects.get`` strips them and raises
+    # the unrelated "Exactly one of 'id' or 'name'" ValueError downstream.
+    normalized_id = _normalize(project_id) or _normalize(_get_project_id_from_env())
+    normalized_name = None if normalized_id else (_normalize(project_name) or _normalize(_get_project_from_env()))
+
+    if not normalized_id and not normalized_name:
         raise _project_not_found_error(None, None)
 
     try:
-        project_obj = Projects().get_with_env_fallbacks(id=project_id, name=project_name)
+        project_obj = Projects().get_with_env_fallbacks(id=normalized_id, name=normalized_name)
     except ProjectNotFoundError:
         project_obj = None
     if not project_obj:
-        raise _project_not_found_error(project_id, project_name)
+        raise _project_not_found_error(normalized_id, normalized_name)
     return project_obj

--- a/src/galileo/shared/project_resolver.py
+++ b/src/galileo/shared/project_resolver.py
@@ -10,21 +10,8 @@ from __future__ import annotations
 
 from galileo.projects import Project as ProjectRecord
 from galileo.projects import ProjectNotFoundError, Projects
-from galileo.shared.exceptions import _project_not_found_error
+from galileo.shared.exceptions import _normalize_identifier, _project_not_found_error
 from galileo.utils.env_helpers import _get_project_from_env, _get_project_id_from_env
-
-
-def _normalize(value: str | None) -> str | None:
-    """Strip and return ``None`` for empty/whitespace-only inputs.
-
-    Mirrors the trimming :meth:`galileo.projects.Projects.get` does internally,
-    so the pre-check below sees the same "effectively empty" value the API
-    client would see.
-    """
-    if value is None:
-        return None
-    stripped = value.strip()
-    return stripped or None
 
 
 def _resolve_project(project_id: str | None, project_name: str | None) -> ProjectRecord:
@@ -46,8 +33,12 @@ def _resolve_project(project_id: str | None, project_name: str | None) -> Projec
     # Normalize before the pre-check so whitespace-only values (e.g. ``" "``)
     # are treated as missing — otherwise ``Projects.get`` strips them and raises
     # the unrelated "Exactly one of 'id' or 'name'" ValueError downstream.
-    normalized_id = _normalize(project_id) or _normalize(_get_project_id_from_env())
-    normalized_name = None if normalized_id else (_normalize(project_name) or _normalize(_get_project_from_env()))
+    normalized_id = _normalize_identifier(project_id) or _normalize_identifier(_get_project_id_from_env())
+    normalized_name = (
+        None
+        if normalized_id
+        else (_normalize_identifier(project_name) or _normalize_identifier(_get_project_from_env()))
+    )
 
     if not normalized_id and not normalized_name:
         raise _project_not_found_error(None, None)

--- a/tests/shared/test_project_resolver.py
+++ b/tests/shared/test_project_resolver.py
@@ -153,3 +153,28 @@ class TestResolveProject:
         # Then: the trimmed value is forwarded to get_with_env_fallbacks
         assert resolved is mock_project
         mock_service.get_with_env_fallbacks.assert_called_once_with(id=None, name="P One")
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_explicit_name_suppresses_env_id_fallback(
+        self, mock_projects_class: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit ``project_name`` must beat ``GALILEO_PROJECT_ID``.
+
+        ``Projects.get_with_env_fallbacks`` documents that an explicit name suppresses
+        the env-id fallback (``id = id or (None if name else env_id)``). The resolver
+        must match this precedence so it doesn't silently look up the wrong project.
+        """
+        # Given: GALILEO_PROJECT_ID is set, but the caller passed an explicit name
+        monkeypatch.setenv("GALILEO_PROJECT_ID", "env-id-should-be-ignored")
+        mock_project = MagicMock()
+        mock_project.id = "name-resolved-id"
+        mock_project.name = "Explicit Name"
+        mock_service = MagicMock()
+        mock_projects_class.return_value = mock_service
+        mock_service.get_with_env_fallbacks.return_value = mock_project
+
+        # When: resolving with explicit project_name only
+        _resolve_project(project_id=None, project_name="Explicit Name")
+
+        # Then: get_with_env_fallbacks is called with the name, NOT the env id
+        mock_service.get_with_env_fallbacks.assert_called_once_with(id=None, name="Explicit Name")

--- a/tests/shared/test_project_resolver.py
+++ b/tests/shared/test_project_resolver.py
@@ -97,3 +97,59 @@ class TestResolveProject:
         # When/Then: a NotFoundError naming the requested project is raised
         with pytest.raises(NotFoundError, match='Project "Missing"'):
             _resolve_project(project_id=None, project_name="Missing")
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_whitespace_only_explicit_args_treated_as_missing(
+        self, mock_projects_class: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Whitespace-only kwargs must follow the same NotFoundError path as ``None``.
+
+        ``Projects.get`` strips inputs before validation, so ``" "`` ends up indistinguishable
+        from ``None`` and raises a generic ``ValueError``. The resolver normalizes
+        whitespace up-front so the user gets the documented ``NotFoundError`` instead.
+        """
+        # Given: env vars unset; explicit kwargs are whitespace-only
+        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
+        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+
+        # When/Then: resolver short-circuits without instantiating Projects
+        with pytest.raises(NotFoundError, match="No project specified"):
+            _resolve_project(project_id="   ", project_name="\t\n")
+        mock_projects_class.assert_not_called()
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_whitespace_only_env_vars_treated_as_missing(
+        self, mock_projects_class: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Whitespace-only env vars must also be treated as missing.
+
+        Without normalization, ``GALILEO_PROJECT="  "`` would pass the truthy
+        pre-check, hit ``Projects().get_with_env_fallbacks``, and leak a raw
+        ``ValueError`` after the API client strips it.
+        """
+        # Given: GALILEO_PROJECT is set but only contains whitespace
+        monkeypatch.setenv("GALILEO_PROJECT", "   ")
+        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+
+        # When/Then: resolver short-circuits with NotFoundError
+        with pytest.raises(NotFoundError, match="No project specified"):
+            _resolve_project(project_id=None, project_name=None)
+        mock_projects_class.assert_not_called()
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_strips_whitespace_around_valid_identifier(self, mock_projects_class: MagicMock) -> None:
+        """A valid identifier with surrounding whitespace is trimmed before delegation."""
+        # Given: a project that resolves successfully
+        mock_project = MagicMock()
+        mock_project.id = "p-1"
+        mock_project.name = "P One"
+        mock_service = MagicMock()
+        mock_projects_class.return_value = mock_service
+        mock_service.get_with_env_fallbacks.return_value = mock_project
+
+        # When: resolving with whitespace-padded project_name
+        resolved = _resolve_project(project_id=None, project_name="  P One  ")
+
+        # Then: the trimmed value is forwarded to get_with_env_fallbacks
+        assert resolved is mock_project
+        mock_service.get_with_env_fallbacks.assert_called_once_with(id=None, name="P One")

--- a/tests/shared/test_project_resolver.py
+++ b/tests/shared/test_project_resolver.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``galileo.shared.project_resolver._resolve_project``.
+
+The resolver is the single canonical entry point used by every ``__future__``
+domain object (LogStream, Experiment, …) to turn explicit kwargs / env vars
+into a concrete project. These tests pin its contract so future callers
+behave consistently.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from galileo.exceptions import NotFoundError
+from galileo.projects import ProjectNotFoundError
+from galileo.shared.exceptions import ResourceNotFoundError
+from galileo.shared.project_resolver import _resolve_project
+
+
+class TestResolveProject:
+    """Behavioral tests for the shared ``_resolve_project`` helper."""
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_returns_project_when_get_with_env_fallbacks_succeeds(self, mock_projects_class: MagicMock) -> None:
+        # Given: an explicit project_id that resolves to a known project
+        mock_project = MagicMock()
+        mock_project.id = "p-1"
+        mock_project.name = "P One"
+        mock_service = MagicMock()
+        mock_projects_class.return_value = mock_service
+        mock_service.get_with_env_fallbacks.return_value = mock_project
+
+        # When: resolving with that project_id
+        resolved = _resolve_project(project_id="p-1", project_name=None)
+
+        # Then: the project is returned and get_with_env_fallbacks was called once
+        assert resolved is mock_project
+        mock_service.get_with_env_fallbacks.assert_called_once_with(id="p-1", name=None)
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_short_circuits_when_no_identifier_anywhere(
+        self, mock_projects_class: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No id, no name, no env vars must raise without touching the API client."""
+        # Given: env vars are unset
+        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
+        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+
+        # When/Then: resolving raises NotFoundError without instantiating Projects
+        with pytest.raises(NotFoundError, match="No project specified"):
+            _resolve_project(project_id=None, project_name=None)
+        mock_projects_class.assert_not_called()
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_returns_resource_not_found_subclass(
+        self, mock_projects_class: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Backward-compat: the raised error is also a ResourceNotFoundError."""
+        # Given: no identifier anywhere
+        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
+        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+
+        # When/Then: the raised exception is BOTH a NotFoundError and a ResourceNotFoundError
+        with pytest.raises(NotFoundError) as exc_info:
+            _resolve_project(project_id=None, project_name=None)
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_converts_project_not_found_error_to_not_found_error(self, mock_projects_class: MagicMock) -> None:
+        # Given: an explicit id that the API reports as not found
+        mock_service = MagicMock()
+        mock_projects_class.return_value = mock_service
+        mock_service.get_with_env_fallbacks.side_effect = ProjectNotFoundError("not found")
+
+        # When/Then: the project-not-found error is rewritten with actionable context
+        with pytest.raises(NotFoundError, match='Project with id "missing-id" not found'):
+            _resolve_project(project_id="missing-id", project_name=None)
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_does_not_swallow_unrelated_value_error(self, mock_projects_class: MagicMock) -> None:
+        """Unrelated ValueErrors from the API client surface unchanged."""
+        # Given: the API client raises a generic ValueError (e.g. deserialization)
+        mock_service = MagicMock()
+        mock_projects_class.return_value = mock_service
+        mock_service.get_with_env_fallbacks.side_effect = ValueError("response decode failed")
+
+        # When/Then: the ValueError propagates instead of being rewritten as NotFoundError
+        with pytest.raises(ValueError, match="response decode failed"):
+            _resolve_project(project_id="some-id", project_name=None)
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_raises_not_found_when_get_with_env_fallbacks_returns_none(self, mock_projects_class: MagicMock) -> None:
+        # Given: get_with_env_fallbacks returns None (project not found, no exception)
+        mock_service = MagicMock()
+        mock_projects_class.return_value = mock_service
+        mock_service.get_with_env_fallbacks.return_value = None
+
+        # When/Then: a NotFoundError naming the requested project is raised
+        with pytest.raises(NotFoundError, match='Project "Missing"'):
+            _resolve_project(project_id=None, project_name="Missing")

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -204,7 +204,7 @@ class TestExperimentEnvFallback:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_uses_env_fallback_when_no_project_specified(
         self,
@@ -216,9 +216,11 @@ class TestExperimentEnvFallback:
         reset_configuration: None,
         mock_experiment_response: MagicMock,
         mock_project: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test create() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: env fallback resolves to a project
+        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = mock_project
@@ -242,7 +244,7 @@ class TestExperimentEnvFallback:
         assert experiment.project_id == mock_project.id
         assert experiment.is_synced()
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_create_raises_named_error_when_project_name_not_found(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -262,7 +264,7 @@ class TestExperimentEnvFallback:
         with pytest.raises(ResourceNotFoundError, match=r'Project "my-nonexistent-project" not found'):
             experiment.create()
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_create_raises_error_when_no_project_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -279,7 +281,7 @@ class TestExperimentEnvFallback:
 
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_without_prompt_succeeds(
         self,
@@ -318,7 +320,7 @@ class TestExperimentEnvFallback:
         assert kwargs.get("prompt_template") is None
         assert kwargs.get("prompt_settings") is None
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_get_uses_env_fallback_when_no_project_specified(
         self,
@@ -327,9 +329,11 @@ class TestExperimentEnvFallback:
         reset_configuration: None,
         mock_experiment_response: MagicMock,
         mock_project: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test get() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: env fallback resolves to a project
+        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = mock_project
@@ -345,7 +349,7 @@ class TestExperimentEnvFallback:
         mock_projects_service.get_with_env_fallbacks.assert_called_once()
         assert experiment.project_id == mock_project.id
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_get_raises_error_when_no_project_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -359,7 +363,7 @@ class TestExperimentEnvFallback:
         with pytest.raises(ResourceNotFoundError, match="No project specified"):
             Experiment.get(name="Test Experiment")
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_list_uses_env_fallback_when_no_project_specified(
         self,
@@ -367,9 +371,11 @@ class TestExperimentEnvFallback:
         mock_projects_class: MagicMock,
         reset_configuration: None,
         mock_project: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test list() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: env fallback resolves to a project
+        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = mock_project
@@ -385,7 +391,7 @@ class TestExperimentEnvFallback:
         mock_projects_service.get_with_env_fallbacks.assert_called_once()
         assert experiments == []
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_list_raises_error_when_no_project_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -399,6 +405,27 @@ class TestExperimentEnvFallback:
         with pytest.raises(ResourceNotFoundError, match="No project specified"):
             Experiment.list()
 
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_list_no_project_no_env_does_not_leak_value_error(
+        self, mock_projects_class: MagicMock, reset_configuration: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: Experiment.list() with no project/no env used to leak a raw ValueError.
+
+        Before the shared resolver, ``Experiment.list()`` called
+        ``Projects().get_with_env_fallbacks(None, None)`` which raised ``ValueError`` from
+        ``Projects.get(id=None, name=None)``. The error wasn't caught (only
+        ``ProjectNotFoundError`` was), so callers saw a ``ValueError`` instead of the
+        documented ``NotFoundError``. The shared ``_resolve_project`` fixes this.
+        """
+        # Given: env vars are unset
+        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
+        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+
+        # When/Then: NotFoundError is raised without instantiating Projects or leaking ValueError
+        with pytest.raises(ResourceNotFoundError, match="No project specified"):
+            Experiment.list()
+        mock_projects_class.assert_not_called()
+
 
 class TestExperimentCreate:
     """Test suite for Experiment.create() method."""
@@ -406,7 +433,7 @@ class TestExperimentCreate:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_persists_and_triggers_experiment(
         self,
@@ -456,7 +483,7 @@ class TestExperimentCreate:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_handles_existing_experiment_with_timestamp(
         self,
@@ -502,7 +529,7 @@ class TestExperimentCreate:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_handles_api_failure(
         self,
@@ -544,7 +571,7 @@ class TestExperimentCreate:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_fills_default_prompt_settings_for_prompt_template(
         self,
@@ -597,7 +624,7 @@ class TestExperimentCreate:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_preserves_user_prompt_settings_when_overriding_model_alias(
         self,
@@ -654,7 +681,7 @@ class TestExperimentCreate:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_treats_not_found_as_no_existing_experiment(
         self,
@@ -705,7 +732,7 @@ class TestExperimentCreate:
 class TestExperimentGet:
     """Test suite for Experiment.get() class method."""
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_get_retrieves_experiment_by_name(
         self,
@@ -735,7 +762,7 @@ class TestExperimentGet:
         assert experiment.is_synced()
         assert experiment.project_id == mock_project.id
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_get_returns_none_when_not_found(
         self,
@@ -764,7 +791,7 @@ class TestExperimentGet:
 class TestExperimentList:
     """Test suite for Experiment.list() class method."""
 
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_list_retrieves_all_experiments(
         self,
@@ -867,7 +894,7 @@ class TestExperimentRun:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_run_raises_error_on_second_call_after_result_consumed(
         self,
@@ -916,7 +943,7 @@ class TestExperimentRun:
     @patch("galileo.experiment.create_metric_configs")
     @patch("galileo.experiment.get_prompt")
     @patch("galileo.experiment.load_dataset_and_records")
-    @patch("galileo.experiment.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.experiment.ExperimentsService")
     def test_create_run_create_run_resets_consumed_flag(
         self,

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytest
 
+from galileo.exceptions import NotFoundError
 from galileo.log_stream import LogStream
 from galileo.projects import ProjectNotFoundError, ProjectsAPIException
 from galileo.resources.models import LLMExportFormat, LogRecordsSortClause, RootType
@@ -11,7 +12,7 @@ from galileo.resources.models.step_type import StepType
 from galileo.search import RecordType
 from galileo.shared.base import SyncState
 from galileo.shared.column import ColumnCollection
-from galileo.shared.exceptions import ResourceNotFoundError, ValidationError
+from galileo.shared.exceptions import ValidationError
 from galileo.shared.query_result import QueryResult
 
 
@@ -167,14 +168,14 @@ class TestLogStreamCreate:
         log_stream = LogStream(name="Test Stream", project_name="my-nonexistent-project")
 
         # Then: error names the project the user specified, not generic guidance
-        with pytest.raises(ResourceNotFoundError, match=r'Project "my-nonexistent-project" not found'):
+        with pytest.raises(NotFoundError, match=r'Project "my-nonexistent-project" not found'):
             log_stream.create()
 
     @patch("galileo.log_stream.Projects")
     def test_create_without_project_info_raises_error(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test create() raises ResourceNotFoundError naming the project that wasn't found."""
+        """Test create() raises NotFoundError naming the project that wasn't found."""
         # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
@@ -187,8 +188,8 @@ class TestLogStreamCreate:
         log_stream.project_name = None
         log_stream._set_state(SyncState.LOCAL_ONLY)
 
-        # When/Then: Create() raises ResourceNotFoundError with guidance to provide a project identifier
-        with pytest.raises(ResourceNotFoundError, match="No project specified"):
+        # When/Then: Create() raises NotFoundError with guidance to provide a project identifier
+        with pytest.raises(NotFoundError, match="No project specified"):
             log_stream.create()
 
 
@@ -285,28 +286,28 @@ class TestLogStreamGet:
     def test_get_raises_error_without_project_info_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test get() raises ResourceNotFoundError naming the project that wasn't found."""
+        """Test get() raises NotFoundError naming the project that wasn't found."""
         # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
 
-        # When/Then: Calling get raises ResourceNotFoundError with guidance to provide a project identifier
-        with pytest.raises(ResourceNotFoundError, match="No project specified"):
+        # When/Then: Calling get raises NotFoundError with guidance to provide a project identifier
+        with pytest.raises(NotFoundError, match="No project specified"):
             LogStream.get(name="Test Stream")
 
     @patch("galileo.log_stream.Projects")
-    def test_get_raises_resource_not_found_when_project_id_unknown(
+    def test_get_raises_not_found_when_project_id_unknown(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test get() raises ResourceNotFoundError including the project_id when HTTP 404 is returned."""
+        """Test get() raises NotFoundError including the project_id when HTTP 404 is returned."""
         # Given: the projects service raises ProjectNotFoundError (HTTP 404) for an unknown project_id
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.side_effect = ProjectNotFoundError("not found")
 
-        # When/Then: calling get with an unknown project_id raises ResourceNotFoundError with the id in the message
-        with pytest.raises(ResourceNotFoundError, match=r'Project with id "unknown-id" not found'):
+        # When/Then: calling get with an unknown project_id raises NotFoundError with the id in the message
+        with pytest.raises(NotFoundError, match=r'Project with id "unknown-id" not found'):
             LogStream.get(name="Test Stream", project_id="unknown-id")
 
     @patch("galileo.log_stream.Projects")
@@ -435,28 +436,28 @@ class TestLogStreamList:
     def test_list_raises_error_without_project_info_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test list() raises ResourceNotFoundError naming the project that wasn't found."""
+        """Test list() raises NotFoundError naming the project that wasn't found."""
         # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
 
-        # When/Then: Calling list raises ResourceNotFoundError with guidance to provide a project identifier
-        with pytest.raises(ResourceNotFoundError, match="No project specified"):
+        # When/Then: Calling list raises NotFoundError with guidance to provide a project identifier
+        with pytest.raises(NotFoundError, match="No project specified"):
             LogStream.list()
 
     @patch("galileo.log_stream.Projects")
-    def test_list_raises_resource_not_found_when_project_id_unknown(
+    def test_list_raises_not_found_when_project_id_unknown(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
-        """Test list() raises ResourceNotFoundError including the project_id when HTTP 404 is returned."""
+        """Test list() raises NotFoundError including the project_id when HTTP 404 is returned."""
         # Given: the projects service raises ProjectNotFoundError (HTTP 404) for an unknown project_id
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.side_effect = ProjectNotFoundError("not found")
 
-        # When/Then: calling list with an unknown project_id raises ResourceNotFoundError with the id in the message
-        with pytest.raises(ResourceNotFoundError, match=r'Project with id "unknown-id" not found'):
+        # When/Then: calling list with an unknown project_id raises NotFoundError with the id in the message
+        with pytest.raises(NotFoundError, match=r'Project with id "unknown-id" not found'):
             LogStream.list(project_id="unknown-id")
 
     @patch("galileo.log_stream.Projects")

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -1135,8 +1135,22 @@ class TestNotFoundErrorOverloads:
         with pytest.raises(TypeError, match="does not accept a content argument"):
             NotFoundError("a message", b"junk")  # type: ignore[call-overload]
 
+    def test_mixing_message_with_empty_content_raises_type_error(self) -> None:
+        # When/Then: even empty bytes count as "explicitly provided" on the message
+        # path. Using a sentinel default lets the guard reject this misuse instead
+        # of silently treating ``b""`` as the omitted-default.
+        with pytest.raises(TypeError, match="does not accept a content argument"):
+            NotFoundError("a message", b"")  # type: ignore[call-overload]
+
     def test_none_first_arg_raises_type_error(self) -> None:
         # When/Then: ``None`` is neither a status code nor a message; the previous
         # implementation fell through to GalileoAPIError and produced "HTTP None".
         with pytest.raises(TypeError, match="requires either"):
             NotFoundError(None)  # type: ignore[call-overload]
+
+    def test_bool_first_arg_raises_type_error(self) -> None:
+        # When/Then: ``bool`` is technically an ``int`` subclass, so a plain
+        # ``isinstance(x, int)`` would let ``NotFoundError(True, b"x")`` produce
+        # an error with ``status_code=True``. The guard rejects it explicitly.
+        with pytest.raises(TypeError, match="requires either"):
+            NotFoundError(True, b"x")  # type: ignore[call-overload]

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -66,7 +66,7 @@ class TestLogStreamCreate:
     """Test suite for LogStream.create() method."""
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_create_persists_log_stream_to_api_with_project_id(
         self,
         mock_projects_class: MagicMock,
@@ -96,7 +96,7 @@ class TestLogStreamCreate:
         assert log_stream.is_synced()
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_create_persists_log_stream_to_api_with_project_name(
         self,
         mock_projects_class: MagicMock,
@@ -129,7 +129,7 @@ class TestLogStreamCreate:
         assert log_stream.project_name == "Test Project"
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_create_handles_api_failure(
         self, mock_projects_class: MagicMock, mock_logstreams_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -154,7 +154,7 @@ class TestLogStreamCreate:
 
         assert log_stream.sync_state == SyncState.FAILED_SYNC
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_create_names_project_in_error_when_project_name_not_found(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -171,7 +171,7 @@ class TestLogStreamCreate:
         with pytest.raises(NotFoundError, match=r'Project "my-nonexistent-project" not found'):
             log_stream.create()
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_create_without_project_info_raises_error(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -197,7 +197,7 @@ class TestLogStreamGet:
     """Test suite for LogStream.get() class method."""
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_get_returns_log_stream_with_project_id(
         self,
         mock_projects_class: MagicMock,
@@ -228,7 +228,7 @@ class TestLogStreamGet:
         mock_service.get.assert_called_once_with(name="Test Stream", project_id="test-project-id")
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_get_returns_log_stream_with_project_name(
         self,
         mock_projects_class: MagicMock,
@@ -259,7 +259,7 @@ class TestLogStreamGet:
         mock_service.get.assert_called_once_with(name="Test Stream", project_id="resolved-project-id")
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_get_returns_none_when_not_found(
         self, mock_projects_class: MagicMock, mock_logstreams_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -282,7 +282,7 @@ class TestLogStreamGet:
         # Then: None is returned
         assert log_stream is None
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_get_raises_error_without_project_info_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -296,7 +296,7 @@ class TestLogStreamGet:
         with pytest.raises(NotFoundError, match="No project specified"):
             LogStream.get(name="Test Stream")
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_get_raises_not_found_when_project_id_unknown(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -310,7 +310,7 @@ class TestLogStreamGet:
         with pytest.raises(NotFoundError, match=r'Project with id "unknown-id" not found'):
             LogStream.get(name="Test Stream", project_id="unknown-id")
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_get_reraises_non_404_projects_api_exception(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -325,16 +325,18 @@ class TestLogStreamGet:
             LogStream.get(name="Test Stream", project_id="some-id")
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_get_uses_env_fallback_when_no_project_specified(
         self,
         mock_projects_class: MagicMock,
         mock_logstreams_class: MagicMock,
         reset_configuration: None,
         mock_logstream: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test get() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: env fallback resolves to a project
+        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
         mock_project = MagicMock()
         mock_project.id = "env-project-id"
         mock_project.name = "Env Project"
@@ -358,7 +360,7 @@ class TestLogStreamList:
     """Test suite for LogStream.list() class method."""
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_list_returns_all_log_streams_with_project_id(
         self, mock_projects_class: MagicMock, mock_logstreams_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -399,7 +401,7 @@ class TestLogStreamList:
         mock_service.list.assert_called_once_with(project_id="test-project-id")
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_list_returns_all_log_streams_with_project_name(
         self, mock_projects_class: MagicMock, mock_logstreams_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -432,7 +434,7 @@ class TestLogStreamList:
         assert all(ls.project_name == "Test Project" for ls in log_streams)
         mock_service.list.assert_called_once_with(project_id="resolved-project-id")
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_list_raises_error_without_project_info_and_no_env_fallback(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -446,7 +448,7 @@ class TestLogStreamList:
         with pytest.raises(NotFoundError, match="No project specified"):
             LogStream.list()
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_list_raises_not_found_when_project_id_unknown(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -460,7 +462,7 @@ class TestLogStreamList:
         with pytest.raises(NotFoundError, match=r'Project with id "unknown-id" not found'):
             LogStream.list(project_id="unknown-id")
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_list_reraises_non_404_projects_api_exception(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -475,12 +477,17 @@ class TestLogStreamList:
             LogStream.list(project_id="some-id")
 
     @patch("galileo.log_stream.LogStreams")
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_list_uses_env_fallback_when_no_project_specified(
-        self, mock_projects_class: MagicMock, mock_logstreams_class: MagicMock, reset_configuration: None
+        self,
+        mock_projects_class: MagicMock,
+        mock_logstreams_class: MagicMock,
+        reset_configuration: None,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test list() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: env fallback resolves to a project
+        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
         mock_project = MagicMock()
         mock_project.id = "env-project-id"
         mock_project.name = "Env Project"
@@ -503,7 +510,7 @@ class TestLogStreamList:
 class TestLogStreamRefresh:
     """Test suite for LogStream.refresh() method."""
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.LogStreams")
     def test_refresh_updates_attributes_from_api(
         self,
@@ -554,7 +561,7 @@ class TestLogStreamRefresh:
         with pytest.raises(ValueError, match="Log stream ID is not set"):
             log_stream.refresh()
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.LogStreams")
     def test_refresh_raises_error_if_log_stream_no_longer_exists(
         self,
@@ -607,7 +614,7 @@ class TestLogStreamQuery:
             ("get_sessions", RecordType.SESSION, 10),
         ],
     )
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.Search")
     @patch("galileo.log_stream.LogStreams")
     def test_query_methods(
@@ -681,7 +688,7 @@ class TestLogStreamQuery:
 class TestLogStreamExportRecords:
     """Test suite for LogStream.export_records() method."""
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.ExportClient")
     @patch("galileo.log_stream.LogStreams")
     def test_export_records_with_default_params(
@@ -720,7 +727,7 @@ class TestLogStreamExportRecords:
         )
         assert result == mock_iterator
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.ExportClient")
     @patch("galileo.log_stream.LogStreams")
     def test_export_records_with_custom_params(
@@ -791,7 +798,7 @@ class TestLogStreamExportRecords:
 class TestLogStreamContext:
     """Test suite for LogStream.context() method."""
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.galileo_context")
     @patch("galileo.log_stream.LogStreams")
     def test_context_returns_galileo_context(
@@ -828,7 +835,7 @@ class TestLogStreamContext:
 class TestLogStreamProject:
     """Test suite for LogStream.project property."""
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.Project")
     @patch("galileo.log_stream.LogStreams")
     def test_project_property_returns_project(
@@ -881,7 +888,7 @@ class TestLogStreamColumns:
             ),
         ],
     )
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.GalileoPythonConfig")
     @patch("galileo.log_stream.LogStreams")
     def test_column_properties_return_column_collection(
@@ -951,7 +958,7 @@ class TestLogStreamColumns:
             ("trace_columns", "traces_available_columns_projects_project_id_traces_available_columns_post"),
         ],
     )
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     @patch("galileo.log_stream.GalileoPythonConfig")
     @patch("galileo.log_stream.LogStreams")
     def test_column_properties_raise_error_on_empty_response(
@@ -1030,7 +1037,7 @@ class TestProjectNotFoundErrorBackwardCompat:
     ResourceNotFoundError inherits from NotFoundError.
     """
 
-    @patch("galileo.log_stream.Projects")
+    @patch("galileo.shared.project_resolver.Projects")
     def test_create_raises_resource_not_found_error_subclass(
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
@@ -1046,21 +1053,21 @@ class TestProjectNotFoundErrorBackwardCompat:
             log_stream.create()
         assert isinstance(exc_info.value, ResourceNotFoundError)
 
-    @patch("galileo.log_stream.Projects")
-    def test_create_handles_value_error_from_projects_get(
-        self, mock_projects_class: MagicMock, reset_configuration: None
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_create_skips_api_when_no_identifier_anywhere(
+        self, mock_projects_class: MagicMock, reset_configuration: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When both project_id and project_name are None (and no env), Projects.get raises ValueError.
+        """When no project_id/project_name and no env vars, the resolver short-circuits.
 
-        _resolve_project must catch that ValueError and convert it into ResourceNotFoundError so the
-        documented contract holds.
+        Previously the resolver called ``Projects().get_with_env_fallbacks(None, None)``
+        which raised ``ValueError`` from ``Projects.get``; the resolver then caught that
+        ``ValueError`` and converted it to ``NotFoundError``. That broad catch could
+        swallow unrelated ``ValueError``s. The new contract: pre-check before the API
+        call and raise ``NotFoundError`` directly.
         """
-        # Given: get_with_env_fallbacks raises ValueError (Projects.get(id=None, name=None) does this)
-        mock_projects_service = MagicMock()
-        mock_projects_class.return_value = mock_projects_service
-        mock_projects_service.get_with_env_fallbacks.side_effect = ValueError(
-            "Exactly one of 'id' or 'name' must be provided."
-        )
+        # Given: env vars are unset and Projects() shouldn't be touched
+        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
+        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
 
         log_stream = LogStream._create_empty()
         log_stream.name = "Test Stream"
@@ -1068,8 +1075,34 @@ class TestProjectNotFoundErrorBackwardCompat:
         log_stream.project_name = None
         log_stream._set_state(SyncState.LOCAL_ONLY)
 
-        # When/Then: ValueError is converted to NotFoundError, not propagated raw
+        # When/Then: NotFoundError is raised without calling the Projects API at all
         with pytest.raises(NotFoundError, match="No project specified"):
+            log_stream.create()
+        mock_projects_class.assert_not_called()
+
+    @patch("galileo.shared.project_resolver.Projects")
+    def test_resolver_does_not_swallow_unrelated_value_error(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        """Unrelated ``ValueError``s from ``get_with_env_fallbacks`` propagate unchanged.
+
+        The resolver used to ``except (ProjectNotFoundError, ValueError)``, which masked
+        any ``ValueError`` raised deeper in the resolution chain. Confirms the narrower
+        catch leaves them visible.
+        """
+        # Given: get_with_env_fallbacks raises a ValueError unrelated to missing id/name
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.side_effect = ValueError("HTTP client blew up")
+
+        log_stream = LogStream._create_empty()
+        log_stream.name = "Test Stream"
+        log_stream.project_id = "explicit-id"
+        log_stream.project_name = None
+        log_stream._set_state(SyncState.LOCAL_ONLY)
+
+        # When/Then: ValueError propagates unchanged (no longer rewritten as NotFoundError)
+        with pytest.raises(ValueError, match="HTTP client blew up"):
             log_stream.create()
 
 
@@ -1094,3 +1127,16 @@ class TestNotFoundErrorOverloads:
         assert err.content == b""
         assert err.message == "custom not-found message"
         assert str(err) == "custom not-found message"
+
+    def test_mixing_message_with_content_raises_type_error(self) -> None:
+        # When/Then: passing both a message string and content bytes is a misuse.
+        # The runtime guard prevents NotFoundError("msg", b"junk") from silently
+        # discarding the content under the str-overload path.
+        with pytest.raises(TypeError, match="does not accept a content argument"):
+            NotFoundError("a message", b"junk")  # type: ignore[call-overload]
+
+    def test_none_first_arg_raises_type_error(self) -> None:
+        # When/Then: ``None`` is neither a status code nor a message; the previous
+        # implementation fell through to GalileoAPIError and produced "HTTP None".
+        with pytest.raises(TypeError, match="requires either"):
+            NotFoundError(None)  # type: ignore[call-overload]

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -12,7 +12,7 @@ from galileo.resources.models.step_type import StepType
 from galileo.search import RecordType
 from galileo.shared.base import SyncState
 from galileo.shared.column import ColumnCollection
-from galileo.shared.exceptions import ValidationError
+from galileo.shared.exceptions import ResourceNotFoundError, ValidationError
 from galileo.shared.query_result import QueryResult
 
 
@@ -1021,3 +1021,76 @@ class TestLogStreamMethods:
         assert "test-id-123" in repr(log_stream)
         assert "test-project-id" in repr(log_stream)
         assert "2024-01-01 12:00:00" in repr(log_stream)
+
+
+class TestProjectNotFoundErrorBackwardCompat:
+    """Verify _project_not_found_error returns ResourceNotFoundError so both catch idioms work.
+
+    Both `except NotFoundError` and `except ResourceNotFoundError` must keep working since
+    ResourceNotFoundError inherits from NotFoundError.
+    """
+
+    @patch("galileo.log_stream.Projects")
+    def test_create_raises_resource_not_found_error_subclass(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: env fallback returns None
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.return_value = None
+
+        log_stream = LogStream(name="Test Stream", project_name="missing-proj")
+
+        # When/Then: the raised exception is BOTH a NotFoundError AND a ResourceNotFoundError
+        with pytest.raises(NotFoundError) as exc_info:
+            log_stream.create()
+        assert isinstance(exc_info.value, ResourceNotFoundError)
+
+    @patch("galileo.log_stream.Projects")
+    def test_create_handles_value_error_from_projects_get(
+        self, mock_projects_class: MagicMock, reset_configuration: None
+    ) -> None:
+        """When both project_id and project_name are None (and no env), Projects.get raises ValueError.
+
+        _resolve_project must catch that ValueError and convert it into ResourceNotFoundError so the
+        documented contract holds.
+        """
+        # Given: get_with_env_fallbacks raises ValueError (Projects.get(id=None, name=None) does this)
+        mock_projects_service = MagicMock()
+        mock_projects_class.return_value = mock_projects_service
+        mock_projects_service.get_with_env_fallbacks.side_effect = ValueError(
+            "Exactly one of 'id' or 'name' must be provided."
+        )
+
+        log_stream = LogStream._create_empty()
+        log_stream.name = "Test Stream"
+        log_stream.project_id = None
+        log_stream.project_name = None
+        log_stream._set_state(SyncState.LOCAL_ONLY)
+
+        # When/Then: ValueError is converted to NotFoundError, not propagated raw
+        with pytest.raises(NotFoundError, match="No project specified"):
+            log_stream.create()
+
+
+class TestNotFoundErrorOverloads:
+    """Verify NotFoundError supports both HTTP-style and string-only construction."""
+
+    def test_construct_from_status_code_and_content(self) -> None:
+        # Given/When: HTTP-style construction (matches generated client call sites)
+        err = NotFoundError(404, b"some body")
+
+        # Then: standard message is used and HTTP attributes are set
+        assert err.status_code == 404
+        assert err.content == b"some body"
+        assert "Resource not found" in err.message
+
+    def test_construct_from_message(self) -> None:
+        # Given/When: string-only construction (used by SDK-level lookups)
+        err = NotFoundError("custom not-found message")
+
+        # Then: the string is used verbatim and HTTP fields default sanely
+        assert err.status_code == 404
+        assert err.content == b""
+        assert err.message == "custom not-found message"
+        assert str(err) == "custom not-found message"


### PR DESCRIPTION
# User description
**Shortcut:**
[SC-61783](https://app.shortcut.com/galileo/story/61783/qa2-0-newsdk-logstream-list-sometimes-throw-notfounderror-and-sometimes-resourcenotfounderror)

**Description:**

 - LogStream.list(), .get(), and .create() now raise NotFoundError (instead of ResourceNotFoundError) when the project cannot be
  resolved                                                                                                                          
  - NotFoundError extended to accept a plain string message in addition to its existing (status_code, content) HTTP constructor, so
  it serves as the single "not found" exception for both HTTP 404 responses and SDK-level resource lookups                          
  - ResourceNotFoundError made a subclass of NotFoundError (while retaining GalileoFutureError in its MRO via multiple inheritance)
  so existing except ResourceNotFoundError handlers continue to work without changes

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align <code>LogStream</code> and <code>Experiment</code> project resolution with the shared <code>_resolve_project</code> helper so unknown projects consistently raise <code>NotFoundError</code> when only <code>project_name</code> is provided and the env fallback logic stays identical. Strengthen the <code>NotFoundError</code>/<code>ResourceNotFoundError</code> hierarchy and tests so SDK-level lookups can supply custom messages without regressing existing handlers.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/577?tool=ast&topic=NotFoundError+API>NotFoundError API</a>
        </td><td>Extend <code>NotFoundError</code> to accept string messages alongside HTTP construction, make <code>ResourceNotFoundError</code> a subclass for backward compatibility, and cover the new overloads/regression cases in the unit tests.<details><summary>Modified files (3)</summary><ul><li>src/galileo/exceptions.py</li>
<li>src/galileo/shared/exceptions.py</li>
<li>tests/test_log_stream.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>refactor(shared): extr...</td><td>May 11, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/577?tool=ast&topic=Project+resolution>Project resolution</a>
        </td><td>Consolidate <code>LogStream</code> and <code>Experiment</code> flows onto <code>_resolve_project</code>, ensuring shared env fallbacks, consistent <code>NotFoundError</code> raises, and no more leaked <code>ValueError</code> when no identifier exists.<details><summary>Modified files (7)</summary><ul><li>src/galileo/experiment.py</li>
<li>src/galileo/log_stream.py</li>
<li>src/galileo/shared/exceptions.py</li>
<li>src/galileo/shared/project_resolver.py</li>
<li>tests/shared/test_project_resolver.py</li>
<li>tests/test_experiment.py</li>
<li>tests/test_log_stream.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>refactor(shared): extr...</td><td>May 11, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat: add metric_aggre...</td><td>May 06, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/577?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>