### PR TITLE
fix(config): extend auth guard to recognize all supported auth methods

### DIFF
--- a/src/galileo/config.py
+++ b/src/galileo/config.py
@@ -23,19 +23,84 @@ class GalileoPythonConfig(GalileoConfig):
 
     @classmethod
     def get(cls, **kwargs: Any) -> "GalileoPythonConfig":
-        # Check for any supported auth method before raising.
-        # TODO: also check GALILEO_USERNAME / GALILEO_PASSWORD / SSO env vars once alternative auth is surfaced.
-        _AUTH_KWARGS = ("api_key", "username", "password", "sso_id_token", "sso_provider")
-        if (
-            cls._instance is None
-            and not any(kwargs.get(k) for k in _AUTH_KWARGS)
-            and not os.environ.get("GALILEO_API_KEY")
-        ):
-            raise ConfigurationError(
-                "GALILEO_API_KEY not detected. "
-                "Please set the GALILEO_API_KEY environment variable or pass api_key= as a keyword argument. "
-                "See https://docs.galileo.ai for setup instructions."
-            )
+        if cls._instance is None:
+            error_message = cls._check_auth_config(kwargs)
+            if error_message is not None:
+                raise ConfigurationError(error_message)
         cls._instance = cls._get(cls._instance, **kwargs)
         assert cls._instance is not None, "Failed to initialize GalileoPythonConfig"
         return cls._instance
