### PR TITLE
feat(metrics): expose ground_truth flag on create_custom_llm_metric

### DIFF
--- a/src/galileo/metric.py
+++ b/src/galileo/metric.py
@@ -404,7 +404,13 @@ class Metric(StateManagementMixin, ABC):
             else:
                 node_level = None
 
-            self._sync_attrs(output_type=output_type, prompt=prompt, node_level=node_level)
+            ground_truth = (
+                False
+                if isinstance(scorer_response.ground_truth, Unset) or scorer_response.ground_truth is None
+                else scorer_response.ground_truth
+            )
+
+            self._sync_attrs(output_type=output_type, prompt=prompt, node_level=node_level, ground_truth=ground_truth)
 
         # Code-specific attributes (only set if this is a CodeMetric)
         if isinstance(self, CodeMetric):
@@ -661,6 +667,7 @@ class LlmMetric(Metric):
     cot_enabled: bool | None
     node_level: StepType | None
     output_type: OutputTypeEnum | None
+    ground_truth: bool
 
     def __init__(
         self,
@@ -678,6 +685,7 @@ class LlmMetric(Metric):
         node_level: StepType | None = None,
         cot_enabled: bool | None = None,
         output_type: str | OutputTypeEnum | None = None,
+        ground_truth: bool = False,
         # Common parameters
         description: str = "",
         tags: list[str] | None = None,
@@ -698,6 +706,8 @@ class LlmMetric(Metric):
             node_level: Node level for the metric. Defaults to StepType.llm.
             cot_enabled: Whether chain-of-thought is enabled. Defaults to True.
             output_type: Output type ("percentage", "boolean", etc.).
+            ground_truth: Whether the scorer requires ground truth (``reference_output``) from the dataset.
+                When True, the judge LLM receives the row's ground-truth value in its prompt.
             description: Description of the metric.
             tags: Tags associated with the metric.
             version: Specific version to reference (for existing metrics).
@@ -752,6 +762,8 @@ class LlmMetric(Metric):
         else:
             self.output_type = output_type or OutputTypeEnum.BOOLEAN
 
+        self.ground_truth = ground_truth
+
         self.scorer_type = ScorerTypes.LLM
 
     def create(self) -> LlmMetric:
@@ -792,6 +804,7 @@ class LlmMetric(Metric):
                 output_type=self.output_type
                 if isinstance(self.output_type, OutputTypeEnum)
                 else OutputTypeEnum.BOOLEAN,
+                ground_truth=self.ground_truth,
             )
 
             # Update attributes from response without triggering dirty-tracking

--- a/src/galileo/metrics.py
+++ b/src/galileo/metrics.py
@@ -56,6 +56,7 @@ class Metrics:
         description: str = "",
         tags: list[str] | None = None,
         output_type: OutputTypeEnum = OutputTypeEnum.BOOLEAN,
+        ground_truth: bool = False,
     ) -> BaseScorerVersionResponse:
         """
         Create a custom LLM metric.
@@ -80,6 +81,9 @@ class Metrics:
             Tags associated with the metric.
         output_type: OutputTypeEnum
             Output type for the metric.
+        ground_truth: bool
+            Whether the scorer requires ground truth (``reference_output``) from the dataset.
+            When True, the judge LLM receives the row's ground-truth value in its prompt.
 
         Returns
         -------
@@ -96,6 +100,7 @@ class Metrics:
             defaults=ScorerDefaults(model_name=model_name, num_judges=num_judges, cot_enabled=cot_enabled),
             scoreable_node_types=[node_level],
             output_type=output_type,
+            ground_truth=ground_truth,
         )
 
         scorer = create_scorers_post.sync(body=create_scorer_request, client=self.config.api_client)
@@ -153,6 +158,7 @@ def create_custom_llm_metric(
     description: str = "",
     tags: list[str] | None = None,
     output_type: OutputTypeEnum = OutputTypeEnum.BOOLEAN,
+    ground_truth: bool = False,
 ) -> BaseScorerVersionResponse:
     """
     Create a custom LLM metric.
