### PR TITLE
docs: fix CONTRIBUTING.md setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,22 +17,21 @@
    pyenv local 3.13
    ```
 
-   `poetry` will create a virtual environment using that Python version when it installs dependencies. You can validate that with:
+   `poetry` will create a virtual environment using that Python version when it installs dependencies.
 
-   > **_NOTE:_** since The `shell` command was moved to a plugin: [poetry-plugin-shell](https://github.com/python-poetry/poetry-plugin-shell)
+   > **_NOTE:_** In Poetry 2.x, the `shell` command was moved to a separate plugin: [poetry-plugin-shell](https://github.com/python-poetry/poetry-plugin-shell). Install it via Poetry's `self add`:
+   >
+   > ```sh
+   > poetry self add poetry-plugin-shell
+   > ```
 
-   The easiest way to install the shell plugin is via the self add command of Poetry:
-
-   ```shell
-   poetry self add poetry-plugin-shell
-   ```
+   You can validate the Python version with:
 
    ```sh
-   poetry shell
    poetry run python --version
    ```
 
-   which should print out `Python 3.13.x`.
+   which should print out `Python 3.13.x`. To activate the virtual environment in your shell, run `poetry shell`.
 
 2. Install dependencies and setup pre-commit hooks:
 
@@ -44,7 +43,7 @@
 3. Run unit tests
 
    ```sh
-   pytest
+   poetry run pytest
    ```
 
 ## Auto-generating the API client


### PR DESCRIPTION
# User description
**Shortcut:**

[sc-65340](https://app.shortcut.com/galileo/story/65340/fix-contributing-md-setup-instructions)

**Description:**

Fixes a few issues in the root `CONTRIBUTING.md` so the setup steps actually run cleanly on a fresh machine using Poetry 2.x:

- Reorder the `poetry-plugin-shell` install **before** the first reference to `poetry shell` (the previous order had the user invoke `poetry shell` before being told to install the plugin that provides it).
- Replace bare `pytest` with `poetry run pytest` so tests execute inside the project's Poetry-managed venv instead of whatever happens to be first on `$PATH`.
- Clean up the broken/incomplete sentence in the Poetry 2.x shell-plugin note and inline the install command into the note block.

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

Docs-only change — no code paths touched, so neither test type applies. Verified the corrected commands locally: `poetry run python --version` → `Python 3.13.12`, `poetry run pytest --collect-only` → 2006 tests collected.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the root CONTRIBUTING instructions by installing the Poetry 2.x shell plugin before invoking <code>poetry shell</code> so the setup walkthrough works end-to-end. Ensure tests run through the Poetry-managed venv by calling <code>poetry run pytest</code> and polish the plugin note to describe and inline the install command.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/584?tool=ast&topic=Shell+plugin+order>Shell plugin order</a>
        </td><td>Reorder the shell plugin guidance to install it before mentioning <code>poetry shell</code>, inline the <code>poetry self add poetry-plugin-shell</code> command, and clarify the Poetry 2.x note about the moved <code>shell</code> command.<details><summary>Modified files (1)</summary><ul><li>CONTRIBUTING.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>docs: fix CONTRIBUTING...</td><td>May 14, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: Update CONTRIBU...</td><td>May 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/584?tool=ast&topic=Poetry+test+command>Poetry test command</a>
        </td><td>Use <code>poetry run pytest</code> so tests execute inside the Poetry venv and keep validation steps tied to the Poetry-managed environment.<details><summary>Modified files (1)</summary><ul><li>CONTRIBUTING.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiago.bomfin@galileo.ai</td><td>docs: fix CONTRIBUTING...</td><td>May 14, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: Update CONTRIBU...</td><td>May 13, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/584?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>