### PR TITLE
feat: add output_type to CodeMetric

### DIFF
--- a/src/galileo/metric.py
+++ b/src/galileo/metric.py
@@ -842,6 +842,7 @@ class CodeMetric(Metric):
     ----------
         node_level (StepType | None): Node level for the metric.
         code (str | None): The Python code for the scorer.
+        output_type (OutputTypeEnum | None): Output type for the metric.
 
     Examples
     --------
@@ -856,6 +857,7 @@ class CodeMetric(Metric):
             description="Custom code-based scorer",
             tags=["custom", "code"],
             node_level=StepType.llm,
+            output_type=OutputTypeEnum.PERCENTAGE,
         ).create()
 
         # Load code from file
@@ -868,6 +870,7 @@ class CodeMetric(Metric):
     # Type annotations for code-specific attributes
     node_level: StepType | None
     code: str | None
+    output_type: OutputTypeEnum | None
     required_metrics: list[str] | None
 
     def __init__(
@@ -876,6 +879,7 @@ class CodeMetric(Metric):
         *,
         code: str | None = None,
         node_level: StepType | None = None,
+        output_type: str | OutputTypeEnum | None = None,
         required_metrics: list[str] | None = None,
         description: str = "",
         tags: list[str] | None = None,
@@ -888,6 +892,8 @@ class CodeMetric(Metric):
             name: The name of the metric.
             code: The Python code for the scorer (optional, can be set later or loaded from file).
             node_level: Node level for the metric. Defaults to StepType.llm.
+            output_type: Output type for the metric ("percentage", "boolean", "categorical",
+                "count", "discrete"). Accepts string or OutputTypeEnum.
             required_metrics: List of metric names that this code metric depends on.
             description: Description of the metric.
             tags: Tags associated with the metric.
@@ -899,6 +905,20 @@ class CodeMetric(Metric):
         self.node_level = node_level or StepType.llm
         self.required_metrics = required_metrics
         self.scorer_type = ScorerTypes.CODE
+
+        if isinstance(output_type, str):
+            output_type_map = {
+                "percentage": OutputTypeEnum.PERCENTAGE,
+                "boolean": OutputTypeEnum.BOOLEAN,
+                "categorical": OutputTypeEnum.CATEGORICAL,
+                "count": OutputTypeEnum.COUNT,
+                "discrete": OutputTypeEnum.DISCRETE,
+                "freeform": OutputTypeEnum.FREEFORM,
+                "multilabel": OutputTypeEnum.MULTILABEL,
+            }
+            self.output_type = output_type_map.get(output_type.lower())
+        else:
+            self.output_type = output_type
 
     def load_code(self, code_file_path: str) -> CodeMetric:
         """
@@ -1091,6 +1111,7 @@ class CodeMetric(Metric):
                 description=self.description,
                 tags=self.tags,
                 scoreable_node_types=[self.node_level.value],
+                output_type=self.output_type,
                 required_scorers=self.required_metrics,
             )
 

--- a/src/galileo/metric.py
+++ b/src/galileo/metric.py
@@ -192,6 +192,26 @@ class Metric(StateManagementMixin, ABC):
 
         self._set_state(SyncState.LOCAL_ONLY)
 
+    @staticmethod
+    def _parse_output_type(
+        output_type: str | OutputTypeEnum | None, default: OutputTypeEnum | None = None
+    ) -> OutputTypeEnum | None:
+        """Map a string or OutputTypeEnum to OutputTypeEnum, with an optional fallback default."""
+        if output_type is None:
+            return default
+        if isinstance(output_type, OutputTypeEnum):
+            return output_type
+        _map = {
+            "percentage": OutputTypeEnum.PERCENTAGE,
+            "boolean": OutputTypeEnum.BOOLEAN,
+            "categorical": OutputTypeEnum.CATEGORICAL,
+            "count": OutputTypeEnum.COUNT,
+            "discrete": OutputTypeEnum.DISCRETE,
+            "freeform": OutputTypeEnum.FREEFORM,
+            "multilabel": OutputTypeEnum.MULTILABEL,
+        }
+        return _map.get(output_type.lower(), default)
+
     @classmethod
     def _create_metric_from_type(cls, scorer_type: ScorerTypes) -> Metric:
         """
@@ -748,17 +768,7 @@ class LlmMetric(Metric):
 
         # Handle output_type (accept string or enum)
         if isinstance(output_type, str):
-            # Map common string values to enum
-            output_type_map = {
-                "percentage": OutputTypeEnum.PERCENTAGE,
-                "boolean": OutputTypeEnum.BOOLEAN,
-                "categorical": OutputTypeEnum.CATEGORICAL,
-                "count": OutputTypeEnum.COUNT,
-                "discrete": OutputTypeEnum.DISCRETE,
-                "freeform": OutputTypeEnum.FREEFORM,
-                "multilabel": OutputTypeEnum.MULTILABEL,
-            }
-            self.output_type = output_type_map.get(output_type.lower(), OutputTypeEnum.PERCENTAGE)
+            self.output_type = Metric._parse_output_type(output_type, default=OutputTypeEnum.PERCENTAGE)
         else:
             self.output_type = output_type or OutputTypeEnum.BOOLEAN
 
@@ -906,19 +916,7 @@ class CodeMetric(Metric):
         self.required_metrics = required_metrics
         self.scorer_type = ScorerTypes.CODE
 
-        if isinstance(output_type, str):
-            output_type_map = {
-                "percentage": OutputTypeEnum.PERCENTAGE,
-                "boolean": OutputTypeEnum.BOOLEAN,
-                "categorical": OutputTypeEnum.CATEGORICAL,
-                "count": OutputTypeEnum.COUNT,
-                "discrete": OutputTypeEnum.DISCRETE,
-                "freeform": OutputTypeEnum.FREEFORM,
-                "multilabel": OutputTypeEnum.MULTILABEL,
-            }
-            self.output_type = output_type_map.get(output_type.lower())
-        else:
-            self.output_type = output_type
+        self.output_type = Metric._parse_output_type(output_type)
 
     def load_code(self, code_file_path: str) -> CodeMetric:
         """

--- a/src/galileo/metric.py
+++ b/src/galileo/metric.py
@@ -443,7 +443,9 @@ class Metric(StateManagementMixin, ABC):
             else:
                 code_node_level = None
 
-            self._sync_attrs(node_level=code_node_level)
+            code_output_type = None if isinstance(scorer_response.output_type, Unset) else scorer_response.output_type
+
+            self._sync_attrs(node_level=code_node_level, output_type=code_output_type)
 
     def update(self, **kwargs: Any) -> Metric:
         """

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -841,6 +841,31 @@ class TestCodeMetricInitialization:
         assert metric.required_metrics == ["context_adherence", "completeness"]
         assert metric.node_level == StepType.llm
 
+    def test_init_with_output_type_enum(self, reset_configuration: None) -> None:
+        """Test initializing a CodeMetric with an OutputTypeEnum output_type."""
+        metric = CodeMetric(name="Test Code Metric", node_level=StepType.llm, output_type=OutputTypeEnum.PERCENTAGE)
+
+        assert metric.output_type == OutputTypeEnum.PERCENTAGE
+
+    def test_init_with_output_type_string(self, reset_configuration: None) -> None:
+        """Test initializing a CodeMetric with a string output_type is mapped to the enum."""
+        cases = [
+            ("percentage", OutputTypeEnum.PERCENTAGE),
+            ("boolean", OutputTypeEnum.BOOLEAN),
+            ("categorical", OutputTypeEnum.CATEGORICAL),
+            ("count", OutputTypeEnum.COUNT),
+            ("discrete", OutputTypeEnum.DISCRETE),
+        ]
+        for string_value, expected_enum in cases:
+            metric = CodeMetric(name="Test Code Metric", node_level=StepType.llm, output_type=string_value)
+            assert metric.output_type == expected_enum, f"Expected {expected_enum} for '{string_value}'"
+
+    def test_init_without_output_type_defaults_to_none(self, reset_configuration: None) -> None:
+        """Test that omitting output_type leaves it as None (API applies its own default)."""
+        metric = CodeMetric(name="Test Code Metric", node_level=StepType.llm)
+
+        assert metric.output_type is None
+
 
 class TestCodeMetricCreate:
     """Test suite for CodeMetric.create() method."""
@@ -928,6 +953,50 @@ class TestCodeMetricCreate:
         # Verify metric was updated
         assert metric.id == scorer_id
         assert metric.is_synced()
+
+    @patch("galileo.metric.GalileoPythonConfig.get")
+    @patch("galileo.metric.get_validate_code_scorer_task_result_scorers_code_validate_task_id_get")
+    @patch("galileo.metric.validate_code_scorer_scorers_code_validate_post")
+    @patch("galileo.metric.create_code_scorer_version_scorers_scorer_id_version_code_post")
+    @patch("galileo.metric.create_scorers_post")
+    @patch("galileo.metric.Scorers")
+    def test_create_forwards_output_type_to_scorer_request(
+        self,
+        mock_scorers_class: MagicMock,
+        mock_create_scorers: MagicMock,
+        mock_create_version: MagicMock,
+        mock_validate_post: MagicMock,
+        mock_validate_get: MagicMock,
+        mock_config: MagicMock,
+        reset_configuration: None,
+        create_temp_code_file,
+        mock_api_client,
+        mock_scorer_response,
+        mock_version_response,
+        mock_scorer_full,
+        mock_validation_response,
+        mock_validation_task_result,
+    ) -> None:
+        """Regression: output_type must be forwarded to CreateScorerRequest so the API
+        stores the correct type and doesn't fall back to its generic default."""
+        mock_config.return_value.api_client = mock_api_client
+        code_file = create_temp_code_file(content="def score(trace):\n    return 1.0")
+        task_id = str(uuid4())
+        mock_validate_post.sync.return_value = mock_validation_response(task_id)
+        mock_validate_get.sync.return_value = mock_validation_task_result(TaskResultStatus.COMPLETED)
+        scorer_id = str(uuid4())
+        mock_create_scorers.sync.return_value = mock_scorer_response(scorer_id, "Test Code Metric")
+        mock_create_version.sync.return_value = mock_version_response(scorer_id)
+        mock_scorers_service = MagicMock()
+        mock_scorers_service.list.return_value = [mock_scorer_full(scorer_id, "Test Code Metric")]
+        mock_scorers_class.return_value = mock_scorers_service
+
+        CodeMetric(name="Test Code Metric", node_level=StepType.llm, output_type=OutputTypeEnum.PERCENTAGE).load_code(
+            str(code_file)
+        ).create()
+
+        create_scorer_call = mock_create_scorers.sync.call_args
+        assert create_scorer_call.kwargs["body"].output_type == OutputTypeEnum.PERCENTAGE
 
     @patch("galileo.metric.GalileoPythonConfig.get")
     @patch("galileo.metric.get_validate_code_scorer_task_result_scorers_code_validate_task_id_get")


### PR DESCRIPTION
# User description
## Summary

- Added `output_type: OutputTypeEnum | None` class attribute to `CodeMetric`
- `CodeMetric.__init__` now accepts `output_type: str | OutputTypeEnum | None = None` with string→enum mapping (same pattern as `LlmMetric`)
- Wired `output_type=self.output_type` into the `CreateScorerRequest` call inside `CodeMetric.create()`
- Updated class docstring to document the new attribute and usage example

## Why

`output_type` was previously omitted from `CodeMetric`, causing a 422 error from the API once it began requiring the field on all code scorer versions. This brings `CodeMetric` in line with `LlmMetric`.

## Test plan

- [ ] Instantiate `CodeMetric` with `output_type="boolean"` and verify it maps to `OutputTypeEnum.boolean`
- [ ] Instantiate `CodeMetric` with `output_type=OutputTypeEnum.continuous` and verify it passes through
- [ ] Call `CodeMetric.create()` and confirm no 422 from the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add output type support to <code>CodeMetric</code> by routing user-provided <code>output_type</code> through <code>Metric._parse_output_type</code> and ensuring the value is attached to <code>CreateScorerRequest</code>. Document the new attribute and explain how it maps strings to <code>OutputTypeEnum</code> so <code>code_metric.create()</code> no longer triggers API errors.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>jweiler@galileo.ai</td><td>fix</td><td>May 26, 2026</td></tr>
<tr><td>AnkushMalaker</td><td>feat(metrics): support...</td><td>May 26, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/590?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>