### PR TITLE
fix: Bump galileo dep rev constraint in galileo-adk

### DIFF
--- a/galileo-adk/pyproject.toml
+++ b/galileo-adk/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "galileo>=1.47.0,<2.0.0",
+    "galileo>=2.0.0,<3.0.0",
     "google-adk>=1.14.1,<2.0.0",
 ]
 
@@ -141,4 +141,3 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjust the dependency specification in <code>pyproject.toml</code> to require <code>galileo</code> within the 2.x series while keeping <code>google-adk</code> pinned to its existing range. Ensure the manifest reflects these updated bounds so the build pulls the newer Galileo release.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sankar@galileo.ai</td><td>fix: Bump galileo dep ...</td><td>May 14, 2026</td></tr>
<tr><td>ci@rungalileo.io</td><td>chore(release): galile...</td><td>May 14, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/583?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>