### PR TITLE
feat: add Agent Control target helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,27 @@ logger.conclude(output="Hello, this is a test", duration_ns=1000)
 logger.flush() # This will upload the trace to Galileo
 ```
 
+#### Using Galileo context with Agent Control
+
+If you use Galileo-hosted Agent Control, pass the current Galileo log stream as
+the Agent Control runtime target:
+
+```python
+from galileo import get_agent_control_target
+
+target = get_agent_control_target()
+
+agent_control_client.evaluate(
+    ...,
+    target_type=target.target_type,
+    target_id=target.target_id,
+)
+```
+
+The helper resolves an explicit log stream ID, `GALILEO_LOG_STREAM_ID`, or an
+already-initialized `galileo_context` logger. It does not import the Agent
+Control SDK or resolve log stream names over the network.
+
 OpenAI streaming example:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ current Galileo log stream as the runtime target:
 
 ```python
 import agent_control
-from galileo import get_agent_control_target
+from galileo import galileo_context, get_agent_control_target
+
+galileo_context.init(project="my-project", log_stream="prod")
 
 target = get_agent_control_target()
 

--- a/README.md
+++ b/README.md
@@ -157,24 +157,28 @@ logger.flush() # This will upload the trace to Galileo
 
 #### Using Galileo context with Agent Control
 
-If you use Galileo-hosted Agent Control, pass the current Galileo log stream as
-the Agent Control runtime target:
+If you use Galileo-hosted Agent Control, initialize Agent Control with the
+current Galileo log stream as the runtime target:
 
 ```python
+import agent_control
 from galileo import get_agent_control_target
 
 target = get_agent_control_target()
 
-agent_control_client.evaluate(
-    ...,
+agent_control.init(
     target_type=target.target_type,
     target_id=target.target_id,
+    # server_url, api_key, and api_key_header can be passed here or configured
+    # through the Agent Control SDK environment variables.
 )
 ```
 
 The helper resolves an explicit log stream ID, `GALILEO_LOG_STREAM_ID`, or an
 already-initialized `galileo_context` logger. It does not import the Agent
-Control SDK or resolve log stream names over the network.
+Control SDK or resolve log stream names over the network. If you use a direct
+Agent Control client instead of `agent_control.init(...)`, pass
+`target.target_type` and `target.target_id` on each evaluation call.
 
 OpenAI streaming example:
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ Control SDK or resolve log stream names over the network. If you use a direct
 Agent Control client instead of `agent_control.init(...)`, pass
 `target.target_type` and `target.target_id` on each evaluation call.
 
