### PR TITLE
fix(docs): escape curly braces and always fence examples for MDX

### DIFF
--- a/scripts/create_docs.py
+++ b/scripts/create_docs.py
@@ -501,6 +501,47 @@ def build_docs(files_docs: list[FileDoc], source_root: str, output_root: str) ->
     print(f"Documentation generation complete. Output written to {out_root}")
 
 
+def escape_curly_braces(text: str) -> str:
+    """Escape `{` and `}` outside code spans so MDX doesn't parse them as JSX expressions.
+
+    Preserves content inside triple-backtick fenced blocks and inline `...` code spans.
+    """
+    if not text:
+        return text
+    triple_segments = re.split(r"(```.*?```)", text, flags=re.DOTALL)
+    for i, triple_seg in enumerate(triple_segments):
+        if triple_seg.startswith("```"):
+            continue
+        single_segments = re.split(r"(`[^`]*`)", triple_seg)
+        for j, single_seg in enumerate(single_segments):
+            if not single_seg.startswith("`"):
+                single_seg = single_seg.replace("{", r"\{").replace("}", r"\}")
+            single_segments[j] = single_seg
+        triple_segments[i] = "".join(single_segments)
+    return "".join(triple_segments)
+
+
+def render_examples(parts: list, examples: list) -> None:
+    """Emit each example as a fenced python block, stripping doctest `>>>` / `...` prefixes."""
+    parts.append("**Examples**\n")
+    for ex in examples:
+        code = ex.get("code")
+        if not code:
+            continue
+        stripped = []
+        for line in code.split("\n"):
+            if line.startswith(">>> ") or line.startswith("... "):
+                stripped.append(line[4:])
+            elif line in (">>>", "..."):
+                stripped.append("")
+            else:
+                stripped.append(line)
+        parts.append("```python")
+        parts.append("\n".join(stripped).rstrip())
+        parts.append("```\n")
+    parts.append("")
+
+
 def write_function(parts: list[str], fn: Any, heading_level: int = 3) -> None:
     """
     Append formatted documentation for a function to the provided parts list.
@@ -537,7 +578,7 @@ def write_function(parts: list[str], fn: Any, heading_level: int = 3) -> None:
     fdoc = fn.doc
     if isinstance(fdoc, dict):
         if fdoc.get("description"):
-            parts.append(f"{fdoc.get('description')}\n")
+            parts.append(f"{escape_curly_braces(fdoc.get('description'))}\n")
         if fdoc.get("params"):
             parts.append("**Arguments**\n")
             for p in fdoc.get("params", []):
@@ -545,24 +586,6 @@ def write_function(parts: list[str], fn: Any, heading_level: int = 3) -> None:
                 t = p.get("type")
                 desc = p.get("description") or ""
                 desc = desc.replace("\n", "\n    ")
-
-                # Escape curly braces outside code blocks (triple or single backticks)
-                def escape_curly_braces(text: str) -> str:
-                    # Split by triple backtick code blocks first
-                    triple_segments = re.split(r"(```.*?```)", text, flags=re.DOTALL)
-                    for i, triple_seg in enumerate(triple_segments):
-                        if triple_seg.startswith("```"):
-                            # Inside triple backtick code block, leave as is
-                            continue
-                        # Now split by single backtick code blocks
-                        single_segments = re.split(r"(`[^`]*`)", triple_seg)
-                        for j, single_seg in enumerate(single_segments):
-                            if not single_seg.startswith("`"):
-                                single_seg = single_seg.replace("{", r"\{").replace("}", r"\}")
-                            single_segments[j] = single_seg
-                        triple_segments[i] = "".join(single_segments)
-                    return "".join(triple_segments)
-
                 desc = escape_curly_braces(desc)
 
                 if t:
@@ -574,7 +597,7 @@ def write_function(parts: list[str], fn: Any, heading_level: int = 3) -> None:
             parts.append("**Raises**\n")
             for r in fdoc.get("raises", []):
                 typ = r.get("type") or "Exception"
-                desc = r.get("description") or ""
+                desc = escape_curly_braces(r.get("description") or "")
                 parts.append(f"- `{typ}`: {desc}")
             parts.append("")
         if fdoc.get("returns"):
@@ -582,34 +605,17 @@ def write_function(parts: list[str], fn: Any, heading_level: int = 3) -> None:
             ret = fdoc.get("returns")
             if ret:
                 rtyp = ret.get("type") or ""
-                rdesc = ret.get("description") or ""
+                rdesc = escape_curly_braces(ret.get("description") or "")
                 if rtyp:
                     parts.append(f"- `{rtyp}`: {rdesc}\n")
                 else:
                     parts.append(f"- {rdesc}\n")
         if fdoc.get("examples"):
-            parts.append("**Examples**\n")
-            is_in_code_block = False
-            for ex in fdoc.get("examples", []):
-                code = ex.get("code")
-                if code:
-                    if not is_in_code_block and code.startswith(">>>"):
-                        is_in_code_block = True
-                        parts.append("```python")
-                    if is_in_code_block and not code.startswith(">>>") and not code.startswith("..."):
-                        is_in_code_block = False
-                        parts.append("```\n")
-                    if not code.startswith(">>>") and not code.startswith("..."):
-                        parts.append(code)
-                    else:
-                        parts.append(code[4:])
-            if is_in_code_block:
-                parts.append("```\n")
-            parts.append("")
+            render_examples(parts, fdoc.get("examples", []))
         if fdoc.get("notes"):
             parts.append("**Notes**\n")
             for note in fdoc.get("notes", []):
-                ntext = note.get("note")
+                ntext = escape_curly_braces(note.get("note") or "")
                 if ntext:
                     parts.append(f"{ntext}")
             parts.append("")
@@ -651,7 +657,7 @@ def write_class(parts: list[str], cls: Any) -> None:
     cdoc = cls.doc
     if isinstance(cdoc, dict):
         if cdoc.get("description"):
-            parts.append(f"{cdoc.get('description')}\n")
+            parts.append(f"{escape_curly_braces(cdoc.get('description'))}\n")
         if cdoc.get("params"):
             parts.append("**Arguments**\n")
             for p in cdoc.get("params", []):
@@ -659,36 +665,20 @@ def write_class(parts: list[str], cls: Any) -> None:
                 t = p.get("type")
                 desc = p.get("description") or ""
                 desc = desc.replace("\n", "\n    ")
+                desc = escape_curly_braces(desc)
                 if t:
                     parts.append(f"- `{name}` (`{t}`): {desc}\n")
                 else:
                     parts.append(f"- `{name}`: {desc}\n")
 
         if cdoc.get("examples"):
-            parts.append("**Examples**\n")
-            is_in_code_block = False
-            for ex in cdoc.get("examples", []):
-                code = ex.get("code")
-                if code:
-                    if not is_in_code_block and code.startswith(">>>"):
-                        is_in_code_block = True
-                        parts.append("```python")
-                    if is_in_code_block and not code.startswith(">>>") and not code.startswith("..."):
-                        is_in_code_block = False
-                        parts.append("```\n")
-                    if not code.startswith(">>>") and not code.startswith("..."):
-                        parts.append(code)
-                    else:
-                        parts.append(code[4:])
-            if is_in_code_block:
-                parts.append("```\n")
-            parts.append("")
+            render_examples(parts, cdoc.get("examples", []))
         if cdoc.get("returns"):
             parts.append("**Returns**\n")
             ret = cdoc.get("returns")
             if ret:
                 rtyp = ret.get("type") or ""
-                rdesc = ret.get("description") or ""
+                rdesc = escape_curly_braces(ret.get("description") or "")
                 if rtyp:
                     parts.append(f"- `{rtyp}`: {rdesc}\n")
                 else:
@@ -696,7 +686,7 @@ def write_class(parts: list[str], cls: Any) -> None:
         if cdoc.get("notes"):
             parts.append("**Notes**\n")
             for note in cdoc.get("notes", []):
-                ntext = note.get("note")
+                ntext = escape_curly_braces(note.get("note") or "")
                 if ntext:
                     parts.append(f"{ntext}")
             parts.append("")
@@ -736,7 +726,7 @@ def write_module(fd: FileDoc, parts: list[str]) -> None:
     md = fd.module.doc
     if isinstance(md, dict):
         if md.get("description"):
-            parts.append(f"{md.get('description')}\n")
+            parts.append(f"{escape_curly_braces(md.get('description'))}\n")
         if md.get("params"):
             parts.append("**Arguments**\n")
             for p in md.get("params", []):
@@ -746,6 +736,7 @@ def write_module(fd: FileDoc, parts: list[str]) -> None:
 
                 # If description is multi-line, indent subsequent lines for better Markdown rendering
                 desc = desc.replace("\n", "\n    ")
+                desc = escape_curly_braces(desc)
 
                 if t:
                     parts.append(f"- `{name}` (`{t}`): {desc}\n")
@@ -755,14 +746,14 @@ def write_module(fd: FileDoc, parts: list[str]) -> None:
             parts.append("**Raises**\n")
             for r in md.get("raises", []):
                 typ = r.get("type") or "Exception"
-                desc = r.get("description") or ""
+                desc = escape_curly_braces(r.get("description") or "")
                 parts.append(f"- `{typ}`: {desc}\n")
         if md.get("returns"):
             parts.append("**Returns**\n")
             ret = md.get("returns")
             if ret:
                 rtyp = ret.get("type") or ""
-                rdesc = ret.get("description") or ""
+                rdesc = escape_curly_braces(ret.get("description") or "")
                 if rtyp:
                     parts.append(f"- `{rtyp}`: {rdesc}\n")
                 else:
@@ -770,7 +761,7 @@ def write_module(fd: FileDoc, parts: list[str]) -> None:
         if md.get("notes"):
             parts.append("**Notes**\n")
             for note in md.get("notes", []):
-                ntext = note.get("note")
+                ntext = escape_curly_braces(note.get("note") or "")
                 if ntext:
                     parts.append(f"{ntext}")
             parts.append("")


### PR DESCRIPTION
# User description
## Summary

The `Publish Docs` workflow has been generating MDX files that fail Mintlify's MDX parser on the consuming side ([`rungalileo/docs-official`](https://github.com/rungalileo/docs-official)). Recent docs-official PRs ([#902](https://github.com/rungalileo/docs-official/pull/902), [#906](https://github.com/rungalileo/docs-official/pull/906)) both hit acorn parse errors that required manual MDX patching. This fix addresses the root cause in `create_docs.py`.

## Bugs fixed

1. **Unescaped `{...}` in body prose.** `description`, `returns`, `raises`, and `notes` text was emitted raw. Any docstring that included a Python dict literal, f-string format spec, or RST literal block with `{...}` would produce MDX that acorn tried to parse as a JSX expression and rejected. Example failure: `experiment.mdx:498:38` parsing `{agg.avg:.3f}` in a `::` literal block.

2. **Examples only fenced when prefixed with `>>>`.** Plain-Python example sections (no doctest prefix) were emitted unfenced, so any `{` inside them tripped the same JSX parser. Example failure: `dataset.mdx:21:17` parsing `{"input": ...}`.

3. **`escape_curly_braces` was scoped inside `write_function`'s params loop and applied nowhere else** — including `write_class` params, which had no escaping at all.

## Changes

- Lift `escape_curly_braces` to module scope so all three writers (`write_function`, `write_class`, `write_module`) can use it.
- Add `render_examples` helper that wraps each example in a python fence unconditionally and strips `>>>` / `...` doctest prefixes line-by-line.
- Apply `escape_curly_braces` to every description, param desc, raise desc, return desc, and note text across the three writers.
- Replace the conditional fence opener with unconditional fencing via `render_examples`.

Net: +56 / -65 lines (consolidation via helpers).

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('scripts/create_docs.py').read())"` — file parses
- [x] Smoke tests on real broken inputs (RST literal blocks, inline code preservation, fenced-block preservation, doctest-prefix stripping, empty/None safety) — all pass
- [ ] Run `Publish Docs` workflow manually after merge and verify the generated PR against `docs-official` passes CI without manual MDX patches

## Out of scope

This fix prevents MDX parse errors but does not convert RST `::` literal blocks into proper fenced code blocks — those will still render with literal `::` and an indented but unhighlighted block. That's a bigger refactor (would require walking the description string with an RST-aware parser) and worth filing separately if rendering quality matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>create_docs.py</code> to escape curly braces in descriptions, params, raises, returns, and notes so MDX consumers no longer misinterpret prose as JSX, and consolidate the helper for these writers. Ensure every documented example runs through the new fenced <code>render_examples</code> helper that strips doctest prefixes before emitting python code blocks.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/585?tool=ast&topic=MDX+escaping>MDX escaping</a>
        </td><td>Escape prose across <code>write_function</code>, <code>write_class</code>, and <code>write_module</code> with the module-level <code>escape_curly_braces</code> helper so descriptions, params, raises, returns, and notes never emit raw <code>{...}</code> sequences.<details><summary>Modified files (1)</summary><ul><li>scripts/create_docs.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>xian@galileo.ai</td><td>fix(docs): escape curl...</td><td>May 15, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/585?tool=ast&topic=Example+fencing>Example fencing</a>
        </td><td>Fence examples through the new <code>render_examples</code> helper that strips doctest <code>>>></code>/<code>...</code> prefixes and emits a consistent python code block every time a function, class, or module declares examples.<details><summary>Modified files (1)</summary><ul><li>scripts/create_docs.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>xian@galileo.ai</td><td>fix(docs): escape curl...</td><td>May 15, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/585?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>