+
+    @staticmethod
+    def _check_auth_config(kwargs: dict) -> str | None:
+        """Validate that a complete auth method is configured.
+
+        Returns None if at least one complete auth method is detectable from
+        either kwargs or the environment. Otherwise returns a specific error
+        message identifying what's missing.
+
+        Auth methods supported by the underlying config model:
+          - API key (standalone): api_key kwarg or GALILEO_API_KEY env
+          - Pre-exchanged Galileo JWT (standalone): jwt_token or GALILEO_JWT_TOKEN
+          - SSO (paired): sso_id_token + sso_provider, both kwargs and env vars
+          - Username/password (paired): username + password, both kwargs and env vars
+
+        Kwargs and env vars are interchangeable — e.g. sso_id_token can come
+        from a kwarg while sso_provider comes from the environment.
+        """
+
+        def _val(kwarg_name: str, env_name: str) -> str | None:
+            value = kwargs.get(kwarg_name)
+            if value:
+                return str(value)
+            return os.environ.get(env_name)
+
+        # Standalone methods — either alone is sufficient.
+        if _val("api_key", "GALILEO_API_KEY"):
+            return None
+        if _val("jwt_token", "GALILEO_JWT_TOKEN"):
+            return None
+
+        # SSO requires BOTH id_token and provider.
+        sso_id_token = _val("sso_id_token", "GALILEO_SSO_ID_TOKEN")
+        sso_provider = _val("sso_provider", "GALILEO_SSO_PROVIDER")
+        if sso_id_token and sso_provider:
+            return None
+        if sso_id_token and not sso_provider:
+            return (
+                "GALILEO_SSO_ID_TOKEN is set but GALILEO_SSO_PROVIDER is missing. "
+                "SSO authentication requires both. Set GALILEO_SSO_PROVIDER to your "
+                "IdP identifier (e.g. 'okta', 'custom') or pass sso_provider=... "
+                "as a keyword argument."
+            )
+        if sso_provider and not sso_id_token:
+            return (
+                "GALILEO_SSO_PROVIDER is set but GALILEO_SSO_ID_TOKEN is missing. "
+                "SSO authentication requires both. Set GALILEO_SSO_ID_TOKEN to your "
+                "IdP-issued ID token or pass sso_id_token=... as a keyword argument."
+            )
+
+        # Username/password requires BOTH.
+        username = _val("username", "GALILEO_USERNAME")
+        password = _val("password", "GALILEO_PASSWORD")
+        if username and password:
+            return None
+        if username and not password:
+            return (
+                "GALILEO_USERNAME is set but GALILEO_PASSWORD is missing. "
+                "Username/password authentication requires both."
+            )
+        if password and not username:
+            return (
+                "GALILEO_PASSWORD is set but GALILEO_USERNAME is missing. "
+                "Username/password authentication requires both."
+            )
+
+        # Nothing configured anywhere.
+        return (
+            "No Galileo authentication detected. Set one of: "
+            "GALILEO_API_KEY; GALILEO_SSO_ID_TOKEN with GALILEO_SSO_PROVIDER; "
+            "or GALILEO_USERNAME with GALILEO_PASSWORD. "
+            "Alternatively, pass the equivalent kwargs to GalileoPythonConfig.get(). "
+            "See https://docs.galileo.ai for setup instructions."
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,25 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from galileo.config import GalileoPythonConfig
 from galileo.shared.exceptions import ConfigurationError
+
+# Auth env vars cleared in tests that exercise the missing-auth guard.
+_AUTH_ENV_VARS = (
+    "GALILEO_API_KEY",
+    "GALILEO_SSO_ID_TOKEN",
+    "GALILEO_SSO_PROVIDER",
+    "GALILEO_USERNAME",
+    "GALILEO_PASSWORD",
+    "GALILEO_JWT_TOKEN",
+)
+
+
+def _clear_auth_env(monkeypatch) -> None:
+    """Clear every auth-related env var so the guard sees a clean slate."""
+    for var in _AUTH_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
 
 
 @patch("galileo_core.schemas.base_config.GalileoConfig.set_validated_api_client", new=lambda x: x)
@@ -24,24 +40,116 @@ def test_default_console_url(mock_get_jwt_token) -> None:
         assert str(config.api_url) == "https://api.galileo.ai/"
 
 
-def test_missing_api_key_raises_clear_error(monkeypatch) -> None:
-    """Test that a clear error message is raised when GALILEO_API_KEY is not set."""
-    # Given: no API key in environment and no cached instance
-    monkeypatch.delenv("GALILEO_API_KEY", raising=False)
+def test_no_auth_configured_raises_with_full_options_listed(monkeypatch) -> None:
+    """When no auth is configured anywhere, the error lists every supported method."""
+    # Given: no auth env vars and no cached instance
+    _clear_auth_env(monkeypatch)
     monkeypatch.setattr(GalileoPythonConfig, "_instance", None)
 
     # When/Then: calling get() without credentials raises ConfigurationError
-    with pytest.raises(ConfigurationError, match="GALILEO_API_KEY not detected"):
+    # listing every supported standalone or paired auth method
+    with pytest.raises(ConfigurationError) as exc_info:
         GalileoPythonConfig.get()
+    message = str(exc_info.value)
+    assert "No Galileo authentication detected" in message
+    assert "GALILEO_API_KEY" in message
+    assert "GALILEO_SSO_ID_TOKEN" in message
+    assert "GALILEO_SSO_PROVIDER" in message
+    assert "GALILEO_USERNAME" in message
+    assert "GALILEO_PASSWORD" in message
 
 
-def test_alternative_auth_kwargs_bypass_api_key_check(monkeypatch) -> None:
-    """Test that passing alternative auth kwargs does not raise ConfigurationError."""
-    # Given: no API key in environment and no cached instance
-    monkeypatch.delenv("GALILEO_API_KEY", raising=False)
+@pytest.mark.parametrize(
+    "env_setup",
+    [
+        # Standalone methods.
+        {"GALILEO_API_KEY": "test-api-key"},
+        {"GALILEO_JWT_TOKEN": "test-jwt"},
+        # Paired methods — both halves required.
+        {"GALILEO_SSO_ID_TOKEN": "test-sso-token", "GALILEO_SSO_PROVIDER": "okta"},
+        {"GALILEO_USERNAME": "test-user", "GALILEO_PASSWORD": "test-pass"},
+    ],
+    ids=["api_key", "jwt_token", "sso_id_token_and_provider", "username_and_password"],
+)
+def test_complete_auth_config_via_env_passes_guard(monkeypatch, env_setup) -> None:
+    """A complete auth configuration in environment variables bypasses the guard."""
+    # Given: a complete env-var auth configuration, no cached instance, and _get
+    # stubbed out so downstream network calls never happen
+    _clear_auth_env(monkeypatch)
+    for env_var, value in env_setup.items():
+        monkeypatch.setenv(env_var, value)
+    monkeypatch.setattr(GalileoPythonConfig, "_instance", None)
+    monkeypatch.setattr(GalileoPythonConfig, "_get", lambda *a, **kw: MagicMock(spec=GalileoPythonConfig))
+
+    # When/Then: the guard passes and _get is reached without raising
+    GalileoPythonConfig.get()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"api_key": "test-api-key"},
+        {"jwt_token": "test-jwt"},
+        {"sso_id_token": "test-sso-token", "sso_provider": "okta"},
+        {"username": "test-user", "password": "test-pass"},
+    ],
+    ids=["api_key", "jwt_token", "sso_id_token_and_provider", "username_and_password"],
+)
+def test_complete_auth_config_via_kwargs_passes_guard(monkeypatch, kwargs) -> None:
+    """A complete auth configuration passed as kwargs bypasses the guard."""
+    # Given: no auth env vars (kwargs are the only auth source), no cached instance,
+    # and _get stubbed out so downstream network calls never happen
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setattr(GalileoPythonConfig, "_instance", None)
+    monkeypatch.setattr(GalileoPythonConfig, "_get", lambda *a, **kw: MagicMock(spec=GalileoPythonConfig))
+
+    # When/Then: the guard passes and _get is reached without raising
+    GalileoPythonConfig.get(**kwargs)
+
+
+def test_kwargs_and_env_can_be_mixed(monkeypatch) -> None:
+    """One half of a paired auth method can come from kwargs, the other from env."""
+    # Given: sso_id_token in env, sso_provider in kwargs, no cached instance,
+    # and _get stubbed out so downstream network calls never happen
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("GALILEO_SSO_ID_TOKEN", "test-sso-token")
+    monkeypatch.setattr(GalileoPythonConfig, "_instance", None)
+    monkeypatch.setattr(GalileoPythonConfig, "_get", lambda *a, **kw: MagicMock(spec=GalileoPythonConfig))
+
+    # When/Then: the guard accepts the mixed configuration and _get is reached without raising
+    GalileoPythonConfig.get(sso_provider="okta")
+
+
+@pytest.mark.parametrize(
+    "env_setup,expected_missing,expected_present",
+    [
+        ({"GALILEO_SSO_ID_TOKEN": "test-token"}, "GALILEO_SSO_PROVIDER", "GALILEO_SSO_ID_TOKEN"),
+        ({"GALILEO_SSO_PROVIDER": "okta"}, "GALILEO_SSO_ID_TOKEN", "GALILEO_SSO_PROVIDER"),
+        ({"GALILEO_USERNAME": "test-user"}, "GALILEO_PASSWORD", "GALILEO_USERNAME"),
+        ({"GALILEO_PASSWORD": "test-pass"}, "GALILEO_USERNAME", "GALILEO_PASSWORD"),
+    ],
+    ids=[
+        "sso_id_token_without_provider",
+        "sso_provider_without_id_token",
+        "username_without_password",
+        "password_without_username",
+    ],
+)
+def test_incomplete_auth_config_rejected_with_specific_guidance(
+    monkeypatch, env_setup, expected_missing, expected_present
+) -> None:
+    """Setting only one half of a paired auth method gives a targeted error."""
+    # Given: an incomplete paired auth configuration and no cached instance
+    _clear_auth_env(monkeypatch)
+    for env_var, value in env_setup.items():
+        monkeypatch.setenv(env_var, value)
     monkeypatch.setattr(GalileoPythonConfig, "_instance", None)
 
