### PR TITLE
docs: clarify export data size support

### DIFF
--- a/src/galileo/export.py
+++ b/src/galileo/export.py
@@ -79,7 +79,9 @@ def export_records(
     column_ids: list[str] | None = None,
     redact: bool = True,
 ) -> Iterator[dict[str, Any]]:
-    """Exports records from a Galileo project.
+    """Exports records from a Galileo project. 
+
+    Supports exporting 1 GB of data.
 
     Defaults to the first logstream if `log_stream_id` and `experiment_id` are not provided.
 


### PR DESCRIPTION
# User description
previously we noted the 1 GB support in this release note: https://docs.galileo.ai/release-notes#export-data

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify that the Galileo export module’s <code>export_records</code> function supports exporting 1 GB of data for the export flow. Document that the iterator can handle that complete dataset size in line with the release notes.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>xian@galileo.ai</td><td>clarify export data si...</td><td>May 15, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>feat(log-stream): add ...</td><td>May 13, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/586?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>