### PR TITLE
fix: Handle checking/using ingest-service when running on local

### DIFF
--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -406,6 +406,8 @@ class GalileoLogger(TracesLogger):
         if "result" not in _ingest_service_cache:
             try:
                 api_url = str(GalileoPythonConfig.get().api_url).rstrip("/")
+                if "localhost" in api_url:
+                    api_url = api_url.replace("8088", "8081")
                 resp = httpx.get(f"{api_url}/ingest/healthz", timeout=2.0)
                 _ingest_service_cache["result"] = resp.is_success
                 if _ingest_service_cache["result"]:
@@ -434,10 +436,13 @@ class GalileoLogger(TracesLogger):
             config = GalileoPythonConfig.get()
             api_key_secret = config.api_key
             api_key = api_key_secret.get_secret_value() if api_key_secret else os.environ.get("GALILEO_API_KEY", "")
+            ingest_url = str(config.api_url)
+            if "localhost" in ingest_url:
+                ingest_url = ingest_url.replace("8088", "8081")
             if api_key:
                 return IngestTraces(
                     project_id=self.project_id,
-                    base_url=str(config.api_url).rstrip("/"),
+                    base_url=ingest_url,
                     api_key=api_key,
                     log_stream_id=self.log_stream_id,
                     experiment_id=self.experiment_id,


### PR DESCRIPTION
# User description
**Shortcut:**

**Description:**

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjust GalileoLogger to rewrite localhost ingest URLs to port 8081 when checking health and constructing clients. Ensure <code>_is_ingest_service_available</code> and <code>_create_traces_client</code> target the corrected ingest endpoint whenever <code>localhost</code> appears in the configuration.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david@galileo.ai</td><td>fix: Handle checking/u...</td><td>May 29, 2026</td></tr>
<tr><td>namrata.ghadi@galileo.ai</td><td>feat: add agentcontrol...</td><td>May 11, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/595?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>