### PR TITLE
feat: add metric_aggregates + experiment_columns, deprecate aggregate_metrics

### DIFF
--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -1550,7 +1550,8 @@ class Experiment(StateManagementMixin):
         warnings.warn(
             "aggregate_metrics is deprecated and will be removed in a future release. "
             "Use metric_aggregates instead, which returns full statistical aggregates "
-            "(avg, min, max, p50, p90, p95, p99) keyed by metric id (UUID).",
+            "(avg, min, max, p50, p90, p95, p99) keyed by scorer UUID for scorer-backed "
+            "metrics or raw string for system metrics (e.g. 'cost', 'duration_ns').",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1626,6 +1627,9 @@ class Experiment(StateManagementMixin):
 
         if hasattr(structured, "additional_properties"):
             return dict(structured.additional_properties)
+
+        if isinstance(structured, dict):
+            return structured
 
         return None
 

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import datetime
+import re
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
@@ -63,6 +64,8 @@ if TYPE_CHECKING:
     from galileo.shared.column import ColumnCollection
 
 _logger = get_logger(__name__)
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
 
 EXPERIMENT_TASK_TYPE: int = 16
 
@@ -2003,6 +2006,74 @@ class Experiment(StateManagementMixin):
             raise ValueError("Unable to retrieve metric columns.")
         columns = [Column(col) for col in response.columns]
         return ColumnCollection(columns)
+
+    def get_metric_aggregate(self, metric: GalileoMetrics | str) -> MetricAggregates | None:
+        """Return aggregate statistics for a specific metric.
+
+        Looks up a metric by any of the following identifiers, tried in order:
+
+        1. :class:`~galileo.schema.metrics.GalileoMetrics` enum value — its
+           ``value`` IS the human-readable label (e.g.
+           ``GalileoMetrics.correctness`` → ``"Correctness"``).
+        2. Scorer UUID string — direct lookup in :attr:`metric_aggregates`,
+           no column resolution needed.
+        3. Human-readable label string (e.g. ``"Correctness"``) — resolved
+           via :attr:`experiment_columns`.
+        4. Legacy ``metric_key_alias`` string (e.g. ``"correctness"``) —
+           fallback after label matching fails.
+
+        Returns ``None`` if :attr:`metric_aggregates` is not yet populated
+        (metrics still computing) or the metric is not found.
+
+        Parameters
+        ----------
+        metric :
+            Any of: a :class:`GalileoMetrics` enum value, scorer UUID string,
+            human-readable label, or legacy metric_key_alias.
+
+        Returns
+        -------
+        MetricAggregates | None
+            Aggregate stats with ``avg``, ``min_``, ``max_``, ``p50``,
+            ``p90``, ``p95``, ``p99``, ``count``, and ``value_distribution``
+            fields; or ``None`` if not available.
+
+        Examples
+        --------
+        Poll until a specific metric is computed, then assert::
+
+            from galileo.schema.metrics import GalileoMetrics
+
+            while experiment.get_metric_aggregate(GalileoMetrics.correctness) is None:
+                time.sleep(5)
+                experiment.refresh()
+
+            agg = experiment.get_metric_aggregate(GalileoMetrics.correctness)
+            assert agg.avg >= 0.95
+        """
+        aggregates = self.metric_aggregates
+        if not aggregates:
+            return None
+
+        # GalileoMetrics.value IS the human-readable label (e.g. "Correctness")
+        metric_str = metric.value if isinstance(metric, GalileoMetrics) else metric
+
+        # Scorer UUID → direct lookup, no column resolution needed
+        if _UUID_RE.fullmatch(metric_str):
+            return aggregates.get(metric_str)
+
+        # Label or metric_key_alias → iterate experiment_columns once, prefer label match
+        alias_match = None
+        for col in self.experiment_columns.values():
+            if col.label == metric_str:
+                return aggregates.get(col.id.removeprefix("metrics/"))
+            if col.metric_key_alias == metric_str and alias_match is None:
+                alias_match = col
+
+        if alias_match:
+            return aggregates.get(alias_match.id.removeprefix("metrics/"))
+
+        return None
 
 
 # Import at end to avoid circular import (dataset.py, prompt.py, project.py import Experiment)

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import builtins
 import datetime
-import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
@@ -1547,13 +1546,11 @@ class Experiment(StateManagementMixin):
                 if 'average_correctness' in metrics:
                     print(f"Average correctness: {metrics['average_correctness']:.2%}")
         """
-        warnings.warn(
-            "aggregate_metrics is deprecated and will be removed in a future release. "
+        _logger.warning(
+            "DEPRECATED: aggregate_metrics is deprecated and will be removed in a future release. "
             "Use metric_aggregates instead, which returns full statistical aggregates "
             "(avg, min, max, p50, p90, p95, p99) keyed by scorer UUID for scorer-backed "
-            "metrics or raw string for system metrics (e.g. 'cost', 'duration_ns').",
-            DeprecationWarning,
-            stacklevel=2,
+            "metrics or raw string for system metrics (e.g. 'cost', 'duration_ns')."
         )
         if self._experiment_response is None:
             return None

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import datetime
+import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
@@ -17,6 +18,7 @@ from galileo.projects import ProjectNotFoundError, Projects
 from galileo.prompts import PromptTemplate, get_prompt
 from galileo.resources.api.experiment import (
     delete_experiment_projects_project_id_experiments_experiment_id_delete,
+    experiments_available_columns_projects_project_id_experiments_available_columns_post,
     get_experiment_projects_project_id_experiments_experiment_id_get,
 )
 from galileo.resources.api.trace import (
@@ -35,6 +37,7 @@ from galileo.resources.models import (
 )
 from galileo.resources.models.log_records_available_columns_request import LogRecordsAvailableColumnsRequest
 from galileo.resources.models.log_records_available_columns_response import LogRecordsAvailableColumnsResponse
+from galileo.resources.models.metric_aggregates import MetricAggregates
 from galileo.resources.types import Unset
 
 # TODO: DatasetRecord needed for function-based experiments
@@ -1544,6 +1547,13 @@ class Experiment(StateManagementMixin):
                 if 'average_correctness' in metrics:
                     print(f"Average correctness: {metrics['average_correctness']:.2%}")
         """
+        warnings.warn(
+            "aggregate_metrics is deprecated and will be removed in a future release. "
+            "Use metric_aggregates instead, which returns full statistical aggregates "
+            "(avg, min, max, p50, p90, p95, p99) keyed by metric id (UUID).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._experiment_response is None:
             return None
 
@@ -1561,6 +1571,63 @@ class Experiment(StateManagementMixin):
             return dict(agg_metrics) if agg_metrics else None
         except (TypeError, ValueError):
             return None
+
+    @property
+    def metric_aggregates(self) -> dict[str, MetricAggregates] | None:
+        """
+        Get structured aggregate metrics for this experiment, keyed by metric identifier.
+
+        Returns full statistical aggregates (avg, min, max, sum, count, p50, p90, p95, p99,
+        value_distribution) for each metric.
+
+        Key types
+        ---------
+        - **UUID keys** (36-char strings, e.g. ``"550e8400-e29b-41d4-a716-446655440000"``) — scorer-backed
+          metrics. The UUID matches ``column.id.removeprefix("metrics/")`` for the corresponding entry
+          in :attr:`experiment_columns`.
+        - **Raw-string keys** (e.g. ``"cost"``, ``"duration_ns"``) — system metrics computed without a
+          scorer. These do **not** appear in :attr:`experiment_columns`.
+
+        Resolving UUIDs to human labels
+        --------------------------------
+        Use :attr:`experiment_columns` to look up the display label and legacy metric name for each UUID::
+
+            cols = experiment.experiment_columns
+            for metric_id, agg in (experiment.metric_aggregates or {}).items():
+                col = cols.get(f"metrics/{metric_id}")   # None for system metrics
+                label = col.label if col else metric_id  # fall back to raw key
+                print(f"{label}: avg={agg.avg:.3f}")
+
+        The ``MetricAggregates`` object exposes: ``avg``, ``min_``, ``max_``, ``sum_``, ``count``,
+        ``pct``, ``p50``, ``p90``, ``p95``, ``p99``, ``value_distribution``.
+        For boolean metrics, ``value_distribution`` holds ``{"0": count_false, "1": count_true}``.
+
+        Note: Call :meth:`refresh` first to get the latest values after experiment completion.
+
+        Returns
+        -------
+            dict[str, MetricAggregates] | None: Mapping of metric identifier to aggregate stats,
+            or None if not yet available.
+
+        Examples
+        --------
+            experiment = Experiment.get(name="ml-evaluation", project_name="My Project")
+            experiment.refresh()
+
+            for metric_id, agg in (experiment.metric_aggregates or {}).items():
+                print(f"{metric_id}: avg={agg.avg}")
+        """
+        if self._experiment_response is None:
+            return None
+
+        structured = getattr(self._experiment_response, "structured_aggregate_metrics", None)
+        if structured is None or isinstance(structured, Unset):
+            return None
+
+        if hasattr(structured, "additional_properties"):
+            return dict(structured.additional_properties)
+
+        return None
 
     @property
     def tags(self) -> dict[str, builtins.list[dict]] | None:
@@ -1868,6 +1935,71 @@ class Experiment(StateManagementMixin):
             traces_available_columns_projects_project_id_traces_available_columns_post,
             "Unable to retrieve trace columns",
         )
+        columns = [Column(col) for col in response.columns]
+        return ColumnCollection(columns)
+
+    @property
+    def experiment_columns(self) -> ColumnCollection:
+        """
+        Get available metric columns for this experiment.
+
+        Returns a :class:`~galileo.shared.column.ColumnCollection` of all columns available
+        in the experiment comparison table. Scorer-backed metric columns carry UUID-based IDs
+        of the form ``"metrics/{scorer-uuid}"``, which map directly to the keys returned by
+        :attr:`metric_aggregates`.
+
+        Column attributes
+        -----------------
+        - ``column.id`` — Full column ID, e.g. ``"metrics/550e8400-e29b-41d4-a716-446655440000"``
+        - ``column.label`` — Human-readable display label, e.g. ``"Correctness"``
+        - ``column.metric_key_alias`` — Legacy snake_case metric name, e.g. ``"correctness"``
+
+        Note: System metrics (``"cost"``, ``"duration_ns"``) appear as raw-string keys in
+        :attr:`metric_aggregates` but **not** in this collection (they have no scorer UUID).
+
+        Resolving metric_aggregates UUIDs to labels
+        --------------------------------------------
+        ::
+
+            cols = experiment.experiment_columns
+            for metric_id, agg in (experiment.metric_aggregates or {}).items():
+                col = cols.get(f"metrics/{metric_id}")   # None for system metrics
+                label = col.label if col else metric_id  # fall back to raw key
+                alias = col.metric_key_alias if col else None
+                print(f"{label} ({alias}): avg={agg.avg:.3f}")
+
+        Returns
+        -------
+            ColumnCollection: Mapping of column ID to :class:`~galileo.shared.column.Column`,
+            accessible by full column ID (e.g. ``columns["metrics/{uuid}"]``).
+
+        Raises
+        ------
+            ValueError: If experiment ID or project ID is not set.
+
+        Examples
+        --------
+            experiment = Experiment.get(name="ml-evaluation", project_name="My AI Project")
+            experiment.refresh()
+
+            cols = experiment.experiment_columns
+            for col_id, col in cols.items():
+                if col_id.startswith("metrics/"):
+                    print(f"{col.label}: id={col_id}, alias={col.metric_key_alias}")
+        """
+        if self.id is None:
+            raise ValueError("Experiment ID is not set. Cannot retrieve metric columns from a local-only experiment.")
+        if self.project_id is None:
+            raise ValueError("Project ID is not set. Cannot retrieve metric columns without project_id.")
+
+        config = GalileoPythonConfig.get()
+        response = experiments_available_columns_projects_project_id_experiments_available_columns_post.sync(
+            project_id=self.project_id, client=config.api_client
+        )
+        if isinstance(response, HTTPValidationError):
+            raise response
+        if not response or isinstance(response.columns, Unset):
+            raise ValueError("Unable to retrieve metric columns.")
         columns = [Column(col) for col in response.columns]
         return ColumnCollection(columns)
 

--- a/src/galileo/resources/models/column_info.py
+++ b/src/galileo/resources/models/column_info.py
@@ -37,6 +37,9 @@ class ColumnInfo:
         is_optional (Union[Unset, bool]): Whether the column is optional. Default: False.
         roll_up_method (Union[None, Unset, str]): Default roll-up aggregation method for this metric (e.g., 'sum',
             'average').
+        metric_key_alias (Union[None, Unset, str]): Alternate metric key for this column. When scorer UUIDs are used
+            as column IDs (e.g. ``"metrics/{uuid}"``), this holds the legacy snake_case metric name
+            (e.g. ``"correctness"``) for display and dual-key query fallback. None for non-metric columns.
     """
 
     id: str
@@ -55,6 +58,7 @@ class ColumnInfo:
     complex_: Unset | bool = False
     is_optional: Unset | bool = False
     roll_up_method: None | Unset | str = UNSET
+    metric_key_alias: None | Unset | str = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -113,6 +117,9 @@ class ColumnInfo:
         roll_up_method: None | Unset | str
         roll_up_method = UNSET if isinstance(self.roll_up_method, Unset) else self.roll_up_method
 
+        metric_key_alias: None | Unset | str
+        metric_key_alias = UNSET if isinstance(self.metric_key_alias, Unset) else self.metric_key_alias
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({"id": id, "category": category, "data_type": data_type})
@@ -142,6 +149,8 @@ class ColumnInfo:
             field_dict["is_optional"] = is_optional
         if roll_up_method is not UNSET:
             field_dict["roll_up_method"] = roll_up_method
+        if metric_key_alias is not UNSET:
+            field_dict["metric_key_alias"] = metric_key_alias
 
         return field_dict
 
@@ -253,6 +262,15 @@ class ColumnInfo:
 
         roll_up_method = _parse_roll_up_method(d.pop("roll_up_method", UNSET))
 
+        def _parse_metric_key_alias(data: object) -> None | Unset | str:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | Unset | str, data)
+
+        metric_key_alias = _parse_metric_key_alias(d.pop("metric_key_alias", UNSET))
+
         column_info = cls(
             id=id,
             category=category,
@@ -270,6 +288,7 @@ class ColumnInfo:
             complex_=complex_,
             is_optional=is_optional,
             roll_up_method=roll_up_method,
+            metric_key_alias=metric_key_alias,
         )
 
         column_info.additional_properties = d

--- a/src/galileo/shared/column.py
+++ b/src/galileo/shared/column.py
@@ -53,6 +53,8 @@ class Column:
         category (str): The column category.
         multi_valued (bool): Whether the column contains multiple values.
         allowed_values (list[Any] | None): Allowed values for this column.
+        metric_key_alias (str | None): For metric columns keyed by scorer UUID, the legacy snake_case metric name
+            (e.g. ``"correctness"``). None for non-metric columns and system metrics.
 
     Examples
     --------
@@ -77,6 +79,7 @@ class Column:
         "filterable",
         "id",
         "label",
+        "metric_key_alias",
         "multi_valued",
         "sortable",
     )
@@ -97,12 +100,14 @@ class Column:
         self.category = column_info.category
         self.multi_valued = _unwrap_unset(column_info.multi_valued, default=False)
         self.allowed_values = _unwrap_unset(column_info.allowed_values)
+        self.metric_key_alias = _unwrap_unset(column_info.metric_key_alias)
 
     def __repr__(self) -> str:
         """String representation of the column."""
         label_str = f", label='{self.label}'" if self.label else ""
         type_str = f", type='{self.data_type.value}'" if self.data_type else ""
-        return f"Column(id='{self.id}'{label_str}{type_str}, filterable={self.filterable}, sortable={self.sortable})"
+        alias_str = f", metric_key_alias='{self.metric_key_alias}'" if self.metric_key_alias else ""
+        return f"Column(id='{self.id}'{label_str}{type_str}{alias_str}, filterable={self.filterable}, sortable={self.sortable})"
 
     __str__ = __repr__
 

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from galileo.resources.models import (
+    ColumnCategory,
     DataType,
     LogRecordsBooleanFilter,
     LogRecordsDateFilter,
@@ -17,6 +18,7 @@ from galileo.resources.models import (
     LogRecordsTextFilter,
     LogRecordsTextFilterOperator,
 )
+from galileo.resources.models.column_info import ColumnInfo
 from galileo.resources.types import UNSET
 from galileo.shared.column import Column, ColumnCollection, _unwrap_unset
 from galileo.shared.exceptions import ValidationError
@@ -42,6 +44,7 @@ def _create_mock_column_info(
     mock.description = kwargs.get("description", UNSET)
     mock.multi_valued = kwargs.get("multi_valued", UNSET)
     mock.allowed_values = kwargs.get("allowed_values", UNSET)
+    mock.metric_key_alias = kwargs.get("metric_key_alias", UNSET)
     return mock
 
 
@@ -311,3 +314,103 @@ class TestColumnCollection:
         repr_str = repr(coll)
         assert "ColumnCollection" in repr_str and "3 columns" in repr_str
         assert str(coll) == repr_str
+
+
+class TestColumnMetricKeyAlias:
+    """Tests for metric_key_alias support on ColumnInfo and Column."""
+
+    def test_column_info_from_dict_parses_metric_key_alias(self) -> None:
+        # Given: a raw API dict for a UUID-keyed metric column including metric_key_alias
+        raw = {
+            "id": "metrics/550e8400-e29b-41d4-a716-446655440000",
+            "category": "metric",
+            "data_type": "floating_point",
+            "label": "Correctness",
+            "metric_key_alias": "correctness",
+        }
+
+        # When: parsed through ColumnInfo.from_dict
+        col_info = ColumnInfo.from_dict(raw)
+
+        # Then: metric_key_alias is preserved
+        assert col_info.metric_key_alias == "correctness"
+        assert col_info.label == "Correctness"
+        assert col_info.id == "metrics/550e8400-e29b-41d4-a716-446655440000"
+
+    def test_column_info_to_dict_serializes_metric_key_alias(self) -> None:
+        # Given: a ColumnInfo with metric_key_alias set
+        col_info = ColumnInfo(
+            id="metrics/550e8400-e29b-41d4-a716-446655440000",
+            category=ColumnCategory.METRIC,
+            data_type=DataType.FLOATING_POINT,
+            label="Correctness",
+            metric_key_alias="correctness",
+        )
+
+        # When: serialized to dict
+        d = col_info.to_dict()
+
+        # Then: metric_key_alias appears in output
+        assert d["metric_key_alias"] == "correctness"
+
+    def test_column_info_round_trip_preserves_metric_key_alias(self) -> None:
+        # Given: a raw dict with metric_key_alias
+        raw = {
+            "id": "metrics/abc-123",
+            "category": "metric",
+            "data_type": "boolean",
+            "metric_key_alias": "groundedness",
+        }
+
+        # When: round-tripped through from_dict / to_dict
+        result = ColumnInfo.from_dict(raw).to_dict()
+
+        # Then: the alias survives
+        assert result["metric_key_alias"] == "groundedness"
+
+    def test_column_info_without_metric_key_alias_omits_field(self) -> None:
+        # Given: a raw dict with no metric_key_alias
+        raw = {"id": "input", "category": "standard", "data_type": "text"}
+
+        # When: parsed and serialized
+        result = ColumnInfo.from_dict(raw).to_dict()
+
+        # Then: metric_key_alias is absent (UNSET, omitted from output)
+        assert "metric_key_alias" not in result
+
+    def test_column_exposes_metric_key_alias_from_column_info(self) -> None:
+        # Given: a ColumnInfo with metric_key_alias="correctness"
+        mock_info = _create_mock_column_info(
+            column_id="metrics/abc-123", label="Correctness", metric_key_alias="correctness"
+        )
+
+        # When: wrapped in Column
+        col = Column(mock_info)
+
+        # Then: the alias is accessible
+        assert col.metric_key_alias == "correctness"
+
+    def test_column_metric_key_alias_is_none_when_unset(self) -> None:
+        # Given: a ColumnInfo without metric_key_alias
+        mock_info = _create_mock_column_info(column_id="input")
+
+        # When: wrapped in Column (metric_key_alias defaults to UNSET in helper)
+        col = Column(mock_info)
+
+        # Then: the alias resolves to None
+        assert col.metric_key_alias is None
+
+    def test_column_repr_includes_metric_key_alias_for_metric_columns(self) -> None:
+        # Given: a metric Column with an alias
+        mock_info = _create_mock_column_info(
+            column_id="metrics/abc-123",
+            label="Correctness",
+            data_type=DataType.FLOATING_POINT,
+            metric_key_alias="correctness",
+        )
+
+        # When: repr is called
+        col = Column(mock_info)
+
+        # Then: alias appears in the string
+        assert "metric_key_alias='correctness'" in repr(col)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1275,9 +1275,8 @@ class TestExperimentProperties:
 
         synced_experiment._experiment_response = mock_response
 
-        # Assert all properties (aggregate_metrics emits a DeprecationWarning — expected)
-        with pytest.warns(DeprecationWarning, match="metric_aggregates"):
-            assert synced_experiment.aggregate_metrics == {"average_cost": 0.05, "total_responses": 100}
+        # Assert all properties (aggregate_metrics logs a DEPRECATED warning)
+        assert synced_experiment.aggregate_metrics == {"average_cost": 0.05, "total_responses": 100}
         assert synced_experiment.rank == 1
         assert synced_experiment.ranking_score == 0.95
         assert synced_experiment.is_winner is True
@@ -1291,8 +1290,7 @@ class TestExperimentProperties:
         """Test all experiment properties return None when no response data."""
         synced_experiment._experiment_response = None
 
-        with pytest.warns(DeprecationWarning, match="metric_aggregates"):
-            assert synced_experiment.aggregate_metrics is None
+        assert synced_experiment.aggregate_metrics is None
         assert synced_experiment.rank is None
         assert synced_experiment.ranking_score is None
         assert synced_experiment.is_winner is False
@@ -1354,18 +1352,22 @@ class TestMetricAggregates:
         assert result[scorer_uuid].avg == 0.85
         assert "cost" in result
 
-    def test_aggregate_metrics_emits_deprecation_warning(
-        self, synced_experiment: Experiment, reset_configuration: None
+    @patch("galileo.experiment._logger")
+    def test_aggregate_metrics_logs_deprecation_warning(
+        self, mock_logger: MagicMock, synced_experiment: Experiment, reset_configuration: None
     ) -> None:
         # Given: a response with aggregate_metrics data
         mock_response = MagicMock()
         mock_response.aggregate_metrics.to_dict.return_value = {"average_cost": 0.05}
         synced_experiment._experiment_response = mock_response
 
-        # When/Then: accessing aggregate_metrics fires DeprecationWarning mentioning metric_aggregates
-        with pytest.warns(DeprecationWarning, match="metric_aggregates"):
-            result = synced_experiment.aggregate_metrics
+        # When: accessing aggregate_metrics
+        result = synced_experiment.aggregate_metrics
 
+        # Then: a DEPRECATED warning is logged mentioning metric_aggregates
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "DEPRECATED" in warning_msg and "metric_aggregates" in warning_msg
         # And: the property still returns data (backward-compatible)
         assert result == {"average_cost": 0.05}
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1426,6 +1426,201 @@ class TestMetricColumns:
             _ = experiment.experiment_columns
 
 
+class TestGetMetricAggregate:
+    """Tests for Experiment.get_metric_aggregate."""
+
+    SCORER_UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+    def _make_experiment_with_aggregates(
+        self, synced_experiment: Experiment, scorer_uuid: str = SCORER_UUID, avg: float = 0.85
+    ) -> Experiment:
+        """Set up metric_aggregates on the experiment."""
+        mock_agg = MagicMock()
+        mock_agg.avg = avg
+        mock_structured = MagicMock()
+        mock_structured.additional_properties = {scorer_uuid: mock_agg}
+        mock_response = MagicMock()
+        mock_response.structured_aggregate_metrics = mock_structured
+        synced_experiment._experiment_response = mock_response
+        return synced_experiment
+
+    def _make_column_response(self, scorer_uuid: str, label: str, alias: str) -> MagicMock:
+        col_info = ColumnInfo(
+            id=f"metrics/{scorer_uuid}",
+            category=ColumnCategory.METRIC,
+            data_type=DataType.FLOATING_POINT,
+            label=label,
+            metric_key_alias=alias,
+        )
+        mock_response = MagicMock()
+        mock_response.columns = [col_info]
+        return mock_response
+
+    def test_returns_none_when_metric_aggregates_empty(
+        self, synced_experiment: Experiment, reset_configuration: None
+    ) -> None:
+        # Given: no structured_aggregate_metrics on the response
+        mock_response = MagicMock()
+        mock_response.structured_aggregate_metrics = None
+        synced_experiment._experiment_response = mock_response
+
+        # When: getting a metric aggregate
+        result = synced_experiment.get_metric_aggregate(GalileoMetrics.correctness)
+
+        # Then: None is returned without error
+        assert result is None
+
+    @patch("galileo.experiment.experiments_available_columns_projects_project_id_experiments_available_columns_post")
+    @patch("galileo.experiment.GalileoPythonConfig")
+    def test_lookup_by_galileo_metrics_enum(
+        self,
+        mock_config_class: MagicMock,
+        mock_api: MagicMock,
+        synced_experiment: Experiment,
+        reset_configuration: None,
+    ) -> None:
+        # Given: metric_aggregates keyed by UUID, columns returning Correctness
+        experiment = self._make_experiment_with_aggregates(synced_experiment)
+        mock_api.sync.return_value = self._make_column_response(
+            self.SCORER_UUID, label="Correctness", alias="correctness"
+        )
+        mock_config_class.get.return_value = MagicMock()
+
+        # When: looking up by GalileoMetrics enum (value == label "Correctness")
+        result = experiment.get_metric_aggregate(GalileoMetrics.correctness)
+
+        # Then: the aggregate for the scorer UUID is returned
+        assert result is not None
+        assert result.avg == 0.85
+
+    @patch("galileo.experiment.experiments_available_columns_projects_project_id_experiments_available_columns_post")
+    @patch("galileo.experiment.GalileoPythonConfig")
+    def test_lookup_by_label_string(
+        self,
+        mock_config_class: MagicMock,
+        mock_api: MagicMock,
+        synced_experiment: Experiment,
+        reset_configuration: None,
+    ) -> None:
+        # Given: metric_aggregates and a column with label "Correctness"
+        experiment = self._make_experiment_with_aggregates(synced_experiment)
+        mock_api.sync.return_value = self._make_column_response(
+            self.SCORER_UUID, label="Correctness", alias="correctness"
+        )
+        mock_config_class.get.return_value = MagicMock()
+
+        # When: looking up by human-readable label string
+        result = experiment.get_metric_aggregate("Correctness")
+
+        # Then: the aggregate is returned
+        assert result is not None
+        assert result.avg == 0.85
+
+    @patch("galileo.experiment.experiments_available_columns_projects_project_id_experiments_available_columns_post")
+    @patch("galileo.experiment.GalileoPythonConfig")
+    def test_lookup_by_metric_key_alias(
+        self,
+        mock_config_class: MagicMock,
+        mock_api: MagicMock,
+        synced_experiment: Experiment,
+        reset_configuration: None,
+    ) -> None:
+        # Given: metric_aggregates and a column with alias "correctness"
+        experiment = self._make_experiment_with_aggregates(synced_experiment)
+        mock_api.sync.return_value = self._make_column_response(
+            self.SCORER_UUID, label="Correctness", alias="correctness"
+        )
+        mock_config_class.get.return_value = MagicMock()
+
+        # When: looking up by legacy metric_key_alias
+        result = experiment.get_metric_aggregate("correctness")
+
+        # Then: the aggregate is returned (alias fallback)
+        assert result is not None
+        assert result.avg == 0.85
+
+    def test_lookup_by_uuid_string(self, synced_experiment: Experiment, reset_configuration: None) -> None:
+        # Given: metric_aggregates keyed by scorer UUID
+        experiment = self._make_experiment_with_aggregates(synced_experiment)
+
+        # When: looking up directly by UUID string (no column resolution needed)
+        result = experiment.get_metric_aggregate(self.SCORER_UUID)
+
+        # Then: the aggregate is returned without calling experiment_columns
+        assert result is not None
+        assert result.avg == 0.85
+
+    @patch("galileo.experiment.experiments_available_columns_projects_project_id_experiments_available_columns_post")
+    @patch("galileo.experiment.GalileoPythonConfig")
+    def test_returns_none_for_unknown_metric(
+        self,
+        mock_config_class: MagicMock,
+        mock_api: MagicMock,
+        synced_experiment: Experiment,
+        reset_configuration: None,
+    ) -> None:
+        # Given: metric_aggregates and columns that don't include "Toxicity"
+        experiment = self._make_experiment_with_aggregates(synced_experiment)
+        mock_api.sync.return_value = self._make_column_response(
+            self.SCORER_UUID, label="Correctness", alias="correctness"
+        )
+        mock_config_class.get.return_value = MagicMock()
+
+        # When: looking up a metric that doesn't exist
+        result = experiment.get_metric_aggregate("Toxicity")
+
+        # Then: None is returned
+        assert result is None
+
+    @patch("galileo.experiment.experiments_available_columns_projects_project_id_experiments_available_columns_post")
+    @patch("galileo.experiment.GalileoPythonConfig")
+    def test_label_takes_priority_over_alias(
+        self,
+        mock_config_class: MagicMock,
+        mock_api: MagicMock,
+        synced_experiment: Experiment,
+        reset_configuration: None,
+    ) -> None:
+        # Given: two columns where one label equals another's alias (edge case)
+        uuid_a = "aaaaaaaa-0000-0000-0000-000000000001"
+        uuid_b = "bbbbbbbb-0000-0000-0000-000000000002"
+        mock_agg_a = MagicMock()
+        mock_agg_a.avg = 0.70
+        mock_agg_b = MagicMock()
+        mock_agg_b.avg = 0.90
+        mock_structured = MagicMock()
+        mock_structured.additional_properties = {uuid_a: mock_agg_a, uuid_b: mock_agg_b}
+        mock_response = MagicMock()
+        mock_response.structured_aggregate_metrics = mock_structured
+        synced_experiment._experiment_response = mock_response
+
+        col_a = ColumnInfo(
+            id=f"metrics/{uuid_a}",
+            category=ColumnCategory.METRIC,
+            data_type=DataType.FLOATING_POINT,
+            label="foo",
+            metric_key_alias="foo",
+        )
+        col_b = ColumnInfo(
+            id=f"metrics/{uuid_b}",
+            category=ColumnCategory.METRIC,
+            data_type=DataType.FLOATING_POINT,
+            label="Correctness",
+            metric_key_alias="foo",  # alias also "foo" — but label wins
+        )
+        mock_col_response = MagicMock()
+        mock_col_response.columns = [col_a, col_b]
+        mock_api.sync.return_value = mock_col_response
+        mock_config_class.get.return_value = MagicMock()
+
+        # When: looking up by the label "Correctness"
+        result = synced_experiment.get_metric_aggregate("Correctness")
+
+        # Then: the label-matched column (uuid_b, avg=0.90) wins over the alias match
+        assert result is not None
+        assert result.avg == 0.90
+
+
 class TestExperimentTagging:
     """Test suite for Experiment tagging functionality."""
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -8,6 +8,9 @@ import pytest
 from galileo.exceptions import NotFoundError
 from galileo.experiment import Experiment
 from galileo.resources.models import ExperimentResponse, PromptRunSettings
+from galileo.resources.models.column_category import ColumnCategory
+from galileo.resources.models.column_info import ColumnInfo
+from galileo.resources.models.data_type import DataType
 from galileo.schema.metrics import GalileoMetrics
 from galileo.search import RecordType
 from galileo.shared.base import SyncState
@@ -1272,8 +1275,9 @@ class TestExperimentProperties:
 
         synced_experiment._experiment_response = mock_response
 
-        # Assert all properties
-        assert synced_experiment.aggregate_metrics == {"average_cost": 0.05, "total_responses": 100}
+        # Assert all properties (aggregate_metrics emits a DeprecationWarning — expected)
+        with pytest.warns(DeprecationWarning, match="metric_aggregates"):
+            assert synced_experiment.aggregate_metrics == {"average_cost": 0.05, "total_responses": 100}
         assert synced_experiment.rank == 1
         assert synced_experiment.ranking_score == 0.95
         assert synced_experiment.is_winner is True
@@ -1287,13 +1291,137 @@ class TestExperimentProperties:
         """Test all experiment properties return None when no response data."""
         synced_experiment._experiment_response = None
 
-        assert synced_experiment.aggregate_metrics is None
+        with pytest.warns(DeprecationWarning, match="metric_aggregates"):
+            assert synced_experiment.aggregate_metrics is None
         assert synced_experiment.rank is None
         assert synced_experiment.ranking_score is None
         assert synced_experiment.is_winner is False
         assert synced_experiment.prompt_model is None
         assert synced_experiment.playground_name is None
         assert synced_experiment.tags is None
+
+
+class TestMetricAggregates:
+    """Tests for Experiment.metric_aggregates and aggregate_metrics deprecation."""
+
+    def test_metric_aggregates_returns_none_without_response(
+        self, synced_experiment: Experiment, reset_configuration: None
+    ) -> None:
+        # Given: no experiment response
+        synced_experiment._experiment_response = None
+
+        # When: accessing metric_aggregates
+        result = synced_experiment.metric_aggregates
+
+        # Then: None is returned without error
+        assert result is None
+
+    def test_metric_aggregates_returns_none_when_field_missing(
+        self, synced_experiment: Experiment, reset_configuration: None
+    ) -> None:
+        # Given: a response where structured_aggregate_metrics is None
+        mock_response = MagicMock()
+        mock_response.structured_aggregate_metrics = None
+        synced_experiment._experiment_response = mock_response
+
+        # When: accessing metric_aggregates
+        result = synced_experiment.metric_aggregates
+
+        # Then: None is returned
+        assert result is None
+
+    def test_metric_aggregates_returns_populated_dict(
+        self, synced_experiment: Experiment, reset_configuration: None
+    ) -> None:
+        # Given: a response with UUID-keyed structured_aggregate_metrics
+        scorer_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        mock_agg = MagicMock()
+        mock_agg.avg = 0.85
+        mock_agg.p90 = 0.92
+
+        mock_structured = MagicMock()
+        mock_structured.additional_properties = {scorer_uuid: mock_agg, "cost": MagicMock(avg=0.02)}
+        mock_response = MagicMock()
+        mock_response.structured_aggregate_metrics = mock_structured
+        synced_experiment._experiment_response = mock_response
+
+        # When: accessing metric_aggregates
+        result = synced_experiment.metric_aggregates
+
+        # Then: dict is returned with UUID and system-metric keys
+        assert result is not None
+        assert scorer_uuid in result
+        assert result[scorer_uuid].avg == 0.85
+        assert "cost" in result
+
+    def test_aggregate_metrics_emits_deprecation_warning(
+        self, synced_experiment: Experiment, reset_configuration: None
+    ) -> None:
+        # Given: a response with aggregate_metrics data
+        mock_response = MagicMock()
+        mock_response.aggregate_metrics.to_dict.return_value = {"average_cost": 0.05}
+        synced_experiment._experiment_response = mock_response
+
+        # When/Then: accessing aggregate_metrics fires DeprecationWarning mentioning metric_aggregates
+        with pytest.warns(DeprecationWarning, match="metric_aggregates"):
+            result = synced_experiment.aggregate_metrics
+
+        # And: the property still returns data (backward-compatible)
+        assert result == {"average_cost": 0.05}
+
+
+class TestMetricColumns:
+    """Tests for Experiment.experiment_columns."""
+
+    @patch("galileo.experiment.experiments_available_columns_projects_project_id_experiments_available_columns_post")
+    @patch("galileo.experiment.GalileoPythonConfig")
+    def test_experiment_columns_returns_column_collection(
+        self,
+        mock_config_class: MagicMock,
+        mock_api: MagicMock,
+        synced_experiment: Experiment,
+        reset_configuration: None,
+    ) -> None:
+        # Given: a mocked available_columns response with one UUID metric column
+        scorer_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        col_info = ColumnInfo(
+            id=f"metrics/{scorer_uuid}",
+            category=ColumnCategory.METRIC,
+            data_type=DataType.FLOATING_POINT,
+            label="Correctness",
+            metric_key_alias="correctness",
+        )
+        mock_response = MagicMock()
+        mock_response.columns = [col_info]
+        mock_api.sync.return_value = mock_response
+        mock_config_class.get.return_value = MagicMock()
+
+        # When: accessing experiment_columns
+        result = synced_experiment.experiment_columns
+
+        # Then: a ColumnCollection is returned with the metric column accessible by full ID
+        assert isinstance(result, ColumnCollection)
+        col = result[f"metrics/{scorer_uuid}"]
+        assert col.label == "Correctness"
+        assert col.metric_key_alias == "correctness"
+
+    def test_experiment_columns_raises_without_experiment_id(self, reset_configuration: None) -> None:
+        # Given: an experiment with no ID
+        experiment = Experiment._create_empty()
+        experiment.project_id = str(uuid4())
+
+        # When/Then: accessing experiment_columns raises ValueError
+        with pytest.raises(ValueError, match="Experiment ID is not set"):
+            _ = experiment.experiment_columns
+
+    def test_experiment_columns_raises_without_project_id(self, reset_configuration: None) -> None:
+        # Given: an experiment with no project_id
+        experiment = Experiment._create_empty()
+        experiment.id = str(uuid4())
+
+        # When/Then: accessing experiment_columns raises ValueError
+        with pytest.raises(ValueError, match="Project ID is not set"):
+            _ = experiment.experiment_columns
 
 
 class TestExperimentTagging:


### PR DESCRIPTION
# User description
## Summary

- **`Experiment.metric_aggregates`** — new property exposing `structured_aggregate_metrics` as `dict[str, MetricAggregates]`. Keys are scorer UUIDs for scorer-backed metrics, or raw strings (`"cost"`, `"duration_ns"`, etc.) for system metrics. Provides full statistical aggregates: `avg`, `min_`, `max_`, `sum_`, `count`, `p50`, `p90`, `p95`, `p99`, `value_distribution`.
- **`Experiment.experiment_columns`** — new property calling the experiments `available_columns` endpoint, returning a `ColumnCollection`. Each scorer-backed metric column has a UUID-based ID (`metrics/{uuid}`) that maps directly to a key in `metric_aggregates`, plus `label` (display name) and `metric_key_alias` (legacy snake_case name) for resolution.
- **`Experiment.aggregate_metrics` deprecated** — emits `DeprecationWarning` pointing users to `metric_aggregates`; property remains functional for backward compat.
- **`ColumnInfo.metric_key_alias` patched** — the generated client was missing this field (added to the API after last regen). Added to `from_dict` / `to_dict` and exposed on `Column`.

Depends on API branch `feat/sc-64064-experiment-uuid-metric-keys` (SC-64064) for `structured_aggregate_metrics` to be UUID-keyed in the response.

## Resolving UUIDs to labels

```python
experiment.refresh()

cols = experiment.experiment_columns
for metric_id, agg in (experiment.metric_aggregates or {}).items():
    col = cols.get(f"metrics/{metric_id}")   # None for system metrics
    label = col.label if col else metric_id
    alias = col.metric_key_alias if col else None
    print(f"{label} ({alias}): avg={agg.avg:.3f}")
```

## Test plan

- [x] Unit tests: `ColumnInfo.metric_key_alias` round-trip, `Column.metric_key_alias`, `metric_aggregates` (None and populated), `aggregate_metrics` DeprecationWarning, `experiment_columns` ColumnCollection
- [x] Local integration: ran `validate_metric_aggregates_v2.py` against local stack with API on `feat/sc-64064-experiment-uuid-metric-keys` — UUID→label resolution working end-to-end, deprecation warning fires correctly
- [ ] CI

SC-64065

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose structured aggregate metrics through the <code>Experiment.metric_aggregates</code> property and the <code>Experiment.experiment_columns</code> flow, leveraging <code>MetricAggregates</code> and <code>ColumnCollection</code> to map scorer UUIDs to labels while keeping <code>aggregate_metrics</code> backward-compatible via a licenced deprecation warning. Ensure metric column metadata carries the new <code>metric_key_alias</code> attribute through <code>ColumnInfo</code>/<code>Column</code> serialization so UUID-based metrics can be resolved to legacy names.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/578?tool=ast&topic=Metric+Columns>Metric Columns</a>
        </td><td>Describe how <code>experiment_columns</code> now calls the available columns endpoint to return a <code>ColumnCollection</code> whose <code>Column</code> wrappers surface the new <code>metric_key_alias</code>, plus the generated <code>ColumnInfo</code> changes and tests that confirm the alias round-tripping and repr.<details><summary>Modified files (4)</summary><ul><li>src/galileo/experiment.py</li>
<li>src/galileo/resources/models/column_info.py</li>
<li>src/galileo/shared/column.py</li>
<li>tests/test_column.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>quinn@rungalileo.io</td><td>feat: add Experiment.g...</td><td>May 06, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix: schema patches (#...</td><td>April 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/578?tool=ast&topic=Metric+Aggregates>Metric Aggregates</a>
        </td><td>Describe the new <code>metric_aggregates</code> property's use of the pre-deserialized <code>structured_aggregate_metrics</code> content, the backward-compatible <code>aggregate_metrics</code> warning, and the helper <code>get_metric_aggregate</code> that looks up stats by UUID, label, or legacy alias to expose scorer-based metrics with full statistics.<details><summary>Modified files (2)</summary><ul><li>src/galileo/experiment.py</li>
<li>tests/test_experiment.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>quinn@rungalileo.io</td><td>feat: add Experiment.g...</td><td>May 06, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix(errors): context-a...</td><td>April 29, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/578?tool=ast>(Baz)</a>.