@@ -177,6 +183,9 @@ def create_custom_llm_metric(
         Tags associated with the metric.
     output_type: OutputTypeEnum
         Output type for the metric.
+    ground_truth: bool
+        Whether the scorer requires ground truth (``reference_output``) from the dataset.
+        When True, the judge LLM receives the row's ground-truth value in its prompt.
 
     Returns
     -------
@@ -186,7 +195,7 @@ def create_custom_llm_metric(
     if tags is None:
         tags = []
     return Metrics().create_custom_llm_metric(
-        name, user_prompt, node_level, cot_enabled, model_name, num_judges, description, tags, output_type
+        name, user_prompt, node_level, cot_enabled, model_name, num_judges, description, tags, output_type, ground_truth
     )
 
 

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -177,6 +177,21 @@ class TestMetricInitialization:
         assert metric.description == "Test metric description"
         assert metric.tags == ["test", "factuality"]
         assert metric.output_type == OutputTypeEnum.PERCENTAGE
+        assert metric.ground_truth is False
+
+    def test_init_ground_truth_defaults_false(self, reset_configuration: None) -> None:
+        # Given: an LlmMetric created without specifying ground_truth
+        metric = LlmMetric(name="Test Metric", prompt="Is it accurate?")
+
+        # Then: ground_truth defaults to False
+        assert metric.ground_truth is False
+
+    def test_init_with_ground_truth_true(self, reset_configuration: None) -> None:
+        # Given: an LlmMetric created with ground_truth=True
+        metric = LlmMetric(name="Test Metric", prompt="Compare against reference_output.", ground_truth=True)
+
+        # Then: ground_truth is exposed on the instance
+        assert metric.ground_truth is True
 
     def test_init_without_name_raises_error(self, reset_configuration: None) -> None:
         """Test initializing a metric without name raises TypeError."""
@@ -237,6 +252,52 @@ class TestMetricCreate:
         mock_metrics_service.create_custom_llm_metric.assert_called_once()
         assert metric.id == scorer_id
         assert metric.is_synced()
+
+    @patch("galileo.metric.Metrics")
+    @patch("galileo.metric.Scorers")
+    def test_create_forwards_ground_truth(
+        self, mock_scorers_class: MagicMock, mock_metrics_class: MagicMock, reset_configuration: None
+    ) -> None:
+        # Given: a mocked metrics service that records the create_custom_llm_metric kwargs
+        mock_metrics_service = MagicMock()
+        mock_metrics_class.return_value = mock_metrics_service
+
+        mock_scorers_service = MagicMock()
+        mock_scorers_class.return_value = mock_scorers_service
+
+        scorer_id = str(uuid4())
+        mock_version = MagicMock()
+        mock_version.scorer_id = scorer_id
+        mock_version.created_at = MagicMock()
+        mock_version.updated_at = MagicMock()
+
+        mock_scorer = MagicMock()
+        mock_scorer.id = scorer_id
+        mock_scorer.name = "GT Metric"
+        mock_scorer.scorer_type = ScorerTypes.LLM
+        mock_scorer.tags = []
+        mock_scorer.description = ""
+        mock_scorer.created_at = MagicMock()
+        mock_scorer.updated_at = MagicMock()
+        mock_scorer.output_type = OutputTypeEnum.BOOLEAN
+        mock_scorer.user_prompt = "Compare against reference_output."
+        mock_scorer.defaults = MagicMock()
+        mock_scorer.defaults.model_name = "gpt-4.1-mini"
+        mock_scorer.defaults.num_judges = 3
+        mock_scorer.defaults.cot_enabled = True
+        mock_scorer.scoreable_node_types = ["llm"]
+        mock_scorer.ground_truth = True
+
+        mock_metrics_service.create_custom_llm_metric.return_value = mock_version
+        mock_scorers_service.list.return_value = [mock_scorer]
+
+        # When: an LlmMetric with ground_truth=True is created
+        metric = LlmMetric(name="GT Metric", prompt="Compare against reference_output.", ground_truth=True).create()
+
+        # Then: ground_truth=True is forwarded to the metrics service and reflected on the synced instance
+        _, kwargs = mock_metrics_service.create_custom_llm_metric.call_args
+        assert kwargs["ground_truth"] is True
+        assert metric.ground_truth is True
 
     @patch("galileo.metric.Metrics")
     def test_create_handles_api_failure(self, mock_metrics_class: MagicMock, reset_configuration: None) -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -113,6 +113,7 @@ class TestMetrics:
         assert scorer_request.output_type == OutputTypeEnum.BOOLEAN
         assert scorer_request.defaults.cot_enabled is True
         assert scorer_request.scoreable_node_types == [StepType.llm]
+        assert scorer_request.ground_truth is False
 
         # Verify create_version was called with correct parameters
         mock_create_version.sync.assert_called_once()
@@ -146,6 +147,7 @@ class TestMetrics:
             description="Custom metric description",
             tags=["custom", "evaluation", "quality"],
             output_type=OutputTypeEnum.CATEGORICAL,
+            ground_truth=True,
         )
 
         # Verify the result
@@ -161,6 +163,7 @@ class TestMetrics:
         assert scorer_request.output_type == OutputTypeEnum.CATEGORICAL
         assert scorer_request.defaults.cot_enabled is False
         assert scorer_request.scoreable_node_types == [StepType.workflow]
+        assert scorer_request.ground_truth is True
 
         # Verify create_version was called with correct parameters
         version_request = mock_create_version.sync.call_args.kwargs["body"]
@@ -278,6 +281,7 @@ class TestPublicFunctions:
             description="Test description",
             tags=["test"],
             output_type=OutputTypeEnum.CATEGORICAL,
+            ground_truth=True,
         )
 
         # Verify Metrics class was instantiated
