### PR TITLE
feat(export): expose include_code_metric_metadata on export_records

### DIFF
--- a/src/galileo/export.py
+++ b/src/galileo/export.py
@@ -40,6 +40,7 @@ class ExportClient:
         experiment_id: str | None = None,
         column_ids: list[str] | None = None,
         redact: bool = True,
+        include_code_metric_metadata: bool = False,
     ) -> Iterator[dict[str, Any]]:
         if filters is None:
             filters = []
@@ -56,6 +57,7 @@ class ExportClient:
                 column_ids=column_ids,
                 sort=sort,
                 redact=redact,
+                include_code_metric_metadata=include_code_metric_metadata,
             ),
         )
 
@@ -78,6 +80,7 @@ def export_records(
     experiment_id: str | None = None,
     column_ids: list[str] | None = None,
     redact: bool = True,
+    include_code_metric_metadata: bool = False,
 ) -> Iterator[dict[str, Any]]:
     """Exports records from a Galileo project.
 
@@ -103,6 +106,10 @@ def export_records(
         A sort clause to order the exported records.
     redact
         Redact sensitive data from the response.
+    include_code_metric_metadata
+        If True, include per-row scorer metadata (the dict returned alongside the score by
+        code-based scorers via the (score, metadata) tuple-return contract) on each
+        MetricSuccess in the export. Off by default to keep payloads small.
 
     Returns
     -------
@@ -132,4 +139,5 @@ def export_records(
         column_ids=column_ids,
         sort=sort,
         redact=redact,
+        include_code_metric_metadata=include_code_metric_metadata,
     )

--- a/src/galileo/resources/models/log_records_export_request.py
+++ b/src/galileo/resources/models/log_records_export_request.py
@@ -44,6 +44,9 @@ class LogRecordsExportRequest:
             'LogRecordsTextFilter']]]): Filters to apply on the export
         sort (Union['LogRecordsSortClause', None, Unset]): Sort clause for the export.  Defaults to native sort
             (created_at, id descending).
+        include_code_metric_metadata (Union[Unset, bool]): If True, include per-row scorer metadata (the dict
+            returned alongside the score by code-based scorers via the (score, metadata) tuple-return contract) on
+            each MetricSuccess in the export. Default: False.
     """
 
     root_type: RootType
@@ -69,6 +72,7 @@ class LogRecordsExportRequest:
         ]
     ) = UNSET
     sort: Union["LogRecordsSortClause", None, Unset] = UNSET
+    include_code_metric_metadata: Unset | bool = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -136,6 +140,8 @@ class LogRecordsExportRequest:
         else:
             sort = self.sort
 
+        include_code_metric_metadata = self.include_code_metric_metadata
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({"root_type": root_type})
@@ -157,6 +163,8 @@ class LogRecordsExportRequest:
             field_dict["filters"] = filters
         if sort is not UNSET:
             field_dict["sort"] = sort
+        if include_code_metric_metadata is not UNSET:
+            field_dict["include_code_metric_metadata"] = include_code_metric_metadata
 
         return field_dict
 
@@ -313,6 +321,8 @@ class LogRecordsExportRequest:
 
         sort = _parse_sort(d.pop("sort", UNSET))
 