+`galileo.agent_control` resolves targets for Agent Control calls.
+`galileo.handlers.agent_control` bridges Agent Control telemetry into Galileo
+logging.
+
 OpenAI streaming example:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ from galileo import get_agent_control_target
 target = get_agent_control_target()
 
 agent_control.init(
+    agent_name="my-agent",
     target_type=target.target_type,
     target_id=target.target_id,
     # server_url, api_key, and api_key_header can be passed here or configured

--- a/src/galileo/__init__.py
+++ b/src/galileo/__init__.py
@@ -1,11 +1,6 @@
 """Galileo."""
 
-from galileo.agent_control import (
-    AgentControlTarget,
-    AgentControlTargetUnresolvedError,
-    get_agent_control_target,
-    get_log_stream_id,
-)
+from galileo.agent_control import AgentControlTarget, AgentControlTargetUnresolvedError, get_agent_control_target
 from galileo.collaborator import Collaborator, CollaboratorRole
 from galileo.configuration import Configuration
 from galileo.dataset import Dataset
@@ -154,7 +149,6 @@ __all__ = [
     "enable_console_logging",
     "galileo_context",
     "get_agent_control_target",
-    "get_log_stream_id",
     "get_protect_stage",
     "get_tracing_headers",
     "invoke_protect",

--- a/src/galileo/__init__.py
+++ b/src/galileo/__init__.py
@@ -1,5 +1,11 @@
 """Galileo."""
 
+from galileo.agent_control import (
+    AgentControlTarget,
+    AgentControlTargetUnresolvedError,
+    get_agent_control_target,
+    get_log_stream_id,
+)
 from galileo.collaborator import Collaborator, CollaboratorRole
 from galileo.configuration import Configuration
 from galileo.dataset import Dataset
@@ -74,6 +80,8 @@ __version__ = "2.2.0"
 
 __all__ = [
     "APIError",
+    "AgentControlTarget",
+    "AgentControlTargetUnresolvedError",
     "AgentSpan",
     "AnthropicProvider",
     "AuthenticationError",
@@ -145,6 +153,8 @@ __all__ = [
     "delete_api_key",
     "enable_console_logging",
     "galileo_context",
+    "get_agent_control_target",
+    "get_log_stream_id",
     "get_protect_stage",
     "get_tracing_headers",
     "invoke_protect",

--- a/src/galileo/agent_control.py
+++ b/src/galileo/agent_control.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from galileo.decorator import galileo_context
+from galileo.utils.env_helpers import _get_log_stream_or_default, _get_project_or_default
 from galileo.utils.singleton import GalileoLoggerSingleton
 
 LOG_STREAM_TARGET_TYPE = "log_stream"
@@ -121,13 +122,13 @@ def _validate_uuid(value: str, source: str) -> None:
 
 
 def _resolve_log_stream_from_cached_context() -> AgentControlTarget | None:
-    current_project = galileo_context.get_current_project()
-    current_log_stream = galileo_context.get_current_log_stream()
-    if current_project is None or current_log_stream is None:
-        return None
+    current_project = _get_project_or_default(galileo_context.get_current_project())
+    current_log_stream = _get_log_stream_or_default(galileo_context.get_current_log_stream())
 
     # Read cached logger state directly so this helper never creates or resolves
     # projects/log streams as a side effect of building an Agent Control target.
+    # Use the same default/env fallback as GalileoLogger so callers that rely on
+    # default project/log-stream creation can still reuse the resolved IDs.
     for logger in GalileoLoggerSingleton()._galileo_loggers.values():
         if logger.project_name != current_project or logger.log_stream_name != current_log_stream:
             continue

--- a/src/galileo/agent_control.py
+++ b/src/galileo/agent_control.py
@@ -1,0 +1,143 @@
+"""Resolve Galileo context for Agent Control calls.
+
+This module produces generic Agent Control targets from Galileo state. It does
+not import the Agent Control SDK; callers wire the two SDKs together explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from uuid import UUID
+
+from galileo.decorator import galileo_context
+from galileo.utils.singleton import GalileoLoggerSingleton
+
+LOG_STREAM_TARGET_TYPE = "log_stream"
+
+
+class AgentControlTargetUnresolvedError(ValueError):
+    """Raised when no Agent Control target can be resolved from available inputs."""
+
+
+@dataclass(frozen=True)
+class AgentControlTarget:
+    """A target identifier that can be passed to Agent Control.
+
+    Parameters
+    ----------
+    target_type
+        Opaque Agent Control target type. Agent Control treats this value as
+        deployer-defined; Galileo currently auto-resolves only ``log_stream``
+        targets.
+    target_id
+        Opaque Agent Control target ID.
+    project_id
+        Galileo project ID for logs, debugging, and audit context only. Agent
+        Control resolves project ownership from ``target_type`` and
+        ``target_id``.
+    """
+
+    target_type: str
+    target_id: str
+    project_id: str | None = None
+
+
+def get_agent_control_target(
+    *,
+    target_type: str = LOG_STREAM_TARGET_TYPE,
+    target_id: str | None = None,
+    log_stream_id: str | None = None,
+    project_id: str | None = None,
+) -> AgentControlTarget:
+    """Resolve an Agent Control target from explicit inputs or Galileo context.
+
+    Resolution order:
+
+    1. Explicit ``target_id``.
+    2. Explicit ``log_stream_id`` for ``log_stream`` targets.
+    3. ``GALILEO_LOG_STREAM_ID`` for ``log_stream`` targets.
+    4. An already-initialized ``galileo_context`` logger.
+
+    This helper does not resolve log stream names over the network. If only a
+    log stream name is available, resolve it with the Galileo SDK first and pass
+    the resulting ID explicitly.
+    """
+    resolved_project_id = project_id or os.getenv("GALILEO_PROJECT_ID")
+
+    if target_type != LOG_STREAM_TARGET_TYPE and log_stream_id is not None:
+        raise ValueError("log_stream_id can only be used with target_type='log_stream'.")
+
+    if target_id is not None and log_stream_id is not None and target_id != log_stream_id:
+        raise ValueError("target_id and log_stream_id must match when both are provided.")
+
+    resolved_target_id = target_id or log_stream_id
+    if resolved_target_id is not None:
+        if target_type == LOG_STREAM_TARGET_TYPE:
+            _validate_uuid(resolved_target_id, "log_stream_id")
+        return AgentControlTarget(target_type=target_type, target_id=resolved_target_id, project_id=resolved_project_id)
+
+    if target_type != LOG_STREAM_TARGET_TYPE:
+        raise AgentControlTargetUnresolvedError(
+            f"Could not resolve Agent Control target for target_type={target_type!r}. "
+            "Provide target_id=<id> explicitly."
+        )
+
+    env_log_stream_id = os.getenv("GALILEO_LOG_STREAM_ID")
+    if env_log_stream_id:
+        _validate_uuid(env_log_stream_id, "GALILEO_LOG_STREAM_ID")
+        return AgentControlTarget(
+            target_type=LOG_STREAM_TARGET_TYPE, target_id=env_log_stream_id, project_id=resolved_project_id
+        )
+
+    context_target = _resolve_log_stream_from_cached_context()
+    if context_target is not None:
+        if resolved_project_id is not None:
+            return AgentControlTarget(
+                target_type=context_target.target_type,
+                target_id=context_target.target_id,
+                project_id=resolved_project_id,
+            )
+        return context_target
+
+    raise AgentControlTargetUnresolvedError(
+        "Could not resolve Galileo log stream ID for Agent Control. Provide one of:\n"
+        "  1. target_id=<uuid> or log_stream_id=<uuid> argument\n"
+        "  2. GALILEO_LOG_STREAM_ID environment variable\n"
+        "  3. An initialized galileo_context with a resolved log stream ID"
+    )
+
+
+def get_log_stream_id(*, log_stream_id: str | None = None) -> str:
+    """Resolve the current Galileo log stream ID for Agent Control calls."""
+    return get_agent_control_target(log_stream_id=log_stream_id).target_id
+
+
+def _validate_uuid(value: str, source: str) -> None:
+    try:
+        UUID(value)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise AgentControlTargetUnresolvedError(f"{source}={value!r} is not a valid UUID.") from exc
+
+
+def _resolve_log_stream_from_cached_context() -> AgentControlTarget | None:
+    current_project = galileo_context.get_current_project()
+    current_log_stream = galileo_context.get_current_log_stream()
+    if current_project is None or current_log_stream is None:
+        return None
+
+    # Read cached logger state directly so this helper never creates or resolves
+    # projects/log streams as a side effect of building an Agent Control target.
+    for logger in GalileoLoggerSingleton()._galileo_loggers.values():
+        if logger.project_name != current_project or logger.log_stream_name != current_log_stream:
+            continue
+        if logger.log_stream_id is None:
+            continue
+        return AgentControlTarget(
+            target_type=LOG_STREAM_TARGET_TYPE, target_id=logger.log_stream_id, project_id=logger.project_id
+        )
+
+    return None
+
+
+__all__ = ["AgentControlTarget", "AgentControlTargetUnresolvedError", "get_agent_control_target", "get_log_stream_id"]

--- a/src/galileo/agent_control.py
+++ b/src/galileo/agent_control.py
@@ -2,6 +2,8 @@
 
 This module produces generic Agent Control targets from Galileo state. It does
 not import the Agent Control SDK; callers wire the two SDKs together explicitly.
+
+For Agent Control telemetry ingestion, use ``galileo.handlers.agent_control``.
 """
 
 from __future__ import annotations

--- a/src/galileo/agent_control.py
+++ b/src/galileo/agent_control.py
@@ -7,6 +7,7 @@ not import the Agent Control SDK; callers wire the two SDKs together explicitly.
 from __future__ import annotations
 
 import os
+import threading
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -64,8 +65,13 @@ def get_agent_control_target(
     log stream name is available, resolve it with the Galileo SDK first and pass
     the resulting ID explicitly.
     """
-    env_project_id = os.getenv("GALILEO_PROJECT_ID")
-    resolved_project_id = project_id or env_project_id
+    explicit_project_id = _strip_optional_string(project_id)
+    env_project_id = _strip_optional_string(os.getenv("GALILEO_PROJECT_ID"))
+    resolved_project_id = explicit_project_id or env_project_id
+
+    if target_type == LOG_STREAM_TARGET_TYPE:
+        target_id = _strip_optional_string(target_id)
+    log_stream_id = _strip_optional_string(log_stream_id)
 
     if target_type != LOG_STREAM_TARGET_TYPE and log_stream_id is not None:
         raise AgentControlTargetUnresolvedError("log_stream_id can only be used with target_type='log_stream'.")
@@ -73,7 +79,7 @@ def get_agent_control_target(
     if target_id is not None and log_stream_id is not None and target_id != log_stream_id:
         raise AgentControlTargetUnresolvedError("target_id and log_stream_id must match when both are provided.")
 
-    resolved_target_id = target_id or log_stream_id
+    resolved_target_id = target_id if target_id is not None else log_stream_id
     if resolved_target_id is not None:
         if target_type == LOG_STREAM_TARGET_TYPE:
             source_label = "target_id" if target_id is not None else "log_stream_id"
@@ -86,7 +92,7 @@ def get_agent_control_target(
             "Provide target_id=<id> explicitly."
         )
 
-    env_log_stream_id = os.getenv("GALILEO_LOG_STREAM_ID")
+    env_log_stream_id = _strip_optional_string(os.getenv("GALILEO_LOG_STREAM_ID"))
     if env_log_stream_id:
         _validate_uuid(env_log_stream_id, "GALILEO_LOG_STREAM_ID")
         return AgentControlTarget(
@@ -98,7 +104,7 @@ def get_agent_control_target(
         return AgentControlTarget(
             target_type=context_target.target_type,
             target_id=context_target.target_id,
-            project_id=project_id or context_target.project_id or env_project_id,
+            project_id=explicit_project_id or context_target.project_id or env_project_id,
         )
 
     raise AgentControlTargetUnresolvedError(
@@ -109,11 +115,6 @@ def get_agent_control_target(
     )
 
 
-def get_log_stream_id(*, log_stream_id: str | None = None) -> str:
-    """Resolve the current Galileo log stream ID for Agent Control calls."""
-    return get_agent_control_target(log_stream_id=log_stream_id).target_id
-
-
 def _validate_uuid(value: str, source: str) -> None:
     try:
         UUID(value)
@@ -121,15 +122,24 @@ def _validate_uuid(value: str, source: str) -> None:
         raise AgentControlTargetUnresolvedError(f"{source}={value!r} is not a valid UUID.") from exc
 
 
+def _strip_optional_string(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return value.strip()
+
+
 def _resolve_log_stream_from_cached_context() -> AgentControlTarget | None:
     current_project = _get_project_or_default(galileo_context.get_current_project())
     current_log_stream = _get_log_stream_or_default(galileo_context.get_current_log_stream())
+    current_thread_name = threading.current_thread().name
 
     # Read cached logger state directly so this helper never creates or resolves
     # projects/log streams as a side effect of building an Agent Control target.
     # Use the same default/env fallback as GalileoLogger so callers that rely on
     # default project/log-stream creation can still reuse the resolved IDs.
-    for logger in GalileoLoggerSingleton().get_all_loggers().values():
+    for key, logger in GalileoLoggerSingleton().get_all_loggers().items():
+        if not key or key[0] != current_thread_name:
+            continue
         if logger.project_name != current_project or logger.log_stream_name != current_log_stream:
             continue
         if logger.log_stream_id is None:
@@ -141,4 +151,4 @@ def _resolve_log_stream_from_cached_context() -> AgentControlTarget | None:
     return None
 
 
-__all__ = ["AgentControlTarget", "AgentControlTargetUnresolvedError", "get_agent_control_target", "get_log_stream_id"]
+__all__ = ["AgentControlTarget", "AgentControlTargetUnresolvedError", "get_agent_control_target"]

--- a/src/galileo/agent_control.py
+++ b/src/galileo/agent_control.py
@@ -64,18 +64,20 @@ def get_agent_control_target(
     log stream name is available, resolve it with the Galileo SDK first and pass
     the resulting ID explicitly.
     """
-    resolved_project_id = project_id or os.getenv("GALILEO_PROJECT_ID")
+    env_project_id = os.getenv("GALILEO_PROJECT_ID")
+    resolved_project_id = project_id or env_project_id
 
     if target_type != LOG_STREAM_TARGET_TYPE and log_stream_id is not None:
-        raise ValueError("log_stream_id can only be used with target_type='log_stream'.")
+        raise AgentControlTargetUnresolvedError("log_stream_id can only be used with target_type='log_stream'.")
 
     if target_id is not None and log_stream_id is not None and target_id != log_stream_id:
-        raise ValueError("target_id and log_stream_id must match when both are provided.")
+        raise AgentControlTargetUnresolvedError("target_id and log_stream_id must match when both are provided.")
 
     resolved_target_id = target_id or log_stream_id
     if resolved_target_id is not None:
         if target_type == LOG_STREAM_TARGET_TYPE:
-            _validate_uuid(resolved_target_id, "log_stream_id")
+            source_label = "target_id" if target_id is not None else "log_stream_id"
+            _validate_uuid(resolved_target_id, source_label)
         return AgentControlTarget(target_type=target_type, target_id=resolved_target_id, project_id=resolved_project_id)
 
     if target_type != LOG_STREAM_TARGET_TYPE:
@@ -93,13 +95,11 @@ def get_agent_control_target(
 
     context_target = _resolve_log_stream_from_cached_context()
     if context_target is not None:
-        if resolved_project_id is not None:
-            return AgentControlTarget(
-                target_type=context_target.target_type,
-                target_id=context_target.target_id,
-                project_id=resolved_project_id,
-            )
-        return context_target
+        return AgentControlTarget(
+            target_type=context_target.target_type,
+            target_id=context_target.target_id,
+            project_id=project_id or context_target.project_id or env_project_id,
+        )
 
     raise AgentControlTargetUnresolvedError(
         "Could not resolve Galileo log stream ID for Agent Control. Provide one of:\n"
@@ -129,7 +129,7 @@ def _resolve_log_stream_from_cached_context() -> AgentControlTarget | None:
     # projects/log streams as a side effect of building an Agent Control target.
     # Use the same default/env fallback as GalileoLogger so callers that rely on
     # default project/log-stream creation can still reuse the resolved IDs.
-    for logger in GalileoLoggerSingleton()._galileo_loggers.values():
+    for logger in GalileoLoggerSingleton().get_all_loggers().values():
         if logger.project_name != current_project or logger.log_stream_name != current_log_stream:
             continue
         if logger.log_stream_id is None:

--- a/src/galileo/handlers/agent_control/__init__.py
+++ b/src/galileo/handlers/agent_control/__init__.py
@@ -1,4 +1,7 @@
-"""Agent Control bridge for Galileo logger-backed control span ingestion."""
+"""Agent Control bridge for Galileo logger-backed control span ingestion.
+
+For Agent Control target resolution, use ``galileo.agent_control``.
+"""
 
 from galileo.handlers.agent_control.bridge import GalileoAgentControlBridge, setup_agent_control_bridge
 

--- a/tests/test_agent_control.py
+++ b/tests/test_agent_control.py
@@ -16,16 +16,20 @@ def reset_agent_control_helper_state(monkeypatch):
     monkeypatch.delenv("GALILEO_LOG_STREAM", raising=False)
     monkeypatch.delenv("GALILEO_LOG_STREAM_ID", raising=False)
     monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
-    singleton = GalileoLoggerSingleton()
-    original_loggers = singleton._galileo_loggers
-    singleton._galileo_loggers = {}
+    monkeypatch.setattr(GalileoLoggerSingleton, "get_all_loggers", lambda self: {})
+    monkeypatch.setattr(
+        galileo_context, "get_logger_instance", lambda *args, **kwargs: SimpleNamespace(flush=lambda: None)
+    )
     galileo_context.reset()
 
     yield
 
     # Then: context and singleton state are restored for following tests
     galileo_context.reset()
-    singleton._galileo_loggers = original_loggers
+
+
+def _stub_cached_logger(monkeypatch, logger: SimpleNamespace) -> None:
+    monkeypatch.setattr(GalileoLoggerSingleton, "get_all_loggers", lambda self: {("test",): logger})
 
 
 def test_get_agent_control_target_uses_explicit_log_stream_id() -> None:
@@ -77,7 +81,7 @@ def test_get_agent_control_target_uses_env_log_stream_id(monkeypatch) -> None:
     assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
 
 
-def test_get_agent_control_target_uses_cached_context_logger() -> None:
+def test_get_agent_control_target_uses_cached_context_logger(monkeypatch) -> None:
     # Given: an active Galileo context with an already-resolved logger
     project_id = str(uuid4())
     log_stream_id = str(uuid4())
@@ -88,18 +92,17 @@ def test_get_agent_control_target_uses_cached_context_logger() -> None:
         log_stream_id=log_stream_id,
         terminate=lambda: None,
     )
-    GalileoLoggerSingleton()._galileo_loggers[("test",)] = logger
-    # galileo_context(...) sets ContextVar state before returning the context manager.
-    galileo_context(project="project-a", log_stream="stream-a")
+    _stub_cached_logger(monkeypatch, logger)
 
     # When: resolving an Agent Control target
-    target = get_agent_control_target()
+    with galileo_context(project="project-a", log_stream="stream-a"):
+        target = get_agent_control_target()
 
     # Then: the helper reads the resolved IDs without creating a new logger
     assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
 
 
-def test_get_agent_control_target_uses_cached_default_logger() -> None:
+def test_get_agent_control_target_uses_cached_default_logger(monkeypatch) -> None:
     # Given: Galileo initialized a logger with default project and log-stream names
     project_id = str(uuid4())
     log_stream_id = str(uuid4())
@@ -110,7 +113,7 @@ def test_get_agent_control_target_uses_cached_default_logger() -> None:
         log_stream_id=log_stream_id,
         terminate=lambda: None,
     )
-    GalileoLoggerSingleton()._galileo_loggers[("test",)] = logger
+    _stub_cached_logger(monkeypatch, logger)
 
     # When: resolving an Agent Control target without explicit context names
     target = get_agent_control_target()
@@ -132,13 +135,58 @@ def test_get_agent_control_target_uses_cached_env_default_logger(monkeypatch) ->
         log_stream_id=log_stream_id,
         terminate=lambda: None,
     )
-    GalileoLoggerSingleton()._galileo_loggers[("test",)] = logger
+    _stub_cached_logger(monkeypatch, logger)
 
     # When: resolving an Agent Control target without explicit context names
     target = get_agent_control_target()
 
     # Then: the helper follows Galileo's env fallback and reuses the resolved ID
     assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
+
+
+def test_get_agent_control_target_prefers_cached_logger_project_id_over_env(monkeypatch) -> None:
+    # Given: env project ID is stale but the cached logger has the resolved project ID
+    cached_project_id = str(uuid4())
+    env_project_id = str(uuid4())
+    log_stream_id = str(uuid4())
+    monkeypatch.setenv("GALILEO_PROJECT_ID", env_project_id)
+    logger = SimpleNamespace(
+        project_name=DEFAULT_PROJECT_NAME,
+        log_stream_name=DEFAULT_LOG_STREAM_NAME,
+        project_id=cached_project_id,
+        log_stream_id=log_stream_id,
+        terminate=lambda: None,
+    )
+    _stub_cached_logger(monkeypatch, logger)
+
+    # When: resolving from cached logger state
+    target = get_agent_control_target()
+
+    # Then: the informational project ID matches the resolved log stream
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=cached_project_id)
+
+
+def test_get_agent_control_target_uses_explicit_project_id_with_cached_logger(monkeypatch) -> None:
+    # Given: a caller explicitly overrides the informational project ID
+    cached_project_id = str(uuid4())
+    explicit_project_id = str(uuid4())
+    log_stream_id = str(uuid4())
+    logger = SimpleNamespace(
+        project_name=DEFAULT_PROJECT_NAME,
+        log_stream_name=DEFAULT_LOG_STREAM_NAME,
+        project_id=cached_project_id,
+        log_stream_id=log_stream_id,
+        terminate=lambda: None,
+    )
+    _stub_cached_logger(monkeypatch, logger)
+
+    # When: resolving from cached logger state with an explicit project ID
+    target = get_agent_control_target(project_id=explicit_project_id)
+
+    # Then: explicit input wins over the cached informational project ID
+    assert target == AgentControlTarget(
+        target_type="log_stream", target_id=log_stream_id, project_id=explicit_project_id
+    )
 
 
 def test_get_log_stream_id_returns_resolved_target_id() -> None:
@@ -173,7 +221,7 @@ def test_get_agent_control_target_rejects_invalid_explicit_log_stream_target_id(
     # Given: an invalid explicit target ID for the default log-stream target type
 
     # When/Then: resolving the target fails before sending a malformed target to Agent Control
-    with pytest.raises(AgentControlTargetUnresolvedError, match="log_stream_id='prod' is not a valid UUID"):
+    with pytest.raises(AgentControlTargetUnresolvedError, match="target_id='prod' is not a valid UUID"):
         get_agent_control_target(target_id="prod")
 
 
@@ -189,7 +237,7 @@ def test_get_agent_control_target_rejects_conflicting_ids() -> None:
     # Given: conflicting target ID inputs
 
     # When/Then: resolving the target fails before choosing one arbitrarily
-    with pytest.raises(ValueError, match="target_id and log_stream_id must match"):
+    with pytest.raises(AgentControlTargetUnresolvedError, match="target_id and log_stream_id must match"):
         get_agent_control_target(target_id=str(uuid4()), log_stream_id=str(uuid4()))
 
 

--- a/tests/test_agent_control.py
+++ b/tests/test_agent_control.py
@@ -1,9 +1,10 @@
+import threading
 from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
-from galileo import AgentControlTarget, AgentControlTargetUnresolvedError, get_agent_control_target, get_log_stream_id
+from galileo import AgentControlTarget, AgentControlTargetUnresolvedError, get_agent_control_target
 from galileo.constants import DEFAULT_LOG_STREAM_NAME, DEFAULT_PROJECT_NAME
 from galileo.decorator import galileo_context
 from galileo.utils.singleton import GalileoLoggerSingleton
@@ -29,7 +30,12 @@ def reset_agent_control_helper_state(monkeypatch):
 
 
 def _stub_cached_logger(monkeypatch, logger: SimpleNamespace) -> None:
-    monkeypatch.setattr(GalileoLoggerSingleton, "get_all_loggers", lambda self: {("test",): logger})
+    key = (threading.current_thread().name, "batch", logger.project_name, logger.log_stream_name)
+    monkeypatch.setattr(GalileoLoggerSingleton, "get_all_loggers", lambda self: {key: logger})
+
+
+def _stub_cached_loggers(monkeypatch, loggers: dict[tuple[str, ...], SimpleNamespace]) -> None:
+    monkeypatch.setattr(GalileoLoggerSingleton, "get_all_loggers", lambda self: loggers)
 
 
 def test_get_agent_control_target_uses_explicit_log_stream_id() -> None:
@@ -79,6 +85,31 @@ def test_get_agent_control_target_uses_env_log_stream_id(monkeypatch) -> None:
 
     # Then: the target uses the env-provided IDs
     assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
+
+
+def test_get_agent_control_target_strips_env_ids(monkeypatch) -> None:
+    # Given: Galileo ID environment values with accidental surrounding whitespace
+    log_stream_id = str(uuid4())
+    project_id = str(uuid4())
+    monkeypatch.setenv("GALILEO_LOG_STREAM_ID", f"  {log_stream_id}  ")
+    monkeypatch.setenv("GALILEO_PROJECT_ID", f"  {project_id}  ")
+
+    # When: resolving an Agent Control target
+    target = get_agent_control_target()
+
+    # Then: the returned IDs are normalized before validation and use
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
+
+
+def test_get_agent_control_target_strips_explicit_log_stream_target_id() -> None:
+    # Given: an explicit Galileo log stream target ID with accidental whitespace
+    log_stream_id = str(uuid4())
+
+    # When: resolving an Agent Control target
+    target = get_agent_control_target(target_id=f"  {log_stream_id}  ")
+
+    # Then: the explicit target ID is normalized before validation and use
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id)
 
 
 def test_get_agent_control_target_uses_cached_context_logger(monkeypatch) -> None:
@@ -144,6 +175,24 @@ def test_get_agent_control_target_uses_cached_env_default_logger(monkeypatch) ->
     assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
 
 
+def test_get_agent_control_target_ignores_cached_logger_from_other_thread(monkeypatch) -> None:
+    # Given: a cached logger for the same default target but from another thread
+    logger = SimpleNamespace(
+        project_name=DEFAULT_PROJECT_NAME,
+        log_stream_name=DEFAULT_LOG_STREAM_NAME,
+        project_id=str(uuid4()),
+        log_stream_id=str(uuid4()),
+        terminate=lambda: None,
+    )
+    _stub_cached_loggers(
+        monkeypatch, {("other-thread", "batch", DEFAULT_PROJECT_NAME, DEFAULT_LOG_STREAM_NAME): logger}
+    )
+
+    # When/Then: resolving the target does not use another thread's logger
+    with pytest.raises(AgentControlTargetUnresolvedError, match="Could not resolve Galileo log stream ID"):
+        get_agent_control_target()
+
+
 def test_get_agent_control_target_prefers_cached_logger_project_id_over_env(monkeypatch) -> None:
     # Given: env project ID is stale but the cached logger has the resolved project ID
     cached_project_id = str(uuid4())
@@ -187,17 +236,6 @@ def test_get_agent_control_target_uses_explicit_project_id_with_cached_logger(mo
     assert target == AgentControlTarget(
         target_type="log_stream", target_id=log_stream_id, project_id=explicit_project_id
     )
-
-
-def test_get_log_stream_id_returns_resolved_target_id() -> None:
-    # Given: an explicit Galileo log stream ID
-    log_stream_id = str(uuid4())
-
-    # When: resolving the log stream ID shortcut
-    resolved_log_stream_id = get_log_stream_id(log_stream_id=log_stream_id)
-
-    # Then: the shortcut returns the target ID
-    assert resolved_log_stream_id == log_stream_id
 
 
 def test_get_agent_control_target_rejects_invalid_log_stream_id(monkeypatch) -> None:

--- a/tests/test_agent_control.py
+++ b/tests/test_agent_control.py
@@ -1,0 +1,156 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from galileo import AgentControlTarget, AgentControlTargetUnresolvedError, get_agent_control_target, get_log_stream_id
+from galileo.decorator import galileo_context
+from galileo.utils.singleton import GalileoLoggerSingleton
+
+
+@pytest.fixture(autouse=True)
+def reset_agent_control_helper_state(monkeypatch):
+    # Given: no log stream ID environment override or cached logger state
+    monkeypatch.delenv("GALILEO_LOG_STREAM_ID", raising=False)
+    monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+    singleton = GalileoLoggerSingleton()
+    original_loggers = singleton._galileo_loggers
+    singleton._galileo_loggers = {}
+    galileo_context.reset()
+
+    yield
+
+    # Then: context and singleton state are restored for following tests
+    galileo_context.reset()
+    singleton._galileo_loggers = original_loggers
+
+
+def test_get_agent_control_target_uses_explicit_log_stream_id() -> None:
+    # Given: an explicit Galileo log stream ID
+    log_stream_id = str(uuid4())
+
+    # When: resolving an Agent Control target
+    target = get_agent_control_target(log_stream_id=log_stream_id)
+
+    # Then: the target is log-stream scoped
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id)
+
+
+def test_get_agent_control_target_uses_env_project_id_with_explicit_log_stream_id(monkeypatch) -> None:
+    # Given: an explicit Galileo log stream ID and project ID from the environment
+    log_stream_id = str(uuid4())
+    project_id = str(uuid4())
+    monkeypatch.setenv("GALILEO_PROJECT_ID", project_id)
+
+    # When: resolving an Agent Control target
+    target = get_agent_control_target(log_stream_id=log_stream_id)
+
+    # Then: the helper includes the informational project ID consistently
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
+
+
+def test_get_agent_control_target_uses_explicit_future_target() -> None:
+    # Given: an explicit non-log-stream Agent Control target
+    project_id = str(uuid4())
+
+    # When: resolving the target
+    target = get_agent_control_target(target_type="agent", target_id="agent-123", project_id=project_id)
+
+    # Then: the helper packages the target without Galileo log-stream validation
+    assert target == AgentControlTarget(target_type="agent", target_id="agent-123", project_id=project_id)
+
+
+def test_get_agent_control_target_uses_env_log_stream_id(monkeypatch) -> None:
+    # Given: a Galileo log stream ID in the environment
+    log_stream_id = str(uuid4())
+    project_id = str(uuid4())
+    monkeypatch.setenv("GALILEO_LOG_STREAM_ID", log_stream_id)
+    monkeypatch.setenv("GALILEO_PROJECT_ID", project_id)
+
+    # When: resolving an Agent Control target
+    target = get_agent_control_target()
+
+    # Then: the target uses the env-provided IDs
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
+
+
+def test_get_agent_control_target_uses_cached_context_logger() -> None:
+    # Given: an active Galileo context with an already-resolved logger
+    project_id = str(uuid4())
+    log_stream_id = str(uuid4())
+    logger = SimpleNamespace(
+        project_name="project-a",
+        log_stream_name="stream-a",
+        project_id=project_id,
+        log_stream_id=log_stream_id,
+        terminate=lambda: None,
+    )
+    GalileoLoggerSingleton()._galileo_loggers[("test",)] = logger
+    # galileo_context(...) sets ContextVar state before returning the context manager.
+    galileo_context(project="project-a", log_stream="stream-a")
+
+    # When: resolving an Agent Control target
+    target = get_agent_control_target()
+
+    # Then: the helper reads the resolved IDs without creating a new logger
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
+
+
+def test_get_log_stream_id_returns_resolved_target_id() -> None:
+    # Given: an explicit Galileo log stream ID
+    log_stream_id = str(uuid4())
+
+    # When: resolving the log stream ID shortcut
+    resolved_log_stream_id = get_log_stream_id(log_stream_id=log_stream_id)
+
+    # Then: the shortcut returns the target ID
+    assert resolved_log_stream_id == log_stream_id
+
+
+def test_get_agent_control_target_rejects_invalid_log_stream_id(monkeypatch) -> None:
+    # Given: an invalid Galileo log stream ID in the environment
+    monkeypatch.setenv("GALILEO_LOG_STREAM_ID", "prod")
+
+    # When/Then: resolving the target fails before sending a malformed target to Agent Control
+    with pytest.raises(AgentControlTargetUnresolvedError, match="GALILEO_LOG_STREAM_ID='prod' is not a valid UUID"):
+        get_agent_control_target()
+
+
+def test_get_agent_control_target_rejects_invalid_explicit_log_stream_id() -> None:
+    # Given: an invalid explicit Galileo log stream ID
+
+    # When/Then: resolving the target fails before sending a malformed target to Agent Control
+    with pytest.raises(AgentControlTargetUnresolvedError, match="log_stream_id='prod' is not a valid UUID"):
+        get_agent_control_target(log_stream_id="prod")
+
+
+def test_get_agent_control_target_rejects_invalid_explicit_log_stream_target_id() -> None:
+    # Given: an invalid explicit target ID for the default log-stream target type
+
+    # When/Then: resolving the target fails before sending a malformed target to Agent Control
+    with pytest.raises(AgentControlTargetUnresolvedError, match="log_stream_id='prod' is not a valid UUID"):
+        get_agent_control_target(target_id="prod")
+
+
+def test_get_agent_control_target_rejects_missing_future_target_id() -> None:
+    # Given: a non-log-stream target type without an explicit target ID
+
+    # When/Then: resolving the target fails with an actionable error
+    with pytest.raises(AgentControlTargetUnresolvedError, match="Provide target_id=<id> explicitly"):
+        get_agent_control_target(target_type="agent")
+
+
+def test_get_agent_control_target_rejects_conflicting_ids() -> None:
+    # Given: conflicting target ID inputs
+
+    # When/Then: resolving the target fails before choosing one arbitrarily
+    with pytest.raises(ValueError, match="target_id and log_stream_id must match"):
+        get_agent_control_target(target_id=str(uuid4()), log_stream_id=str(uuid4()))
+
+
+def test_get_agent_control_target_errors_when_unresolved() -> None:
+    # Given: no explicit ID, env ID, or cached context logger
+
+    # When/Then: resolving the target fails with the supported resolution options
+    with pytest.raises(AgentControlTargetUnresolvedError, match="Could not resolve Galileo log stream ID"):
+        get_agent_control_target()

--- a/tests/test_agent_control.py
+++ b/tests/test_agent_control.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import pytest
 
 from galileo import AgentControlTarget, AgentControlTargetUnresolvedError, get_agent_control_target, get_log_stream_id
+from galileo.constants import DEFAULT_LOG_STREAM_NAME, DEFAULT_PROJECT_NAME
 from galileo.decorator import galileo_context
 from galileo.utils.singleton import GalileoLoggerSingleton
 
@@ -11,6 +12,8 @@ from galileo.utils.singleton import GalileoLoggerSingleton
 @pytest.fixture(autouse=True)
 def reset_agent_control_helper_state(monkeypatch):
     # Given: no log stream ID environment override or cached logger state
+    monkeypatch.delenv("GALILEO_PROJECT", raising=False)
+    monkeypatch.delenv("GALILEO_LOG_STREAM", raising=False)
     monkeypatch.delenv("GALILEO_LOG_STREAM_ID", raising=False)
     monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
     singleton = GalileoLoggerSingleton()
@@ -93,6 +96,48 @@ def test_get_agent_control_target_uses_cached_context_logger() -> None:
     target = get_agent_control_target()
 
     # Then: the helper reads the resolved IDs without creating a new logger
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
+
+
+def test_get_agent_control_target_uses_cached_default_logger() -> None:
+    # Given: Galileo initialized a logger with default project and log-stream names
+    project_id = str(uuid4())
+    log_stream_id = str(uuid4())
+    logger = SimpleNamespace(
+        project_name=DEFAULT_PROJECT_NAME,
+        log_stream_name=DEFAULT_LOG_STREAM_NAME,
+        project_id=project_id,
+        log_stream_id=log_stream_id,
+        terminate=lambda: None,
+    )
+    GalileoLoggerSingleton()._galileo_loggers[("test",)] = logger
+
+    # When: resolving an Agent Control target without explicit context names
+    target = get_agent_control_target()
+
+    # Then: the helper reuses the default logger's resolved log-stream ID
+    assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
+
+
+def test_get_agent_control_target_uses_cached_env_default_logger(monkeypatch) -> None:
+    # Given: Galileo initialized a logger using environment-provided default names
+    project_id = str(uuid4())
+    log_stream_id = str(uuid4())
+    monkeypatch.setenv("GALILEO_PROJECT", "project-env")
+    monkeypatch.setenv("GALILEO_LOG_STREAM", "stream-env")
+    logger = SimpleNamespace(
+        project_name="project-env",
+        log_stream_name="stream-env",
+        project_id=project_id,
+        log_stream_id=log_stream_id,
+        terminate=lambda: None,
+    )
+    GalileoLoggerSingleton()._galileo_loggers[("test",)] = logger
+
+    # When: resolving an Agent Control target without explicit context names
+    target = get_agent_control_target()
+
+    # Then: the helper follows Galileo's env fallback and reuses the resolved ID
     assert target == AgentControlTarget(target_type="log_stream", target_id=log_stream_id, project_id=project_id)
 
 

--- a/tests/test_agent_control.py
+++ b/tests/test_agent_control.py
@@ -17,6 +17,7 @@ def reset_agent_control_helper_state(monkeypatch):
     monkeypatch.delenv("GALILEO_LOG_STREAM", raising=False)
     monkeypatch.delenv("GALILEO_LOG_STREAM_ID", raising=False)
     monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+    GalileoLoggerSingleton().reset_all()
     monkeypatch.setattr(GalileoLoggerSingleton, "get_all_loggers", lambda self: {})
     monkeypatch.setattr(
         galileo_context, "get_logger_instance", lambda *args, **kwargs: SimpleNamespace(flush=lambda: None)
@@ -27,6 +28,7 @@ def reset_agent_control_helper_state(monkeypatch):
 
     # Then: context and singleton state are restored for following tests
     galileo_context.reset()
+    GalileoLoggerSingleton().reset_all()
 
 
 def _stub_cached_logger(monkeypatch, logger: SimpleNamespace) -> None:


### PR DESCRIPTION
# User description
## Summary

Adds a small Galileo Python SDK helper for wiring Galileo log-stream context into Agent Control target context.

Agent Control runtime calls can be scoped to an opaque `(target_type, target_id)` pair. For Galileo-backed usage, the first target type is a Galileo log stream. This PR lets users already using the Galileo SDK derive that target from existing Galileo state instead of manually finding and passing a log stream UUID.

## Public API

Exports from `galileo`:

- `AgentControlTarget`
- `AgentControlTargetUnresolvedError`
- `get_agent_control_target`

The helper returns:

```python
AgentControlTarget(
    target_type="log_stream",
    target_id="<log-stream-uuid>",
    project_id="<project-uuid-or-none>",  # informational only
)
```

`get_log_stream_id` was intentionally not added as a shortcut. `get_agent_control_target(...).target_id` keeps the Agent Control association explicit at the call site.

## Resolution Behavior

`get_agent_control_target()` resolves in this order:

1. Explicit `target_id` or `log_stream_id`
2. `GALILEO_LOG_STREAM_ID`
3. An already-initialized Galileo logger from `galileo_context`

For cached logger lookup, it follows Galileo's normal default/env behavior for names:

- project name: explicit context -> `GALILEO_PROJECT` -> default project
- log stream name: explicit context -> `GALILEO_LOG_STREAM` -> default log stream

This means it supports the common case where users do not explicitly configure a log stream and Galileo creates or picks up the default log stream, as long as the Galileo logger has already initialized.

## Non-Goals

- Does not import or depend on the Agent Control SDK.
- Does not create projects or log streams.
- Does not resolve log stream names over the network.
- Does not make Agent Control concepts part of the core Galileo logging path.

The caller still wires the two SDKs together explicitly.

## Usage

```python
from galileo import galileo_context, get_agent_control_target
import agent_control

galileo_context.init(project="my-project", log_stream="prod")

target = get_agent_control_target()

agent_control.init(
    agent_name="my-agent",
    target_type=target.target_type,
    target_id=target.target_id,
)
```

After `agent_control.init(...)`, Agent Control can reuse the initialized target for subsequent calls. Direct `AgentControlClient` users can instead pass `target.target_type` and `target.target_id` per evaluation call.

## Safety and Edge Cases

- Validates UUIDs for log-stream targets before returning a target.
- Normalizes accidental surrounding whitespace in explicit/env UUID inputs.
- Raises `AgentControlTargetUnresolvedError` for missing, invalid, or conflicting target inputs.
- Uses the public `GalileoLoggerSingleton.get_all_loggers()` accessor.
- Restricts cached logger lookup to the current thread.
- Prefers the cached logger's `project_id` over `GALILEO_PROJECT_ID` when resolving from cached logger state, so the informational project ID matches the resolved log stream.

## Tests

Local checks run:

- `poetry run pytest tests/test_agent_control.py -q`
- `poetry run ruff check src/galileo/agent_control.py tests/test_agent_control.py src/galileo/__init__.py`
- `poetry run ruff format --check src/galileo/agent_control.py tests/test_agent_control.py src/galileo/__init__.py`
- `git diff --check`

CI is green on the latest pushed commit.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce <code>get_agent_control_target</code> and its supporting <code>AgentControlTarget</code> data model so callers can derive validated Agent Control targets from explicit inputs, environment overrides, or cached Galileo log-stream context before wiring into runtime calls. Provide direct exports from <code>galileo.__init__</code> and expand tests to exercise resolution paths, ensuring the helper and its errors behave correctly for the Galileo log-stream-backed flow.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/581?tool=ast&topic=Target+resolution>Target resolution</a>
        </td><td>Describe how <code>get_agent_control_target</code> resolves explicit IDs, env vars, and cached <code>galileo_context</code> log-streams into validated <code>AgentControlTarget</code> instances while exposing the helper and related exceptions via the public API and guarding UUID inputs for the log-stream flow.<details><summary>Modified files (3)</summary><ul><li>src/galileo/__init__.py</li>
<li>src/galileo/agent_control.py</li>
<li>tests/test_agent_control.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>abhinav@galileo.ai</td><td>docs(agent-control): c...</td><td>May 13, 2026</td></tr>
<tr><td>namrata.ghadi@galileo.ai</td><td>feat: add agentcontrol...</td><td>May 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/581?tool=ast&topic=Usage+docs>Usage docs</a>
        </td><td>Document how to initialize Agent Control with Galileo context and clarify the role of <code>galileo.agent_control</code> versus the existing handler bridge so runtime wiring guidance is discoverable alongside the handler’s intent.<details><summary>Modified files (2)</summary><ul><li>README.md</li>
<li>src/galileo/handlers/agent_control/__init__.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>abhinav@galileo.ai</td><td>docs(agent-control): c...</td><td>May 13, 2026</td></tr>
<tr><td>namrata.ghadi@galileo.ai</td><td>feat: add agentcontrol...</td><td>May 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/581?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>