-    # When/Then: passing username= does not raise ConfigurationError (it may fail downstream, but the guard passes)
-    with pytest.raises(Exception) as exc_info:
-        GalileoPythonConfig.get(username="user", password="pass")
-    assert "GALILEO_API_KEY not detected" not in str(exc_info.value)
+    # When/Then: the guard rejects with a message identifying both the
+    # variable that's set and the one that's missing
+    with pytest.raises(ConfigurationError) as exc_info:
+        GalileoPythonConfig.get()
+    message = str(exc_info.value)
+    assert expected_present in message, f"Expected error to reference {expected_present}: {message}"
+    assert expected_missing in message, f"Expected error to reference {expected_missing}: {message}"
+    assert "is set but" in message, f"Expected targeted incomplete-config phrasing: {message}"


### PR DESCRIPTION
# User description
**Shortcut:**
[sc-63971](https://app.shortcut.com/galileo/story/63971/galileopythonconfig-get-rejects-valid-galileo-sso-id-token-env-var-auth)

**Description:**
**Problem** - `GalileoPythonConfig.get()` has a guard that rejects callers before any downstream initialization runs. That guard only checked GALILEO_API_KEY. Users authenticating via SSO (GALILEO_SSO_ID_TOKEN + GALILEO_SSO_PROVIDER), username/password, or a pre-exchanged JWT were greeted with:
```
GALILEO_API_KEY not detected. Please set the GALILEO_API_KEY environment variable...
```
even when their credentials were perfectly valid.

**Fix** - Replaced the single env-var check with _check_auth_config(), a new static method that checks all four auth methods the underlying config model supports


Method | Standalone / Paired | Source
-- | -- | --
api_key | standalone | kwarg or GALILEO_API_KEY
jwt_token | standalone | kwarg or GALILEO_JWT_TOKEN
SSO | paired (both required) | sso_id_token/GALILEO_SSO_ID_TOKEN + sso_provider/GALILEO_SSO_PROVIDER
Username/password | paired (both required) | username/GALILEO_USERNAME + password/GALILEO_PASSWORD

Incomplete paired configs get targeted errors rather than the generic "no API key" message:

GALILEO_SSO_ID_TOKEN is set but GALILEO_SSO_PROVIDER is missing.
SSO authentication requires both. Set GALILEO_SSO_PROVIDER to your
IdP identifier (e.g. 'okta', 'custom') or pass sso_provider=... as a keyword argument.


**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expand <code>GalileoPythonConfig.get</code>'s guard to rely on <code>_check_auth_config</code> so the singleton initialization only proceeds when one of the supported auth methods is fully configured. Clarify <code>_check_auth_config</code>'s messaging for incomplete SSO or username/password pairs to point users at the missing environment variable or kwarg.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/579?tool=ast&topic=Auth+guard+logic>Auth guard logic</a>
        </td><td>Validate all supported authentication paths via <code>_check_auth_config</code> before allowing <code>GalileoPythonConfig.get</code> to build the singleton, and return targeted messages when paired credentials are partially provided.<details><summary>Modified files (1)</summary><ul><li>src/galileo/config.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>michael@galileo.ai</td><td>fix(config): extend au...</td><td>May 05, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix: clarify error mes...</td><td>March 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/579?tool=ast&topic=Config+tests>Config tests</a>
        </td><td>Expand config guard tests to cover every standalone and paired auth combination, mixed sources, and the new incomplete-pair guidance.<details><summary>Modified files (1)</summary><ul><li>tests/test_config.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>michael@galileo.ai</td><td>fix(config): extend au...</td><td>May 05, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix: clarify error mes...</td><td>March 26, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-python/579?tool=ast>(Baz)</a>.