+        include_code_metric_metadata = d.pop("include_code_metric_metadata", UNSET)
+
         log_records_export_request = cls(
             root_type=root_type,
             column_ids=column_ids,
@@ -324,6 +334,7 @@ class LogRecordsExportRequest:
             metrics_testing_id=metrics_testing_id,
             filters=filters,
             sort=sort,
+            include_code_metric_metadata=include_code_metric_metadata,
         )
 
         log_records_export_request.additional_properties = d

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -296,13 +296,7 @@ def test_export_records_include_code_metric_metadata_opt_in(mock_export_records_
     mock_export_records_stream.return_value = iter([])
 
     # When: export_records is invoked with include_code_metric_metadata=True.
-    list(
-        export_records(
-            project_id=project_id,
-            log_stream_id=str(uuid4()),
-            include_code_metric_metadata=True,
-        )
-    )
+    list(export_records(project_id=project_id, log_stream_id=str(uuid4()), include_code_metric_metadata=True))
 
     # Then: the kwarg flows into the request body and serializes to True.
     request_body = mock_export_records_stream.call_args.kwargs["body"]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -272,3 +272,39 @@ def test_export_records_redact(mock_export_records_stream, redact_param):
     mock_export_records_stream.assert_called_once()
     request_body = mock_export_records_stream.call_args.kwargs["body"]
     assert request_body.redact == redact_param
+
+
+@patch("galileo.export.export_records_stream")
+def test_export_records_include_code_metric_metadata_default(mock_export_records_stream):
+    # Given: a caller that does not pass include_code_metric_metadata.
+    project_id = str(uuid4())
+    mock_export_records_stream.return_value = iter([])
+
+    # When: export_records is invoked with default kwargs.
+    list(export_records(project_id=project_id, log_stream_id=str(uuid4())))
+
+    # Then: the request body's flag defaults to False and is serialized as such.
+    request_body = mock_export_records_stream.call_args.kwargs["body"]
+    assert request_body.include_code_metric_metadata is False
+    assert request_body.to_dict()["include_code_metric_metadata"] is False
+
+
+@patch("galileo.export.export_records_stream")
+def test_export_records_include_code_metric_metadata_opt_in(mock_export_records_stream):
+    # Given: a caller that opts into per-row scorer metadata.
+    project_id = str(uuid4())
+    mock_export_records_stream.return_value = iter([])
+
+    # When: export_records is invoked with include_code_metric_metadata=True.
+    list(
+        export_records(
+            project_id=project_id,
+            log_stream_id=str(uuid4()),
+            include_code_metric_metadata=True,
+        )
+    )
+
+    # Then: the kwarg flows into the request body and serializes to True.
+    request_body = mock_export_records_stream.call_args.kwargs["body"]
+    assert request_body.include_code_metric_metadata is True
+    assert request_body.to_dict()["include_code_metric_metadata"] is True


### PR DESCRIPTION
# User description
## Summary

- Adds an opt-in `include_code_metric_metadata: bool = False` kwarg to `ExportClient.records` and the top-level `export_records` function so SDK callers can request that per-row scorer metadata (the dict returned alongside the score by code-based scorers via the `(score, metadata)` tuple-return contract) be included on each `MetricSuccess` in the exported payload.
- Adds the matching field to the generated `LogRecordsExportRequest` model so it serializes to the API correctly. This file is normally regenerated from the OpenAPI spec — once the API PR merges and the OpenAPI spec is regenerated, re-running the codegen will re-emit this cleanly. Until then, the manual patch is the source of truth.
- Defaults to `False`, so existing callers and payload sizes are unchanged.

## Dependency

This is the user-facing surface for an end-to-end change. The API-side change lives in rungalileo/api#6529. Until that merges and deploys, requests sent with `include_code_metric_metadata=True` will succeed but the server will silently drop the field.

The orbit-side `MetricSuccessBase.metadata` declaration is already on orbit `main` (orbit#596) and already in api's pinned orbit ref, so no orbit work is blocking this.

## Test plan

- [x] Added `test_export_records_include_code_metric_metadata_default` / `_opt_in` in `tests/test_export.py` that assert the kwarg flows into the request body and serializes correctly via `to_dict`.
- [x] `poetry run pytest tests/test_export.py` — 17 passed locally.
- [ ] End-to-end sanity check against a deployed API that includes the upstream change.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add optional <code>include_code_metric_metadata</code> parameters to <code>ExportClient.records</code> and <code>export_records</code> so callers can request per-row scorer metadata on each exported <code>MetricSuccess</code>. Update <code>LogRecordsExportRequest</code> serialization to carry the new flag through the API payload.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/587?tool=ast&topic=Metadata+export+opt-in>Metadata export opt-in</a>
        </td><td>Extend <code>ExportClient.records</code> and <code>export_records</code> to accept <code>include_code_metric_metadata</code> so callers can opt into per-row scorer metadata, and verify the flag defaults to <code>False</code> and flows through via <code>test_export_records_include_code_metric_metadata_default</code>/<code>_opt_in</code>.<details><summary>Modified files (2)</summary><ul><li>src/galileo/export.py</li>
<li>tests/test_export.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>AnkushMalaker</td><td>style(test): apply ruf...</td><td>May 15, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>feat(log-stream): add ...</td><td>May 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/587?tool=ast&topic=Request+serialization>Request serialization</a>
        </td><td>Update <code>LogRecordsExportRequest</code> to persist <code>include_code_metric_metadata</code> through <code>to_dict</code>/<code>from_dict</code> so the exported payload serializes the opt-in flag for the API.<details><summary>Modified files (1)</summary><ul><li>src/galileo/resources/models/log_records_export_request.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>AnkushMalaker</td><td>feat(export): expose i...</td><td>May 15, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix: schema patches (#...</td><td>April 29, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/587?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>