@@ -294,6 +298,7 @@ class TestPublicFunctions:
             "Test description",
             ["test"],
             OutputTypeEnum.CATEGORICAL,
+            True,
         )
 
         # Verify the result is returned
@@ -322,6 +327,7 @@ class TestPublicFunctions:
             "",  # default
             [],  # default
             OutputTypeEnum.BOOLEAN,  # default
+            False,  # default ground_truth
         )
 
         # Verify the result is returned


### PR DESCRIPTION
# User description
## Summary

Custom LLM-judge scorers have a server-side `ground_truth` flag (the **Use ground truth in prompt** toggle in the UI). When `True`, the runner renames the dataset's `output` column to `reference_output` so the judge LLM sees the row's ground-truth value in its prompt — turning the judge into a real correctness check rather than a model-knowledge check.

The SDK helper `create_custom_llm_metric` never accepted this parameter, so users could not enable the toggle through the SDK. The auto-generated `CreateScorerRequest` already declares `ground_truth: bool | None`, so this is purely a public-surface gap.

## Causal chain (before this PR)

1. User calls `create_custom_llm_metric(..., ground_truth=True)`.
   ❌ Unexpected keyword argument.
2. Falling back to constructing `CreateScorerRequest` manually requires importing from `galileo.resources.models`, which the wrapper exists to hide.
3. Workaround: UI toggle only, or hand-rolled HTTP call.

## What changed

- `src/galileo/metrics.py` — add `ground_truth: bool = False` to:
  - `Metrics.create_custom_llm_metric`
  - the module-level public `create_custom_llm_metric`
  - forward into the `CreateScorerRequest` body
- `tests/test_metrics.py` — assert `ground_truth` is forwarded in default and custom-parameter cases, and update positional-args assertions in the public-function tests.

## Cross-repo context

Pairs with the server-side fix in [rungalileo/orbit#709](https://github.com/rungalileo/orbit/pull/709) (`fix(scorers): propagate ground_truth flag for custom LLM scorers`). That PR fixes `scorer_factory.get_scorer_settings`'s `ScorerTypes.llm` branch to actually plumb `scorer.ground_truth` into the runner — without it, even servers that stored `ground_truth=True` silently scored without the reference output.

The TypeScript SDK has the same gap: [rungalileo/galileo-js#607](https://github.com/rungalileo/galileo-js/pull/607).

## Usage

```python
from galileo.metrics import create_custom_llm_metric
from galileo.resources.models.output_type_enum import OutputTypeEnum

create_custom_llm_metric(
    name="matches-expected-output",
    user_prompt="Compare the response against reference_output. Return True if equivalent.",
    output_type=OutputTypeEnum.BOOLEAN,
    ground_truth=True,  # new — enables the "Use ground truth in prompt" toggle
)
```

## Test plan

- [x] `poetry run pytest tests/test_metrics.py tests/test_metric.py` — 79/79 pass (3 assertions updated, GT propagation covered in default + custom cases)
- [x] `poetry run ruff check` — clean
- [x] `poetry run ruff format` — clean
- [ ] Manual smoke against staging once merged: run an experiment with a custom GT scorer + the orbit fix and confirm the judge's rationale references `reference_output`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>ground_truth</code> handling to <code>LlmMetric</code> and its request sync so scorer instances persist whether they require the dataset reference output. Forward the flag through <code>Metrics.create_custom_llm_metric</code> and the public helper so SDK callers can enable the ground-truth prompt toggle.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/588?tool=ast&topic=Ground+truth+flag>Ground truth flag</a>
        </td><td>Describe how <code>LlmMetric</code> now stores and syncs <code>ground_truth</code> from scorer responses so instances surface the flag, with tests covering its defaults and propagation during creation.<details><summary>Modified files (2)</summary><ul><li>src/galileo/metric.py</li>
<li>tests/test_metric.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>AnkushMalaker</td><td>feat(metric): expose g...</td><td>May 19, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/588?tool=ast&topic=Custom+metric+API>Custom metric API</a>
        </td><td>Explain how <code>Metrics.create_custom_llm_metric</code> plus the module helper now accept <code>ground_truth</code> and pass it into <code>CreateScorerRequest</code>, ensuring the generated requests toggle reference-output prompts with matching tests.<details><summary>Modified files (2)</summary><ul><li>src/galileo/metrics.py</li>
<li>tests/test_metrics.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>AnkushMalaker</td><td>feat(metrics): expose ...</td><td>May 19, 2026</td></tr>
<tr><td>fernando.correia@galil...</td><td>chore: update ruff tar...</td><td>April 07, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/588?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>