### PR TITLE
feat(config): rename GALILEO_* env vars to SPLUNK_AO_* (HYBIM-713, 727) [DO NOT MERGE]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry==${{ vars.POETRY_V2_VERSION }}
+        run: pipx install poetry==${{ vars.POETRY_V2_VERSION || '2.1.4' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/docs/SPLUNK_AO_ENV_RENAME.md
+++ b/docs/SPLUNK_AO_ENV_RENAME.md
@@ -1,14 +1,14 @@
 # Spec: Rename `GALILEO_*` Environment Variables to `SPLUNK_AO_*`
 
-**Jira Tickets:** [HYBIM-713](https://splunk.atlassian.net/browse/HYBIM-713) · [HYBIM-716](https://splunk.atlassian.net/browse/HYBIM-716) · [HYBIM-727](https://splunk.atlassian.net/browse/HYBIM-727)  
-**Status:** Draft / In Review  
-**Author:** Aditya Mehra  
+**Jira Tickets:** [HYBIM-713](https://splunk.atlassian.net/browse/HYBIM-713) · [HYBIM-716](https://splunk.atlassian.net/browse/HYBIM-716) · [HYBIM-727](https://splunk.atlassian.net/browse/HYBIM-727)
+**Status:** Draft / In Review
+**Author:** Aditya Mehra
 **Date:** 2026-06-04
 
 ---
 
-> **Repository migration notice**  
-> The changes in this PR are authored against the current `rungalileo/galileo-python` repository.  
+> **Repository migration notice**
+> The changes in this PR are authored against the current `rungalileo/galileo-python` repository.
 > Once the Splunk Agent Observability (Splunk AO) project is formally open-sourced, this code will
 > be re-homed to **[signalfx/splunk-ao-python](https://github.com/signalfx/splunk-ao-python)** on
 > GitHub. A corresponding notice applies to the companion PRs:
@@ -64,7 +64,7 @@ Tickets in scope for this change:
 This is a **hard cut-over** — only `SPLUNK_AO_*` environment variables are supported after this
 change. There is no backward-compatibility shim for external consumers.
 
-**Exception — `galileo-core` bridge:**  
+**Exception — `galileo-core` bridge:**
 The `galileo-core` package (a private dependency) continues to read `GALILEO_*` variables
 internally. Until `galileo-core` is updated (tracked separately), the SDK automatically bridges
 `SPLUNK_AO_*` → `GALILEO_*` at startup via `GalileoPythonConfig._bridge_env_vars()`. This is a

--- a/docs/SPLUNK_AO_ENV_RENAME.md
+++ b/docs/SPLUNK_AO_ENV_RENAME.md
@@ -1,0 +1,176 @@
+# Spec: Rename `GALILEO_*` Environment Variables to `SPLUNK_AO_*`
+
+**Jira Tickets:** [HYBIM-713](https://splunk.atlassian.net/browse/HYBIM-713) · [HYBIM-716](https://splunk.atlassian.net/browse/HYBIM-716) · [HYBIM-727](https://splunk.atlassian.net/browse/HYBIM-727)  
+**Status:** Draft / In Review  
+**Author:** Aditya Mehra  
+**Date:** 2026-06-04
+
+---
+
+> **Repository migration notice**  
+> The changes in this PR are authored against the current `rungalileo/galileo-python` repository.  
+> Once the Splunk Agent Observability (Splunk AO) project is formally open-sourced, this code will
+> be re-homed to **[signalfx/splunk-ao-python](https://github.com/signalfx/splunk-ao-python)** on
+> GitHub. A corresponding notice applies to the companion PRs:
+> - `sdk-examples` → `signalfx/splunk-ao-python-examples`
+> - `e2e-testing` → internal Splunk AO QA repo
+>
+> These PRs are opened now to facilitate early review. **Do not merge** until the migration is
+> complete and the target repositories exist.
+
+---
+
+## 1. Background
+
+The Galileo Python SDK is being rebranded as part of the **Splunk Agent Observability (Splunk AO)**
+initiative. Environment variables currently prefixed with `GALILEO_` will be replaced with
+`SPLUNK_AO_` to align with Splunk naming conventions and the new product identity.
+
+Tickets in scope for this change:
+
+| Ticket | Title |
+|--------|-------|
+| HYBIM-713 | Rename `GALILEO_API_KEY` → `SPLUNK_AO_API_KEY` |
+| HYBIM-716 | Rename `GALILEO_PROJECT` / `GALILEO_LOG_STREAM` → `SPLUNK_AO_*` |
+| HYBIM-727 | Rename remaining `GALILEO_*` env vars to `SPLUNK_AO_*` |
+
+> **Out of scope:** `GALILEO_HEADER_PREFIX` — tracked separately as [HYBIM-729](https://splunk.atlassian.net/browse/HYBIM-729).
+
+---
+
+## 2. Scope of Changes
+
+### 2.1 Environment Variable Mapping
+
+| Old (`GALILEO_*`) | New (`SPLUNK_AO_*`) |
+|-------------------|---------------------|
+| `GALILEO_API_KEY` | `SPLUNK_AO_API_KEY` |
+| `GALILEO_CONSOLE_URL` | `SPLUNK_AO_CONSOLE_URL` |
+| `GALILEO_PROJECT` | `SPLUNK_AO_PROJECT` |
+| `GALILEO_PROJECT_ID` | `SPLUNK_AO_PROJECT_ID` |
+| `GALILEO_LOG_STREAM` | `SPLUNK_AO_LOG_STREAM` |
+| `GALILEO_LOG_STREAM_ID` | `SPLUNK_AO_LOG_STREAM_ID` |
+| `GALILEO_JWT_TOKEN` | `SPLUNK_AO_JWT_TOKEN` |
+| `GALILEO_SSO_ID_TOKEN` | `SPLUNK_AO_SSO_ID_TOKEN` |
+| `GALILEO_SSO_PROVIDER` | `SPLUNK_AO_SSO_PROVIDER` |
+| `GALILEO_USERNAME` | `SPLUNK_AO_USERNAME` |
+| `GALILEO_PASSWORD` | `SPLUNK_AO_PASSWORD` |
+| `GALILEO_MODE` | `SPLUNK_AO_MODE` |
+| `GALILEO_LOGGING_DISABLED` | `SPLUNK_AO_LOGGING_DISABLED` |
+| `GALILEO_INGEST_BETA_DISABLED` | `SPLUNK_AO_INGEST_BETA_DISABLED` |
+
+### 2.2 Compatibility Strategy
+
+This is a **hard cut-over** — only `SPLUNK_AO_*` environment variables are supported after this
+change. There is no backward-compatibility shim for external consumers.
+
+**Exception — `galileo-core` bridge:**  
+The `galileo-core` package (a private dependency) continues to read `GALILEO_*` variables
+internally. Until `galileo-core` is updated (tracked separately), the SDK automatically bridges
+`SPLUNK_AO_*` → `GALILEO_*` at startup via `GalileoPythonConfig._bridge_env_vars()`. This is a
+transparent, temporary compatibility layer that does not expose `GALILEO_*` names to SDK consumers.
+
+```python
+# src/galileo/config.py — bridge called inside GalileoPythonConfig.get()
+@staticmethod
+def _bridge_env_vars() -> None:
+    """Copy SPLUNK_AO_* values into GALILEO_* so galileo-core can authenticate.
+    Only sets GALILEO_* if it is not already present — explicit overrides win.
+    """
+    _BRIDGE = [
+        ("SPLUNK_AO_API_KEY",       "GALILEO_API_KEY"),
+        ("SPLUNK_AO_CONSOLE_URL",   "GALILEO_CONSOLE_URL"),
+        ("SPLUNK_AO_PROJECT",       "GALILEO_PROJECT"),
+        ...
+    ]
+    for new_key, old_key in _BRIDGE:
+        if new_key in os.environ and old_key not in os.environ:
+            os.environ[old_key] = os.environ[new_key]
+```
+
+---
+
+## 3. Files Changed
+
+### `galileo-python` (this repo)
+
+| File | Change |
+|------|--------|
+| `src/galileo/configuration.py` | 14 `ConfigKey.env_var` fields renamed |
+| `src/galileo/config.py` | Auth validation + `_bridge_env_vars()` added |
+| `src/galileo/utils/env_helpers.py` | `os.getenv()` calls updated |
+| `src/galileo/utils/decorators/telemetry_toggle.py` | `GALILEO_LOGGING_DISABLED` renamed |
+| `src/galileo/logger/logger.py` | `GALILEO_INGEST_BETA_DISABLED` renamed |
+| `src/galileo/{agent_control,decorator,exceptions,experiment,experiments,log_stream,log_streams,metric,middleware/tracing,otel,projects,prompt,shared/exceptions,utils/singleton}.py` | Docstrings / comments / error strings updated |
+| `src/galileo/README_API_CLIENT.md` | Docs updated |
+| `tests/**` | All `GALILEO_*` references in test files renamed to `SPLUNK_AO_*` |
+
+### `sdk-examples`
+
+| File | Change |
+|------|--------|
+| `python/agent/langchain-agent/.env.example` | Renamed keys to `SPLUNK_AO_*` |
+| `python/agent/langchain-agent/main.py` | `os.environ["GALILEO_*"]` → `os.environ["SPLUNK_AO_*"]` |
+| `python/agent/strands-agents/.env.example` | Renamed keys to `SPLUNK_AO_*` |
+
+### `e2e-testing`
+
+| File | Change |
+|------|--------|
+| `py-sdk-and-ui/.env.example` | New file — `SPLUNK_AO_*` keys, no values |
+
+---
+
+## 4. Testing
+
+### Unit Tests
+
+```bash
+cd galileo-python
+poetry run pytest                # 2015 passed, 5 skipped
+```
+
+### E2E Tests
+
+```bash
+cd e2e-testing/py-sdk-and-ui
+poetry run playwright install --with-deps
+poetry run pytest tests/ -k "langchain" --headed
+```
+
+Result: all targeted tests passed (one pre-existing 404 on `test_log_session_with_multiple_traces`
+is a server-side issue unrelated to this change).
+
+### Examples
+
+```bash
+# langchain-agent
+cd sdk-examples/python/agent/langchain-agent
+source .venv/bin/activate && python main.py
+# → "Hello, Erin! 👋"   exit 0
+
+# strands-agents
+cd sdk-examples/python/agent/strands-agents
+source .venv/bin/activate && python agent.py
+# → Tool results returned   exit 0
+```
+
+---
+
+## 5. Decisions & Rationale
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Backward compatibility | Hard cut-over | No dual-support maintenance burden; clean break aligned with rebrand |
+| `galileo-core` handling | Bridge only in SDK | `galileo-core` changes tracked separately; bridge is transparent to consumers |
+| `GALILEO_HEADER_PREFIX` | **Not renamed** | Separate ticket HYBIM-729 |
+| Test files | Renamed to `SPLUNK_AO_*` | Consistency; tests document the new public API |
+
+---
+
+## 6. Open Questions / Follow-ups
+
+- [ ] Update `galileo-core` to read `SPLUNK_AO_*` natively and remove `_bridge_env_vars()`
+- [ ] Rename `GALILEO_HEADER_PREFIX` (HYBIM-729)
+- [ ] Update CI/CD secrets and deployment configs to use `SPLUNK_AO_*` names
+- [ ] Migrate this repo to `signalfx/splunk-ao-python`

--- a/src/galileo/README_API_CLIENT.md
+++ b/src/galileo/README_API_CLIENT.md
@@ -9,7 +9,7 @@ First, create a client:
 ```python
 from galileo.api_client import GalileoApiClient
 
-# Make sure you've set the GALILEO_CONSOLE_URL and GALILEO_API_KEY env vars
+# Make sure you've set the SPLUNK_AO_CONSOLE_URL and SPLUNK_AO_API_KEY env vars
 # Optionally, you can specify both base_url and api_key
 client = GalileoApiClient()
 ```

--- a/src/galileo/agent_control.py
+++ b/src/galileo/agent_control.py
@@ -60,7 +60,7 @@ def get_agent_control_target(
 
     1. Explicit ``target_id``.
     2. Explicit ``log_stream_id`` for ``log_stream`` targets.
-    3. ``GALILEO_LOG_STREAM_ID`` for ``log_stream`` targets.
+    3. ``SPLUNK_AO_LOG_STREAM_ID`` for ``log_stream`` targets.
     4. An already-initialized ``galileo_context`` logger.
 
     This helper does not resolve log stream names over the network. If only a
@@ -68,7 +68,7 @@ def get_agent_control_target(
     the resulting ID explicitly.
     """
     explicit_project_id = _strip_optional_string(project_id)
-    env_project_id = _strip_optional_string(os.getenv("GALILEO_PROJECT_ID"))
+    env_project_id = _strip_optional_string(os.getenv("SPLUNK_AO_PROJECT_ID"))
     resolved_project_id = explicit_project_id or env_project_id
 
     if target_type == LOG_STREAM_TARGET_TYPE:
@@ -94,9 +94,9 @@ def get_agent_control_target(
             "Provide target_id=<id> explicitly."
         )
 
-    env_log_stream_id = _strip_optional_string(os.getenv("GALILEO_LOG_STREAM_ID"))
+    env_log_stream_id = _strip_optional_string(os.getenv("SPLUNK_AO_LOG_STREAM_ID"))
     if env_log_stream_id:
-        _validate_uuid(env_log_stream_id, "GALILEO_LOG_STREAM_ID")
+        _validate_uuid(env_log_stream_id, "SPLUNK_AO_LOG_STREAM_ID")
         return AgentControlTarget(
             target_type=LOG_STREAM_TARGET_TYPE, target_id=env_log_stream_id, project_id=resolved_project_id
         )
@@ -112,7 +112,7 @@ def get_agent_control_target(
     raise AgentControlTargetUnresolvedError(
         "Could not resolve Galileo log stream ID for Agent Control. Provide one of:\n"
         "  1. target_id=<uuid> or log_stream_id=<uuid> argument\n"
-        "  2. GALILEO_LOG_STREAM_ID environment variable\n"
+        "  2. SPLUNK_AO_LOG_STREAM_ID environment variable\n"
         "  3. An initialized galileo_context with a resolved log stream ID"
     )
 

--- a/src/galileo/config.py
+++ b/src/galileo/config.py
@@ -24,12 +24,41 @@ class GalileoPythonConfig(GalileoConfig):
     @classmethod
     def get(cls, **kwargs: Any) -> "GalileoPythonConfig":
         if cls._instance is None:
+            cls._bridge_env_vars()
             error_message = cls._check_auth_config(kwargs)
             if error_message is not None:
                 raise ConfigurationError(error_message)
         cls._instance = cls._get(cls._instance, **kwargs)
         assert cls._instance is not None, "Failed to initialize GalileoPythonConfig"
         return cls._instance
+
+    @staticmethod
+    def _bridge_env_vars() -> None:
+        """Bridge SPLUNK_AO_* env vars into GALILEO_* for galileo-core compatibility.
+
+        galileo-core still reads GALILEO_* env vars. Until galileo-core is updated,
+        this method propagates any SPLUNK_AO_* values to their GALILEO_* equivalents
+        so that galileo-core can authenticate successfully.
+
+        Only bridges values that are not already set — explicit GALILEO_* overrides win.
+        """
+        _BRIDGE = [
+            ("SPLUNK_AO_API_KEY", "GALILEO_API_KEY"),
+            ("SPLUNK_AO_CONSOLE_URL", "GALILEO_CONSOLE_URL"),
+            ("SPLUNK_AO_PROJECT", "GALILEO_PROJECT"),
+            ("SPLUNK_AO_PROJECT_ID", "GALILEO_PROJECT_ID"),
+            ("SPLUNK_AO_LOG_STREAM", "GALILEO_LOG_STREAM"),
+            ("SPLUNK_AO_LOG_STREAM_ID", "GALILEO_LOG_STREAM_ID"),
+            ("SPLUNK_AO_JWT_TOKEN", "GALILEO_JWT_TOKEN"),
+            ("SPLUNK_AO_SSO_ID_TOKEN", "GALILEO_SSO_ID_TOKEN"),
+            ("SPLUNK_AO_SSO_PROVIDER", "GALILEO_SSO_PROVIDER"),
+            ("SPLUNK_AO_USERNAME", "GALILEO_USERNAME"),
+            ("SPLUNK_AO_PASSWORD", "GALILEO_PASSWORD"),
+            ("SPLUNK_AO_MODE", "GALILEO_MODE"),
+        ]
+        for new_key, old_key in _BRIDGE:
+            if new_key in os.environ and old_key not in os.environ:
+                os.environ[old_key] = os.environ[new_key]
 
     @staticmethod
     def _check_auth_config(kwargs: dict) -> str | None:
@@ -40,8 +69,8 @@ class GalileoPythonConfig(GalileoConfig):
         message identifying what's missing.
 
         Auth methods supported by the underlying config model:
-          - API key (standalone): api_key kwarg or GALILEO_API_KEY env
-          - Pre-exchanged Galileo JWT (standalone): jwt_token or GALILEO_JWT_TOKEN
+          - API key (standalone): api_key kwarg or SPLUNK_AO_API_KEY env
+          - Pre-exchanged JWT (standalone): jwt_token or SPLUNK_AO_JWT_TOKEN
           - SSO (paired): sso_id_token + sso_provider, both kwargs and env vars
           - Username/password (paired): username + password, both kwargs and env vars
 
@@ -56,51 +85,51 @@ class GalileoPythonConfig(GalileoConfig):
             return os.environ.get(env_name)
 
         # Standalone methods — either alone is sufficient.
-        if _val("api_key", "GALILEO_API_KEY"):
+        if _val("api_key", "SPLUNK_AO_API_KEY"):
             return None
-        if _val("jwt_token", "GALILEO_JWT_TOKEN"):
+        if _val("jwt_token", "SPLUNK_AO_JWT_TOKEN"):
             return None
 
         # SSO requires BOTH id_token and provider.
-        sso_id_token = _val("sso_id_token", "GALILEO_SSO_ID_TOKEN")
-        sso_provider = _val("sso_provider", "GALILEO_SSO_PROVIDER")
+        sso_id_token = _val("sso_id_token", "SPLUNK_AO_SSO_ID_TOKEN")
+        sso_provider = _val("sso_provider", "SPLUNK_AO_SSO_PROVIDER")
         if sso_id_token and sso_provider:
             return None
         if sso_id_token and not sso_provider:
             return (
-                "GALILEO_SSO_ID_TOKEN is set but GALILEO_SSO_PROVIDER is missing. "
-                "SSO authentication requires both. Set GALILEO_SSO_PROVIDER to your "
+                "SPLUNK_AO_SSO_ID_TOKEN is set but SPLUNK_AO_SSO_PROVIDER is missing. "
+                "SSO authentication requires both. Set SPLUNK_AO_SSO_PROVIDER to your "
                 "IdP identifier (e.g. 'okta', 'custom') or pass sso_provider=... "
                 "as a keyword argument."
             )
         if sso_provider and not sso_id_token:
             return (
-                "GALILEO_SSO_PROVIDER is set but GALILEO_SSO_ID_TOKEN is missing. "
-                "SSO authentication requires both. Set GALILEO_SSO_ID_TOKEN to your "
+                "SPLUNK_AO_SSO_PROVIDER is set but SPLUNK_AO_SSO_ID_TOKEN is missing. "
+                "SSO authentication requires both. Set SPLUNK_AO_SSO_ID_TOKEN to your "
                 "IdP-issued ID token or pass sso_id_token=... as a keyword argument."
             )
 
         # Username/password requires BOTH.
-        username = _val("username", "GALILEO_USERNAME")
-        password = _val("password", "GALILEO_PASSWORD")
+        username = _val("username", "SPLUNK_AO_USERNAME")
+        password = _val("password", "SPLUNK_AO_PASSWORD")
         if username and password:
             return None
         if username and not password:
             return (
-                "GALILEO_USERNAME is set but GALILEO_PASSWORD is missing. "
+                "SPLUNK_AO_USERNAME is set but SPLUNK_AO_PASSWORD is missing. "
                 "Username/password authentication requires both."
             )
         if password and not username:
             return (
-                "GALILEO_PASSWORD is set but GALILEO_USERNAME is missing. "
+                "SPLUNK_AO_PASSWORD is set but SPLUNK_AO_USERNAME is missing. "
                 "Username/password authentication requires both."
             )
 
         # Nothing configured anywhere.
         return (
-            "No Galileo authentication detected. Set one of: "
-            "GALILEO_API_KEY; GALILEO_SSO_ID_TOKEN with GALILEO_SSO_PROVIDER; "
-            "or GALILEO_USERNAME with GALILEO_PASSWORD. "
+            "No Splunk AO authentication detected. Set one of: "
+            "SPLUNK_AO_API_KEY; SPLUNK_AO_SSO_ID_TOKEN with SPLUNK_AO_SSO_PROVIDER; "
+            "or SPLUNK_AO_USERNAME with SPLUNK_AO_PASSWORD. "
             "Alternatively, pass the equivalent kwargs to GalileoPythonConfig.get(). "
-            "See https://docs.galileo.ai for setup instructions."
+            "See https://docs.splunk.com for setup instructions."
         )

--- a/src/galileo/configuration.py
+++ b/src/galileo/configuration.py
@@ -311,7 +311,7 @@ class Configuration(metaclass=ConfigurationMeta):
     ```python
     # Set explicitly (also updates environment variables)
     Configuration.galileo_api_key = "your-api-key"
-    Configuration.console_url = "https://console.splunk.com"
+    Configuration.console_url = "your-console-url"
     ```
 
     Checking and connecting:

--- a/src/galileo/configuration.py
+++ b/src/galileo/configuration.py
@@ -29,7 +29,7 @@ class ConfigKey:
     name : str
         The attribute name used in the Configuration class (e.g., "galileo_api_key").
     env_var : str
-        The corresponding environment variable name (e.g., "GALILEO_API_KEY").
+        The corresponding environment variable name (e.g., "SPLUNK_AO_API_KEY").
     description : str
         Human-readable description of the configuration key's purpose.
     required : bool
@@ -72,15 +72,15 @@ def parse_log_level(value: str) -> str:
 _CONFIGURATION_KEYS = [
     ConfigKey(
         name="galileo_api_key",
-        env_var="GALILEO_API_KEY",
-        description="API key for authenticating with Galileo",
+        env_var="SPLUNK_AO_API_KEY",
+        description="API key for authenticating with Splunk Agent Observability",
         required=True,
         sensitive=True,
     ),
     ConfigKey(
         name="console_url",
-        env_var="GALILEO_CONSOLE_URL",
-        description="URL of the Galileo console",
+        env_var="SPLUNK_AO_CONSOLE_URL",
+        description="URL of the Splunk Agent Observability console",
         default=DEFAULT_CONSOLE_URL,
     ),
     ConfigKey(
@@ -89,19 +89,19 @@ _CONFIGURATION_KEYS = [
         description="OpenAI API key for interoperability with OpenAI SDK",
         sensitive=True,
     ),
-    ConfigKey(name="default_project_name", env_var="GALILEO_PROJECT", description="Default project name"),
-    ConfigKey(name="default_project_id", env_var="GALILEO_PROJECT_ID", description="Default project ID"),
-    ConfigKey(name="default_logstream_name", env_var="GALILEO_LOG_STREAM", description="Default log stream name"),
-    ConfigKey(name="default_logstream_id", env_var="GALILEO_LOG_STREAM_ID", description="Default log stream ID"),
+    ConfigKey(name="default_project_name", env_var="SPLUNK_AO_PROJECT", description="Default project name"),
+    ConfigKey(name="default_project_id", env_var="SPLUNK_AO_PROJECT_ID", description="Default project ID"),
+    ConfigKey(name="default_logstream_name", env_var="SPLUNK_AO_LOG_STREAM", description="Default log stream name"),
+    ConfigKey(name="default_logstream_id", env_var="SPLUNK_AO_LOG_STREAM_ID", description="Default log stream ID"),
     ConfigKey(
         name="default_scorer_model",
-        env_var="GALILEO_DEFAULT_SCORER_MODEL",
+        env_var="SPLUNK_AO_DEFAULT_SCORER_MODEL",
         description="Default model for LLM-based scorers/metrics",
         default="gpt-4.1-mini",
     ),
     ConfigKey(
         name="default_scorer_judges",
-        env_var="GALILEO_DEFAULT_SCORER_JUDGES",
+        env_var="SPLUNK_AO_DEFAULT_SCORER_JUDGES",
         description="Default number of judges for LLM-based scorers/metrics",
         default=3,
         value_type=int,
@@ -109,15 +109,15 @@ _CONFIGURATION_KEYS = [
     ),
     ConfigKey(
         name="logging_disabled",
-        env_var="GALILEO_LOGGING_DISABLED",
-        description="Disable all telemetry logging to Galileo",
+        env_var="SPLUNK_AO_LOGGING_DISABLED",
+        description="Disable all telemetry logging to Splunk Agent Observability",
         default=False,
         value_type=bool,
         parser=lambda v: v.lower() in ("true", "1", "t", "yes"),
     ),
     ConfigKey(
         name="log_level",
-        env_var="GALILEO_LOG_LEVEL",
+        env_var="SPLUNK_AO_LOG_LEVEL",
         description="Python logging level for SDK output (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
         default=None,
         value_type=str,
@@ -125,7 +125,7 @@ _CONFIGURATION_KEYS = [
     ),
     ConfigKey(
         name="code_validation_timeout",
-        env_var="GALILEO_CODE_VALIDATION_TIMEOUT",
+        env_var="SPLUNK_AO_CODE_VALIDATION_TIMEOUT",
         description="Timeout in seconds for code scorer validation",
         default=60.0,
         value_type=float,
@@ -133,7 +133,7 @@ _CONFIGURATION_KEYS = [
     ),
     ConfigKey(
         name="code_validation_initial_delay",
-        env_var="GALILEO_CODE_VALIDATION_INITIAL_DELAY",
+        env_var="SPLUNK_AO_CODE_VALIDATION_INITIAL_DELAY",
         description="Initial delay in seconds between validation polling attempts",
         default=5.0,
         value_type=float,
@@ -141,7 +141,7 @@ _CONFIGURATION_KEYS = [
     ),
     ConfigKey(
         name="code_validation_max_delay",
-        env_var="GALILEO_CODE_VALIDATION_MAX_DELAY",
+        env_var="SPLUNK_AO_CODE_VALIDATION_MAX_DELAY",
         description="Maximum delay in seconds between validation polling attempts",
         default=30.0,
         value_type=float,
@@ -149,7 +149,7 @@ _CONFIGURATION_KEYS = [
     ),
     ConfigKey(
         name="code_validation_backoff_multiplier",
-        env_var="GALILEO_CODE_VALIDATION_BACKOFF_MULTIPLIER",
+        env_var="SPLUNK_AO_CODE_VALIDATION_BACKOFF_MULTIPLIER",
         description="Multiplier for exponential backoff between validation polling attempts",
         default=1.5,
         value_type=float,
@@ -242,7 +242,7 @@ class ConfigurationMeta(type):
 
         When setting a configuration key, the value is:
         1. Stored internally with underscore prefix (e.g., `_galileo_api_key`)
-        2. Synced to the corresponding environment variable (e.g., `GALILEO_API_KEY`)
+        2. Synced to the corresponding environment variable (e.g., `SPLUNK_AO_API_KEY`)
 
         This ensures that both the Configuration class and environment variables
         remain consistent, maintaining compatibility with third-party libraries.
@@ -276,7 +276,7 @@ class Configuration(metaclass=ConfigurationMeta):
     attribute, with values resolved in the following priority order:
 
     1. Explicitly set value (via `Configuration.key = value`)
-    2. Environment variable (e.g., GALILEO_API_KEY)
+    2. Environment variable (e.g., SPLUNK_AO_API_KEY)
     3. .env file (loaded automatically on first access)
     4. Default value (defined in the key configuration)
 
@@ -311,7 +311,7 @@ class Configuration(metaclass=ConfigurationMeta):
     ```python
     # Set explicitly (also updates environment variables)
     Configuration.galileo_api_key = "your-api-key"
-    Configuration.console_url = "https://console.galileo.ai"
+    Configuration.console_url = "https://console.splunk.com"
     ```
 
     Checking and connecting:
@@ -388,7 +388,7 @@ class Configuration(metaclass=ConfigurationMeta):
 
         if not cls.galileo_api_key:
             raise ConfigurationError(
-                "Galileo API key is required. Set Configuration.galileo_api_key or GALILEO_API_KEY."
+                "Splunk AO API key is required. Set Configuration.galileo_api_key or SPLUNK_AO_API_KEY."
             )
 
         logger.info("Validating Galileo configuration and connectivity...")

--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -37,8 +37,8 @@ How to use decorators:
    ```
 
 Setup requirements:
-- Galileo API key must be set (via environment variable GALILEO_API_KEY or programmatically)
-- Project and Log Stream names should be defined if using the `log` decorator (either via environment variables GALILEO_PROJECT and GALILEO_LOG_STREAM, or via `galileo_context.init()`)
+- Galileo API key must be set (via environment variable SPLUNK_AO_API_KEY or programmatically)
+- Project and Log Stream names should be defined if using the `log` decorator (either via environment variables SPLUNK_AO_PROJECT and SPLUNK_AO_LOG_STREAM, or via `galileo_context.init()`)
 
 For more examples and detailed usage, see the Galileo SDK documentation.
 """

--- a/src/galileo/exceptions.py
+++ b/src/galileo/exceptions.py
@@ -49,7 +49,7 @@ class AuthenticationError(GalileoAPIError):
             status_code,
             content,
             "Authentication failed. Check your API key is valid and not expired. "
-            "Set via GALILEO_API_KEY environment variable or pass api_key= when initializing the client.",
+            "Set via SPLUNK_AO_API_KEY environment variable or pass api_key= when initializing the client.",
         )
 
 

--- a/src/galileo/experiment.py
+++ b/src/galileo/experiment.py
@@ -231,9 +231,9 @@ class Experiment(StateManagementMixin):
                   This will be used to configure the prompt_settings when running the experiment.
             metrics: List of metrics to evaluate.
             project_id: The project ID. If neither project_id nor project_name is provided,
-                       falls back to GALILEO_PROJECT_ID or GALILEO_PROJECT environment variables.
+                       falls back to SPLUNK_AO_PROJECT_ID or SPLUNK_AO_PROJECT environment variables.
             project_name: The project name. If neither project_id nor project_name is provided,
-                         falls back to GALILEO_PROJECT environment variable.
+                         falls back to SPLUNK_AO_PROJECT environment variable.
             prompt_settings: Settings for prompt runs. If provided along with model parameter,
                            the model parameter takes precedence.
 
@@ -269,12 +269,12 @@ class Experiment(StateManagementMixin):
                 project_name="My AI Project"
             )
 
-            # Create using GALILEO_PROJECT environment variable
+            # Create using SPLUNK_AO_PROJECT environment variable
             experiment = Experiment(
                 name="ml-evaluation",
                 dataset_name="ml-dataset",
                 prompt_name="ml-prompt"
-                # project resolved from GALILEO_PROJECT env var
+                # project resolved from SPLUNK_AO_PROJECT env var
             )
         """
         super().__init__()
@@ -399,7 +399,7 @@ class Experiment(StateManagementMixin):
             raise ValueError("Experiment name is not set. Cannot create experiment without a name.")
 
         # Note: project_id and project_name can both be None here — resolution happens below
-        # via _resolve_project, which reads GALILEO_PROJECT_ID / GALILEO_PROJECT env vars.
+        # via _resolve_project, which reads SPLUNK_AO_PROJECT_ID / SPLUNK_AO_PROJECT env vars.
 
         try:
             _logger.info(f"Experiment.create: name='{self.name}' project_id='{self.project_id}' - started")
@@ -640,9 +640,9 @@ class Experiment(StateManagementMixin):
         Args:
             name (str): The experiment name.
             project_id (Optional[str]): The project ID. If neither project_id nor project_name is provided,
-                       falls back to GALILEO_PROJECT_ID or GALILEO_PROJECT environment variables.
+                       falls back to SPLUNK_AO_PROJECT_ID or SPLUNK_AO_PROJECT environment variables.
             project_name (Optional[str]): The project name. If neither project_id nor project_name is provided,
-                         falls back to GALILEO_PROJECT environment variable.
+                         falls back to SPLUNK_AO_PROJECT environment variable.
 
         Returns
         -------
@@ -666,7 +666,7 @@ class Experiment(StateManagementMixin):
                 project_id="project-123"
             )
 
-            # Get using GALILEO_PROJECT environment variable
+            # Get using SPLUNK_AO_PROJECT environment variable
             experiment = Experiment.get(name="ml-evaluation")
         """
         project_obj = _resolve_project(project_id, project_name)
@@ -689,9 +689,9 @@ class Experiment(StateManagementMixin):
 
         Args:
             project_id (Optional[str]): The project ID. If neither project_id nor project_name is provided,
-                       falls back to GALILEO_PROJECT_ID or GALILEO_PROJECT environment variables.
+                       falls back to SPLUNK_AO_PROJECT_ID or SPLUNK_AO_PROJECT environment variables.
             project_name (Optional[str]): The project name. If neither project_id nor project_name is provided,
-                         falls back to GALILEO_PROJECT environment variable.
+                         falls back to SPLUNK_AO_PROJECT environment variable.
 
         Returns
         -------
@@ -709,7 +709,7 @@ class Experiment(StateManagementMixin):
             # List by project ID
             experiments = Experiment.list(project_id="project-123")
 
-            # List using GALILEO_PROJECT environment variable
+            # List using SPLUNK_AO_PROJECT environment variable
             experiments = Experiment.list()
         """
         project_obj = _resolve_project(project_id, project_name)

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -328,7 +328,7 @@ def run_experiment(
 
     When using a runner function, you can also pass a list of dictionaries to the function to act as a dataset.
 
-    The project can be specified by providing exactly one of the project name (via the 'project' parameter or the GALILEO_PROJECT environment variable) or the project ID (via the 'project_id' parameter or the GALILEO_PROJECT_ID environment variable).
+    The project can be specified by providing exactly one of the project name (via the 'project' parameter or the SPLUNK_AO_PROJECT environment variable) or the project ID (via the 'project_id' parameter or the SPLUNK_AO_PROJECT_ID environment variable).
 
     Parameters
     ----------
@@ -340,9 +340,9 @@ def run_experiment(
         Settings for prompt runs. Accepts a ``PromptRunSettings`` instance or a plain ``dict``
         with matching field names, which will be coerced to ``PromptRunSettings`` automatically.
     project
-        Optional project name. Takes preference over the GALILEO_PROJECT environment variable. Leave empty if using project_id
+        Optional project name. Takes preference over the SPLUNK_AO_PROJECT environment variable. Leave empty if using project_id
     project_id
-        Optional project Id. Takes preference over the GALILEO_PROJECT_ID environment variable. Leave empty if using project
+        Optional project Id. Takes preference over the SPLUNK_AO_PROJECT_ID environment variable. Leave empty if using project
     dataset
         Dataset object, list of records, or dataset name
     dataset_id
@@ -504,17 +504,17 @@ def create_experiment(
     """
     Create an experiment with the specified parameters.
 
-    The project can be specified by providing exactly one of the project name (via the 'project' parameter or the GALILEO_PROJECT environment variable)
-    or the project ID (via the 'project_id' parameter or the GALILEO_PROJECT_ID environment variable).
+    The project can be specified by providing exactly one of the project name (via the 'project' parameter or the SPLUNK_AO_PROJECT environment variable)
+    or the project ID (via the 'project_id' parameter or the SPLUNK_AO_PROJECT_ID environment variable).
 
     Parameters
     ----------
     project_id
-        Optional project Id. Takes preference over the GALILEO_PROJECT_ID environment variable. Leave empty if using project
+        Optional project Id. Takes preference over the SPLUNK_AO_PROJECT_ID environment variable. Leave empty if using project
     experiment_name
         Name of the experiment. Required.
     project
-        Optional project name. Takes preference over the GALILEO_PROJECT environment variable. Leave empty if using project_id
+        Optional project name. Takes preference over the SPLUNK_AO_PROJECT environment variable. Leave empty if using project_id
     experiment_group
         Optional name of an experiment group to assign this experiment to. If a group with
         this name does not exist in the project, the API auto-creates it.
@@ -565,17 +565,17 @@ def get_experiment(
     """
     Get an experiment with the specified parameters.
 
-    The project can be specified by providing exactly one of the project name (via the 'project' parameter or the GALILEO_PROJECT environment variable)
-    or the project ID (via the 'project_id' parameter or the GALILEO_PROJECT_ID environment variable).
+    The project can be specified by providing exactly one of the project name (via the 'project' parameter or the SPLUNK_AO_PROJECT environment variable)
+    or the project ID (via the 'project_id' parameter or the SPLUNK_AO_PROJECT_ID environment variable).
 
     Parameters
     ----------
     project_id
-        Optional project Id. Takes preference over the GALILEO_PROJECT_ID environment variable. Leave empty if using ``project``
+        Optional project Id. Takes preference over the SPLUNK_AO_PROJECT_ID environment variable. Leave empty if using ``project``
     experiment_name
         Name of the experiment. Required.
     project_name
-        Optional project name. Takes preference over the GALILEO_PROJECT environment variable. Leave empty if using ``project_id``
+        Optional project name. Takes preference over the SPLUNK_AO_PROJECT environment variable. Leave empty if using ``project_id``
 
     Returns
     -------
@@ -620,9 +620,9 @@ def get_experiments(
     Parameters
     ----------
     project_id
-        Optional project Id. Takes preference over the GALILEO_PROJECT_ID environment variable. Leave empty if using ``project``
+        Optional project Id. Takes preference over the SPLUNK_AO_PROJECT_ID environment variable. Leave empty if using ``project``
     project_name
-        Optional project name. Takes preference over the GALILEO_PROJECT environment variable. Leave empty if using ``project_id``
+        Optional project name. Takes preference over the SPLUNK_AO_PROJECT environment variable. Leave empty if using ``project_id``
     experiment_group
         Optional experiment-group name to filter by. Returns only experiments assigned to
         a group with this name. Mutually compatible with ``experiment_group_id``: if both
@@ -708,16 +708,16 @@ def list_experiment_groups(
     do not need to handle pagination tokens.
 
     The project can be specified by providing exactly one of the project name (via the
-    ``project_name`` parameter or the ``GALILEO_PROJECT`` environment variable) or the
-    project ID (via the ``project_id`` parameter or the ``GALILEO_PROJECT_ID``
+    ``project_name`` parameter or the ``SPLUNK_AO_PROJECT`` environment variable) or the
+    project ID (via the ``project_id`` parameter or the ``SPLUNK_AO_PROJECT_ID``
     environment variable).
 
     Parameters
     ----------
     project_id
-        Optional project ID. Takes preference over the ``GALILEO_PROJECT_ID`` env var.
+        Optional project ID. Takes preference over the ``SPLUNK_AO_PROJECT_ID`` env var.
     project_name
-        Optional project name. Takes preference over the ``GALILEO_PROJECT`` env var.
+        Optional project name. Takes preference over the ``SPLUNK_AO_PROJECT`` env var.
 
     Returns
     -------

--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -113,9 +113,9 @@ class LogStream(StateManagementMixin):
         Args:
             name (str): The name of the log stream to create.
             project_id (Optional[str]): The project ID. If neither project_id nor project_name is provided,
-                       falls back to GALILEO_PROJECT_ID or GALILEO_PROJECT environment variables.
+                       falls back to SPLUNK_AO_PROJECT_ID or SPLUNK_AO_PROJECT environment variables.
             project_name (Optional[str]): The project name. If neither project_id nor project_name is provided,
-                         falls back to GALILEO_PROJECT environment variable.
+                         falls back to SPLUNK_AO_PROJECT environment variable.
 
         Raises
         ------
@@ -130,7 +130,7 @@ class LogStream(StateManagementMixin):
             # Create by project name
             log_stream = LogStream(name="Production Logs", project_name="My AI Project")
 
-            # Create using GALILEO_PROJECT environment variable
+            # Create using SPLUNK_AO_PROJECT environment variable
             log_stream = LogStream(name="Production Logs")
         """
         super().__init__()
@@ -173,7 +173,7 @@ class LogStream(StateManagementMixin):
             raise ValueError("Log stream name is not set. Cannot create log stream without a name.")
 
         # Note: project_id and project_name can both be None here — resolution happens below
-        # via _resolve_project, which reads GALILEO_PROJECT_ID / GALILEO_PROJECT env vars.
+        # via _resolve_project, which reads SPLUNK_AO_PROJECT_ID / SPLUNK_AO_PROJECT env vars.
 
         try:
             logger.info(f"LogStream.create: name='{self.name}' project_id='{self.project_id}' - started")
@@ -253,9 +253,9 @@ class LogStream(StateManagementMixin):
         Args:
             name (str): The log stream name.
             project_id (Optional[str]): The project ID. If neither project_id nor project_name is provided,
-                       falls back to GALILEO_PROJECT_ID or GALILEO_PROJECT environment variables.
+                       falls back to SPLUNK_AO_PROJECT_ID or SPLUNK_AO_PROJECT environment variables.
             project_name (Optional[str]): The project name. If neither project_id nor project_name is provided,
-                         falls back to GALILEO_PROJECT environment variable.
+                         falls back to SPLUNK_AO_PROJECT environment variable.
 
         Returns
         -------
@@ -279,7 +279,7 @@ class LogStream(StateManagementMixin):
                 project_id="project-123"
             )
 
-            # Get using GALILEO_PROJECT environment variable
+            # Get using SPLUNK_AO_PROJECT environment variable
             log_stream = LogStream.get(name="Production Logs")
         """
         project_obj = _resolve_project(project_id, project_name)
@@ -311,9 +311,9 @@ class LogStream(StateManagementMixin):
 
         Args:
             project_id (Optional[str]): The project ID. If neither project_id nor project_name is provided,
-                       falls back to GALILEO_PROJECT_ID or GALILEO_PROJECT environment variables.
+                       falls back to SPLUNK_AO_PROJECT_ID or SPLUNK_AO_PROJECT environment variables.
             project_name (Optional[str]): The project name. If neither project_id nor project_name is provided,
-                         falls back to GALILEO_PROJECT environment variable.
+                         falls back to SPLUNK_AO_PROJECT environment variable.
             limit (Union[Unset, int]): Maximum number of log streams to return per page. Defaults to 100.
             starting_token (Union[Unset, int]): Pagination token to start from. Defaults to 0 (first page).
 
@@ -333,7 +333,7 @@ class LogStream(StateManagementMixin):
             # List by project ID
             log_streams = LogStream.list(project_id="project-123")
 
-            # List using GALILEO_PROJECT environment variable
+            # List using SPLUNK_AO_PROJECT environment variable
             log_streams = LogStream.list()
 
             # Cap the number of returned log streams

--- a/src/galileo/log_streams.py
+++ b/src/galileo/log_streams.py
@@ -81,8 +81,8 @@ class LogStream(LogStreamResponse):
     from galileo.schema.metrics import GalileoMetrics
 
     # Set environment variables first
-    # export GALILEO_LOG_STREAM="Production Logs"
-    # export GALILEO_PROJECT="My AI Project"
+    # export SPLUNK_AO_LOG_STREAM="Production Logs"
+    # export SPLUNK_AO_PROJECT="My AI Project"
 
     # Clean and simple - just pass the metrics!
     local_metrics = enable_metrics([
@@ -487,17 +487,17 @@ class LogStreams:
         Enable metrics for a log stream by configuring scorers.
 
         The project name can be provided via the 'project_name' parameter or the
-        GALILEO_PROJECT environment variable.
+        SPLUNK_AO_PROJECT environment variable.
 
         The log stream name can be provided via the 'log_stream_name' parameter or the
-        GALILEO_LOG_STREAM environment variable.
+        SPLUNK_AO_LOG_STREAM environment variable.
 
         Parameters
         ----------
         log_stream_name : Optional[str], optional
-            The name of the log stream. Takes precedence over the GALILEO_LOG_STREAM environment variable. Defaults to None.
+            The name of the log stream. Takes precedence over the SPLUNK_AO_LOG_STREAM environment variable. Defaults to None.
         project_name : Optional[str], optional
-            The name of the project. Takes precedence over the GALILEO_PROJECT environment variable. Defaults to None.
+            The name of the project. Takes precedence over the SPLUNK_AO_PROJECT environment variable. Defaults to None.
         metrics : builtins.list[Union[GalileoMetrics, Metric, LocalMetricConfig, str]]
             List of metrics to enable. Can include:
             - GalileoMetrics enum values (e.g., GalileoMetrics.correctness)
@@ -534,8 +534,8 @@ class LogStreams:
         )
 
         # Enable metrics using environment variables
-        # export GALILEO_LOG_STREAM="Production Logs"
-        # export GALILEO_PROJECT="My AI Project"
+        # export SPLUNK_AO_LOG_STREAM="Production Logs"
+        # export SPLUNK_AO_PROJECT="My AI Project"
         scorer_configs, local_metrics = log_streams.enable_metrics(
             metrics=["correctness", "completeness"]
         )
@@ -546,7 +546,7 @@ class LogStreams:
         def custom_scorer(trace_or_span):
             return 0.85  # Custom scoring logic
 
-        # export GALILEO_PROJECT="My AI Project"
+        # export SPLUNK_AO_PROJECT="My AI Project"
         scorer_configs, local_metrics = log_streams.enable_metrics(
             log_stream_name="Production Logs",  # Explicit log stream
             # project_name from env var
@@ -699,19 +699,19 @@ def enable_metrics(
 
     Environment Variables (Optional Fallbacks)
     ------------------------------------------
-    GALILEO_PROJECT : str
+    SPLUNK_AO_PROJECT : str
         The name of the Galileo project (used when project_name not provided)
-    GALILEO_LOG_STREAM : str
+    SPLUNK_AO_LOG_STREAM : str
         The name of the log stream (used when log_stream_name not provided)
 
     Parameters
     ----------
     log_stream_name : Optional[str], optional
-        The name of the log stream. Takes precedence over GALILEO_LOG_STREAM environment variable.
-        If None, will use GALILEO_LOG_STREAM env var. Defaults to None.
+        The name of the log stream. Takes precedence over SPLUNK_AO_LOG_STREAM environment variable.
+        If None, will use SPLUNK_AO_LOG_STREAM env var. Defaults to None.
     project_name : Optional[str], optional
-        The name of the project. Takes precedence over GALILEO_PROJECT environment variable.
-        If None, will use GALILEO_PROJECT env var. Defaults to None.
+        The name of the project. Takes precedence over SPLUNK_AO_PROJECT environment variable.
+        If None, will use SPLUNK_AO_PROJECT env var. Defaults to None.
     metrics : builtins.list[Union[GalileoMetrics, Metric, LocalMetricConfig, str]]
         List of metrics to enable on the log stream. Can include:
         - GalileoMetrics enum values (e.g., GalileoMetrics.correctness)
@@ -753,8 +753,8 @@ def enable_metrics(
     )
 
     # Enable metrics using environment variables only
-    # export GALILEO_LOG_STREAM="Production Logs"
-    # export GALILEO_PROJECT="My AI Project"
+    # export SPLUNK_AO_LOG_STREAM="Production Logs"
+    # export SPLUNK_AO_PROJECT="My AI Project"
     local_metrics = enable_metrics(metrics=["correctness", "completeness"])
 
     # Enable custom and local metrics with environment variable fallbacks

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -211,11 +211,11 @@ class GalileoLogger(TracesLogger):
         Parameters
         ----------
         project: Optional[str]
-            Project name. If not provided, will use the project_id param or the project name from the environment variable GALILEO_PROJECT.
+            Project name. If not provided, will use the project_id param or the project name from the environment variable SPLUNK_AO_PROJECT.
         project_id: Optional[str]
             Project ID.
         log_stream: Optional[str]
-            Log stream name. If not provided, will use the log_stream_id param or the log stream name from the environment variable GALILEO_LOG_STREAM.
+            Log stream name. If not provided, will use the log_stream_id param or the log stream name from the environment variable SPLUNK_AO_LOG_STREAM.
         log_stream_id: Optional[str]
             Log stream ID.
         experiment_id: Optional[str]
@@ -235,7 +235,7 @@ class GalileoLogger(TracesLogger):
         local_metrics: Optional[list[LocalMetricConfig]]
             Local metrics
         mode: Optional[str]
-            Logger mode: "batch" or "distributed". Defaults to GALILEO_MODE env var, or "batch" if not set.
+            Logger mode: "batch" or "distributed". Defaults to SPLUNK_AO_MODE env var, or "batch" if not set.
             - "batch": Batches traces and sends on flush() (default)
             - "distributed": Enables distributed tracing with immediate updates to backend
         ingestion_hook: Optional[Callable[[TracesIngestRequest], None]]
@@ -396,10 +396,10 @@ class GalileoLogger(TracesLogger):
     def _is_ingest_service_available(cls) -> bool:
         """Check whether the ingest service is reachable, caching the result for the process lifetime.
 
-        The cache is bypassed (and cleared) whenever GALILEO_INGEST_BETA_DISABLED is set so that
+        The cache is bypassed (and cleared) whenever SPLUNK_AO_INGEST_BETA_DISABLED is set so that
         toggling the flag within the same process takes effect immediately.
         """
-        if os.environ.get("GALILEO_INGEST_BETA_DISABLED", "").lower() in ("1", "true", "yes"):
+        if os.environ.get("SPLUNK_AO_INGEST_BETA_DISABLED", "").lower() in ("1", "true", "yes"):
             _ingest_service_cache.clear()
             return False
 
@@ -425,7 +425,7 @@ class GalileoLogger(TracesLogger):
 
         Uses the dedicated Go ingest service (IngestTraces) when available,
         detected by probing {api_url}/ingest/healthz. Falls back to the standard
-        API client if the healthz check fails or if GALILEO_INGEST_BETA_DISABLED is set.
+        API client if the healthz check fails or if SPLUNK_AO_INGEST_BETA_DISABLED is set.
         """
         if not self.project_id:
             self._init_project()
@@ -435,7 +435,7 @@ class GalileoLogger(TracesLogger):
         if self._is_ingest_service_available():
             config = GalileoPythonConfig.get()
             api_key_secret = config.api_key
-            api_key = api_key_secret.get_secret_value() if api_key_secret else os.environ.get("GALILEO_API_KEY", "")
+            api_key = api_key_secret.get_secret_value() if api_key_secret else os.environ.get("SPLUNK_AO_API_KEY", "")
             ingest_url = str(config.api_url)
             if "localhost" in ingest_url:
                 ingest_url = ingest_url.replace("8088", "8081")

--- a/src/galileo/metric.py
+++ b/src/galileo/metric.py
@@ -48,10 +48,10 @@ from galileo_core.schemas.shared.metric import MetricValueType
 logger = logging.getLogger(__name__)
 
 # Code validation polling parameters are configurable via Configuration:
-#   - Configuration.code_validation_timeout (env: GALILEO_CODE_VALIDATION_TIMEOUT) - default: 60.0s
-#   - Configuration.code_validation_initial_delay (env: GALILEO_CODE_VALIDATION_INITIAL_DELAY) - default: 5.0s
-#   - Configuration.code_validation_max_delay (env: GALILEO_CODE_VALIDATION_MAX_DELAY) - default: 30.0s
-#   - Configuration.code_validation_backoff_multiplier (env: GALILEO_CODE_VALIDATION_BACKOFF_MULTIPLIER) - default: 1.5
+#   - Configuration.code_validation_timeout (env: SPLUNK_AO_CODE_VALIDATION_TIMEOUT) - default: 60.0s
+#   - Configuration.code_validation_initial_delay (env: SPLUNK_AO_CODE_VALIDATION_INITIAL_DELAY) - default: 5.0s
+#   - Configuration.code_validation_max_delay (env: SPLUNK_AO_CODE_VALIDATION_MAX_DELAY) - default: 30.0s
+#   - Configuration.code_validation_backoff_multiplier (env: SPLUNK_AO_CODE_VALIDATION_BACKOFF_MULTIPLIER) - default: 1.5
 
 
 class BuiltInMetrics:
@@ -646,8 +646,8 @@ class LlmMetric(Metric):
     Configuration
     -------------
         Default values for `model` and `judges` can be configured via:
-        - Configuration.default_scorer_model (env: GALILEO_DEFAULT_SCORER_MODEL)
-        - Configuration.default_scorer_judges (env: GALILEO_DEFAULT_SCORER_JUDGES)
+        - Configuration.default_scorer_model (env: SPLUNK_AO_DEFAULT_SCORER_MODEL)
+        - Configuration.default_scorer_judges (env: SPLUNK_AO_DEFAULT_SCORER_JUDGES)
 
     Examples
     --------

--- a/src/galileo/middleware/tracing.py
+++ b/src/galileo/middleware/tracing.py
@@ -97,7 +97,7 @@ class TracingMiddleware(BaseHTTPMiddleware):
     The middleware is compatible with FastAPI and any Starlette-based framework.
 
     Note: Project and log_stream are configured per service via environment variables
-    (GALILEO_PROJECT and GALILEO_LOG_STREAM). They are not propagated via headers,
+    (SPLUNK_AO_PROJECT and SPLUNK_AO_LOG_STREAM). They are not propagated via headers,
     following standard distributed tracing patterns.
     """
 
@@ -161,11 +161,11 @@ def get_request_logger() -> GalileoLogger:
     - X-Galileo-Parent-ID: Parent span/trace ID to attach to
 
     Project and log_stream are configured per service via environment variables
-    (GALILEO_PROJECT and GALILEO_LOG_STREAM), not propagated via headers, following
+    (SPLUNK_AO_PROJECT and SPLUNK_AO_LOG_STREAM), not propagated via headers, following
     standard distributed tracing patterns.
 
     If no tracing headers were present in the request, a regular logger is returned
-    (using GALILEO_PROJECT and GALILEO_LOG_STREAM env vars).
+    (using SPLUNK_AO_PROJECT and SPLUNK_AO_LOG_STREAM env vars).
 
     Note: This creates a new logger per request, unlike the decorator's get_logger_instance()
     which uses a singleton pattern.
@@ -220,7 +220,7 @@ def get_request_logger() -> GalileoLogger:
     parent_id = _parent_id_context.get()
 
     # Create logger with trace context
-    # Project and log_stream come from env vars (GALILEO_PROJECT, GALILEO_LOG_STREAM)
+    # Project and log_stream come from env vars (SPLUNK_AO_PROJECT, SPLUNK_AO_LOG_STREAM)
     # If parent_id equals trace_id, it means the parent is the root trace itself,
     # not a span. In this case, we should pass None as span_id to avoid
     # GalileoLoggerException when it tries to look up a span with the trace_id.

--- a/src/galileo/otel.py
+++ b/src/galileo/otel.py
@@ -104,7 +104,7 @@ class GalileoOTLPExporter(OTLPSpanExporter):
         Parameters
         ----------
         project : str, optional
-            Target Galileo project name. Falls back to GALILEO_PROJECT environment variable.
+            Target Galileo project name. Falls back to SPLUNK_AO_PROJECT environment variable.
         logstream : str, optional
             Target logstream for trace organization. Uses default logstream if not specified.
         **kwargs
@@ -223,7 +223,7 @@ class GalileoSpanProcessor(SpanProcessor):
         Parameters
         ----------
         project : str, optional
-            Target Galileo project for trace data. Falls back to GALILEO_PROJECT environment variable.
+            Target Galileo project for trace data. Falls back to SPLUNK_AO_PROJECT environment variable.
         logstream : str, optional
             Target logstream for trace organization. Uses default logstream if not specified.
         SpanProcessor : type, optional

--- a/src/galileo/projects.py
+++ b/src/galileo/projects.py
@@ -166,8 +166,8 @@ class Projects:
 
         At least one of `id` or `name` must be provided (directly or via environment).
         If both are provided, `id` takes precedence and `name` is ignored. If neither is
-        provided, the method will attempt to read from `GALILEO_PROJECT_ID` and
-        `GALILEO_PROJECT`; if both environment variables are set, `GALILEO_PROJECT_ID`
+        provided, the method will attempt to read from `SPLUNK_AO_PROJECT_ID` and
+        `SPLUNK_AO_PROJECT`; if both environment variables are set, `SPLUNK_AO_PROJECT_ID`
         takes precedence.
 
         Parameters

--- a/src/galileo/prompt.py
+++ b/src/galileo/prompt.py
@@ -224,7 +224,7 @@ class Prompt(StateManagementMixin):
             messages (Optional[list[Message]]): The messages for the prompt.
             project_id (Optional[str]): The project ID to associate with this prompt.
             project_name (Optional[str]): The project name to associate with this prompt.
-                If not provided, falls back to GALILEO_PROJECT environment variable.
+                If not provided, falls back to SPLUNK_AO_PROJECT environment variable.
 
         Raises
         ------
@@ -319,7 +319,7 @@ class Prompt(StateManagementMixin):
         Persist this prompt to the API.
 
         If project_id or project_name is set, associates the prompt with that project.
-        If neither is set, falls back to GALILEO_PROJECT_ID or GALILEO_PROJECT env vars.
+        If neither is set, falls back to SPLUNK_AO_PROJECT_ID or SPLUNK_AO_PROJECT env vars.
 
         Returns
         -------
@@ -338,7 +338,7 @@ class Prompt(StateManagementMixin):
         try:
             logger.info(f"Prompt.create: name='{self.name}' - started")
 
-            # Resolve project using explicit params or env fallbacks (GALILEO_PROJECT_ID, GALILEO_PROJECT)
+            # Resolve project using explicit params or env fallbacks (SPLUNK_AO_PROJECT_ID, SPLUNK_AO_PROJECT)
             resolved_project_id: str | None = None
             has_explicit_project = self.project_id is not None or self.project_name is not None
             has_project_context = (

--- a/src/galileo/shared/exceptions.py
+++ b/src/galileo/shared/exceptions.py
@@ -122,8 +122,8 @@ def _resolve_project_identifiers(project_id: str | None, project_name: str | Non
     """Apply env-fallback precedence to produce a normalized ``(id, name)`` tuple.
 
     Matches the precedence documented by :meth:`galileo.projects.Projects.get_with_env_fallbacks`
-    exactly: explicit ``project_id`` > explicit ``project_name`` > ``GALILEO_PROJECT_ID``
-    > ``GALILEO_PROJECT``. Once an id is chosen, name is dropped; once a name is chosen,
+    exactly: explicit ``project_id`` > explicit ``project_name`` > ``SPLUNK_AO_PROJECT_ID``
+    > ``SPLUNK_AO_PROJECT``. Once an id is chosen, name is dropped; once a name is chosen,
     env-id is *not* consulted (an explicit name suppresses env-id fallback).
 
     Whitespace-only values (explicit kwargs or env vars) are treated as missing, so
@@ -175,5 +175,5 @@ def _project_not_found_error(project_id: str | None, project_name: str | None) -
             "Use Project(name=...).create() or the Galileo UI to create a project first."
         )
     return ResourceNotFoundError(
-        "No project specified. Provide project_id, project_name, or set GALILEO_PROJECT env var."
+        "No project specified. Provide project_id, project_name, or set SPLUNK_AO_PROJECT env var."
     )

--- a/src/galileo/utils/decorators/telemetry_toggle.py
+++ b/src/galileo/utils/decorators/telemetry_toggle.py
@@ -1,7 +1,7 @@
 """
 Decorators for conditionally enabling/disabling Galileo telemetry.
 
-These decorators check the GALILEO_LOGGING_DISABLED environment variable
+These decorators check the SPLUNK_AO_LOGGING_DISABLED environment variable
 and skip execution of telemetry operations when disabled.
 """
 
@@ -21,16 +21,16 @@ def galileo_logging_enabled() -> bool:
     Returns
     -------
     bool
-        True if logging is enabled (default), False if GALILEO_LOGGING_DISABLED is set.
+        True if logging is enabled (default), False if SPLUNK_AO_LOGGING_DISABLED is set.
     """
-    return os.getenv("GALILEO_LOGGING_DISABLED", "false").lower() not in ("true", "1", "t")
+    return os.getenv("SPLUNK_AO_LOGGING_DISABLED", "false").lower() not in ("true", "1", "t")
 
 
 def nop_sync(f: Callable) -> Callable:
     """
     Decorator that skips execution of sync functions when Galileo logging is disabled.
 
-    When GALILEO_LOGGING_DISABLED is set to "true", "1", or "t", the decorated
+    When SPLUNK_AO_LOGGING_DISABLED is set to "true", "1", or "t", the decorated
     function will not execute and will return None instead.
 
     Parameters
@@ -58,7 +58,7 @@ def nop_async(f: Callable) -> Callable:
     """
     Decorator that skips execution of async functions when Galileo logging is disabled.
 
-    When GALILEO_LOGGING_DISABLED is set to "true", "1", or "t", the decorated
+    When SPLUNK_AO_LOGGING_DISABLED is set to "true", "1", or "t", the decorated
     function will not execute and will return None instead.
 
     Parameters

--- a/src/galileo/utils/env_helpers.py
+++ b/src/galileo/utils/env_helpers.py
@@ -24,7 +24,7 @@ def _get_mode_or_default(mode: str | None) -> LoggerModeType:
         - "distributed": Enables distributed tracing with immediate updates
     """
     if mode is None:
-        mode = getenv("GALILEO_MODE", DEFAULT_MODE)
+        mode = getenv("SPLUNK_AO_MODE", DEFAULT_MODE)
 
     if not isinstance(mode, str):
         raise GalileoLoggerException(f"Invalid mode: {mode}. Mode must be 'batch' or 'distributed'.")
@@ -38,7 +38,7 @@ def _get_mode_or_default(mode: str | None) -> LoggerModeType:
 
 def _get_project_or_default(project: str | None) -> str:
     """
-    Get the project name, falling back to GALILEO_PROJECT env var or default.
+    Get the project name, falling back to SPLUNK_AO_PROJECT env var or default.
 
     Parameters
     ----------
@@ -51,13 +51,13 @@ def _get_project_or_default(project: str | None) -> str:
         The project name to use.
     """
     if project is None:
-        return getenv("GALILEO_PROJECT", DEFAULT_PROJECT_NAME)
+        return getenv("SPLUNK_AO_PROJECT", DEFAULT_PROJECT_NAME)
     return project
 
 
 def _get_log_stream_or_default(log_stream: str | None) -> str:
     """
-    Get the log stream name, falling back to GALILEO_LOG_STREAM env var or default.
+    Get the log stream name, falling back to SPLUNK_AO_LOG_STREAM env var or default.
 
     Parameters
     ----------
@@ -70,53 +70,53 @@ def _get_log_stream_or_default(log_stream: str | None) -> str:
         The log stream name to use.
     """
     if log_stream is None:
-        return getenv("GALILEO_LOG_STREAM", DEFAULT_LOG_STREAM_NAME)
+        return getenv("SPLUNK_AO_LOG_STREAM", DEFAULT_LOG_STREAM_NAME)
     return log_stream
 
 
 def _get_project_from_env() -> str | None:
     """
-    Get the project name from GALILEO_PROJECT environment variable.
+    Get the project name from SPLUNK_AO_PROJECT environment variable.
 
     Returns
     -------
     Optional[str]
         The project name from environment variable, or None if not set.
     """
-    return getenv("GALILEO_PROJECT")
+    return getenv("SPLUNK_AO_PROJECT")
 
 
 def _get_project_id_from_env() -> str | None:
     """
-    Get the project ID from GALILEO_PROJECT_ID environment variable.
+    Get the project ID from SPLUNK_AO_PROJECT_ID environment variable.
 
     Returns
     -------
     Optional[str]
         The project ID from environment variable, or None if not set.
     """
-    return getenv("GALILEO_PROJECT_ID")
+    return getenv("SPLUNK_AO_PROJECT_ID")
 
 
 def _get_log_stream_from_env() -> str | None:
     """
-    Get the log stream name from GALILEO_LOG_STREAM environment variable.
+    Get the log stream name from SPLUNK_AO_LOG_STREAM environment variable.
 
     Returns
     -------
     Optional[str]
         The log stream name from environment variable, or None if not set.
     """
-    return getenv("GALILEO_LOG_STREAM")
+    return getenv("SPLUNK_AO_LOG_STREAM")
 
 
 def _get_log_stream_id_from_env() -> str | None:
     """
-    Get the log stream ID from GALILEO_LOG_STREAM_ID environment variable.
+    Get the log stream ID from SPLUNK_AO_LOG_STREAM_ID environment variable.
 
     Returns
     -------
     Optional[str]
         The log stream ID from environment variable, or None if not set.
     """
-    return getenv("GALILEO_LOG_STREAM_ID")
+    return getenv("SPLUNK_AO_LOG_STREAM_ID")

--- a/src/galileo/utils/singleton.py
+++ b/src/galileo/utils/singleton.py
@@ -18,7 +18,7 @@ class GalileoLoggerSingleton:
     provides a thread-safe way to retrieve or create GalileoLogger clients based on
     the given 'project' and 'log_stream' parameters. If the parameters are not provided,
     the class attempts to read the values from the environment variables
-    GALILEO_PROJECT and GALILEO_LOG_STREAM. The loggers are stored in a dictionary
+    SPLUNK_AO_PROJECT and SPLUNK_AO_LOG_STREAM. The loggers are stored in a dictionary
     using a tuple (project, log_stream) as the key.
     """
 
@@ -57,7 +57,7 @@ class GalileoLoggerSingleton:
         Generate a key tuple based on project, log_stream, and tracing parameters.
 
         If project or log_stream are None, the method attempts to retrieve them
-        from environment variables (GALILEO_PROJECT and GALILEO_LOG_STREAM). If still
+        from environment variables (SPLUNK_AO_PROJECT and SPLUNK_AO_LOG_STREAM). If still
         None, defaults to "default".
 
         Parameters
@@ -204,7 +204,7 @@ class GalileoLoggerSingleton:
         experiment_id (Optional[str], optional)
             The experiment ID. Defaults to None.
         mode (Optional[str], optional)
-            The logger mode. Defaults to GALILEO_MODE env var, or "batch" if not set.
+            The logger mode. Defaults to SPLUNK_AO_MODE env var, or "batch" if not set.
         """
         mode = _get_mode_or_default(mode)
 
@@ -248,7 +248,7 @@ class GalileoLoggerSingleton:
         experiment_id (Optional[str], optional)
             The experiment ID. Defaults to None.
         mode (Optional[str], optional)
-            The logger mode. Defaults to GALILEO_MODE env var, or "batch" if not set.
+            The logger mode. Defaults to SPLUNK_AO_MODE env var, or "batch" if not set.
         """
         mode = _get_mode_or_default(mode)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,10 +22,10 @@ from openai.types.responses import (
 )
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
-_os.environ["GALILEO_CONSOLE_URL"] = "http://localtest:8088"
-_os.environ["GALILEO_API_KEY"] = "api-1234567890"
-_os.environ["GALILEO_PROJECT"] = "test-project"
-_os.environ["GALILEO_LOG_STREAM"] = "test-log-stream"
+_os.environ["SPLUNK_AO_CONSOLE_URL"] = "http://localtest:8088"
+_os.environ["SPLUNK_AO_API_KEY"] = "api-1234567890"
+_os.environ["SPLUNK_AO_PROJECT"] = "test-project"
+_os.environ["SPLUNK_AO_LOG_STREAM"] = "test-log-stream"
 _os.environ["OPENAI_API_KEY"] = "sk-test"
 del _os  # Clean up temporary import
 # fmt: on

--- a/tests/shared/test_project_resolver.py
+++ b/tests/shared/test_project_resolver.py
@@ -42,8 +42,8 @@ class TestResolveProject:
     ) -> None:
         """No id, no name, no env vars must raise without touching the API client."""
         # Given: env vars are unset
-        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
-        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT_ID", raising=False)
 
         # When/Then: resolving raises NotFoundError without instantiating Projects
         with pytest.raises(NotFoundError, match="No project specified"):
@@ -56,8 +56,8 @@ class TestResolveProject:
     ) -> None:
         """Backward-compat: the raised error is also a ResourceNotFoundError."""
         # Given: no identifier anywhere
-        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
-        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT_ID", raising=False)
 
         # When/Then: the raised exception is BOTH a NotFoundError and a ResourceNotFoundError
         with pytest.raises(NotFoundError) as exc_info:
@@ -109,8 +109,8 @@ class TestResolveProject:
         whitespace up-front so the user gets the documented ``NotFoundError`` instead.
         """
         # Given: env vars unset; explicit kwargs are whitespace-only
-        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
-        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT_ID", raising=False)
 
         # When/Then: resolver short-circuits without instantiating Projects
         with pytest.raises(NotFoundError, match="No project specified"):
@@ -123,13 +123,13 @@ class TestResolveProject:
     ) -> None:
         """Whitespace-only env vars must also be treated as missing.
 
-        Without normalization, ``GALILEO_PROJECT="  "`` would pass the truthy
+        Without normalization, ``SPLUNK_AO_PROJECT="  "`` would pass the truthy
         pre-check, hit ``Projects().get_with_env_fallbacks``, and leak a raw
         ``ValueError`` after the API client strips it.
         """
-        # Given: GALILEO_PROJECT is set but only contains whitespace
-        monkeypatch.setenv("GALILEO_PROJECT", "   ")
-        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+        # Given: SPLUNK_AO_PROJECT is set but only contains whitespace
+        monkeypatch.setenv("SPLUNK_AO_PROJECT", "   ")
+        monkeypatch.delenv("SPLUNK_AO_PROJECT_ID", raising=False)
 
         # When/Then: resolver short-circuits with NotFoundError
         with pytest.raises(NotFoundError, match="No project specified"):
@@ -158,14 +158,14 @@ class TestResolveProject:
     def test_explicit_name_suppresses_env_id_fallback(
         self, mock_projects_class: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Explicit ``project_name`` must beat ``GALILEO_PROJECT_ID``.
+        """Explicit ``project_name`` must beat ``SPLUNK_AO_PROJECT_ID``.
 
         ``Projects.get_with_env_fallbacks`` documents that an explicit name suppresses
         the env-id fallback (``id = id or (None if name else env_id)``). The resolver
         must match this precedence so it doesn't silently look up the wrong project.
         """
-        # Given: GALILEO_PROJECT_ID is set, but the caller passed an explicit name
-        monkeypatch.setenv("GALILEO_PROJECT_ID", "env-id-should-be-ignored")
+        # Given: SPLUNK_AO_PROJECT_ID is set, but the caller passed an explicit name
+        monkeypatch.setenv("SPLUNK_AO_PROJECT_ID", "env-id-should-be-ignored")
         mock_project = MagicMock()
         mock_project.id = "name-resolved-id"
         mock_project.name = "Explicit Name"

--- a/tests/test_agent_control.py
+++ b/tests/test_agent_control.py
@@ -13,10 +13,10 @@ from galileo.utils.singleton import GalileoLoggerSingleton
 @pytest.fixture(autouse=True)
 def reset_agent_control_helper_state(monkeypatch):
     # Given: no log stream ID environment override or cached logger state
-    monkeypatch.delenv("GALILEO_PROJECT", raising=False)
-    monkeypatch.delenv("GALILEO_LOG_STREAM", raising=False)
-    monkeypatch.delenv("GALILEO_LOG_STREAM_ID", raising=False)
-    monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+    monkeypatch.delenv("SPLUNK_AO_PROJECT", raising=False)
+    monkeypatch.delenv("SPLUNK_AO_LOG_STREAM", raising=False)
+    monkeypatch.delenv("SPLUNK_AO_LOG_STREAM_ID", raising=False)
+    monkeypatch.delenv("SPLUNK_AO_PROJECT_ID", raising=False)
     GalileoLoggerSingleton().reset_all()
     monkeypatch.setattr(GalileoLoggerSingleton, "get_all_loggers", lambda self: {})
     monkeypatch.setattr(
@@ -55,7 +55,7 @@ def test_get_agent_control_target_uses_env_project_id_with_explicit_log_stream_i
     # Given: an explicit Galileo log stream ID and project ID from the environment
     log_stream_id = str(uuid4())
     project_id = str(uuid4())
-    monkeypatch.setenv("GALILEO_PROJECT_ID", project_id)
+    monkeypatch.setenv("SPLUNK_AO_PROJECT_ID", project_id)
 
     # When: resolving an Agent Control target
     target = get_agent_control_target(log_stream_id=log_stream_id)
@@ -79,8 +79,8 @@ def test_get_agent_control_target_uses_env_log_stream_id(monkeypatch) -> None:
     # Given: a Galileo log stream ID in the environment
     log_stream_id = str(uuid4())
     project_id = str(uuid4())
-    monkeypatch.setenv("GALILEO_LOG_STREAM_ID", log_stream_id)
-    monkeypatch.setenv("GALILEO_PROJECT_ID", project_id)
+    monkeypatch.setenv("SPLUNK_AO_LOG_STREAM_ID", log_stream_id)
+    monkeypatch.setenv("SPLUNK_AO_PROJECT_ID", project_id)
 
     # When: resolving an Agent Control target
     target = get_agent_control_target()
@@ -93,8 +93,8 @@ def test_get_agent_control_target_strips_env_ids(monkeypatch) -> None:
     # Given: Galileo ID environment values with accidental surrounding whitespace
     log_stream_id = str(uuid4())
     project_id = str(uuid4())
-    monkeypatch.setenv("GALILEO_LOG_STREAM_ID", f"  {log_stream_id}  ")
-    monkeypatch.setenv("GALILEO_PROJECT_ID", f"  {project_id}  ")
+    monkeypatch.setenv("SPLUNK_AO_LOG_STREAM_ID", f"  {log_stream_id}  ")
+    monkeypatch.setenv("SPLUNK_AO_PROJECT_ID", f"  {project_id}  ")
 
     # When: resolving an Agent Control target
     target = get_agent_control_target()
@@ -159,8 +159,8 @@ def test_get_agent_control_target_uses_cached_env_default_logger(monkeypatch) ->
     # Given: Galileo initialized a logger using environment-provided default names
     project_id = str(uuid4())
     log_stream_id = str(uuid4())
-    monkeypatch.setenv("GALILEO_PROJECT", "project-env")
-    monkeypatch.setenv("GALILEO_LOG_STREAM", "stream-env")
+    monkeypatch.setenv("SPLUNK_AO_PROJECT", "project-env")
+    monkeypatch.setenv("SPLUNK_AO_LOG_STREAM", "stream-env")
     logger = SimpleNamespace(
         project_name="project-env",
         log_stream_name="stream-env",
@@ -200,7 +200,7 @@ def test_get_agent_control_target_prefers_cached_logger_project_id_over_env(monk
     cached_project_id = str(uuid4())
     env_project_id = str(uuid4())
     log_stream_id = str(uuid4())
-    monkeypatch.setenv("GALILEO_PROJECT_ID", env_project_id)
+    monkeypatch.setenv("SPLUNK_AO_PROJECT_ID", env_project_id)
     logger = SimpleNamespace(
         project_name=DEFAULT_PROJECT_NAME,
         log_stream_name=DEFAULT_LOG_STREAM_NAME,
@@ -242,10 +242,10 @@ def test_get_agent_control_target_uses_explicit_project_id_with_cached_logger(mo
 
 def test_get_agent_control_target_rejects_invalid_log_stream_id(monkeypatch) -> None:
     # Given: an invalid Galileo log stream ID in the environment
-    monkeypatch.setenv("GALILEO_LOG_STREAM_ID", "prod")
+    monkeypatch.setenv("SPLUNK_AO_LOG_STREAM_ID", "prod")
 
     # When/Then: resolving the target fails before sending a malformed target to Agent Control
-    with pytest.raises(AgentControlTargetUnresolvedError, match="GALILEO_LOG_STREAM_ID='prod' is not a valid UUID"):
+    with pytest.raises(AgentControlTargetUnresolvedError, match="SPLUNK_AO_LOG_STREAM_ID='prod' is not a valid UUID"):
         get_agent_control_target()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,12 +7,12 @@ from galileo.shared.exceptions import ConfigurationError
 
 # Auth env vars cleared in tests that exercise the missing-auth guard.
 _AUTH_ENV_VARS = (
-    "GALILEO_API_KEY",
-    "GALILEO_SSO_ID_TOKEN",
-    "GALILEO_SSO_PROVIDER",
-    "GALILEO_USERNAME",
-    "GALILEO_PASSWORD",
-    "GALILEO_JWT_TOKEN",
+    "SPLUNK_AO_API_KEY",
+    "SPLUNK_AO_SSO_ID_TOKEN",
+    "SPLUNK_AO_SSO_PROVIDER",
+    "SPLUNK_AO_USERNAME",
+    "SPLUNK_AO_PASSWORD",
+    "SPLUNK_AO_JWT_TOKEN",
 )
 
 
@@ -26,7 +26,7 @@ def _clear_auth_env(monkeypatch) -> None:
 @patch("galileo_core.schemas.base_config.GalileoConfig.get_jwt_token")
 def test_default_console_url(mock_get_jwt_token) -> None:
     """
-    Test that the default console_url is used when GALILEO_CONSOLE_URL is not set.
+    Test that the default console_url is used when SPLUNK_AO_CONSOLE_URL is not set.
     """
     mock_get_jwt_token.return_value = ("mock_jwt_token", "mock_refresh_token")
 
@@ -51,23 +51,23 @@ def test_no_auth_configured_raises_with_full_options_listed(monkeypatch) -> None
     with pytest.raises(ConfigurationError) as exc_info:
         GalileoPythonConfig.get()
     message = str(exc_info.value)
-    assert "No Galileo authentication detected" in message
-    assert "GALILEO_API_KEY" in message
-    assert "GALILEO_SSO_ID_TOKEN" in message
-    assert "GALILEO_SSO_PROVIDER" in message
-    assert "GALILEO_USERNAME" in message
-    assert "GALILEO_PASSWORD" in message
+    assert "No Splunk AO authentication detected" in message
+    assert "SPLUNK_AO_API_KEY" in message
+    assert "SPLUNK_AO_SSO_ID_TOKEN" in message
+    assert "SPLUNK_AO_SSO_PROVIDER" in message
+    assert "SPLUNK_AO_USERNAME" in message
+    assert "SPLUNK_AO_PASSWORD" in message
 
 
 @pytest.mark.parametrize(
     "env_setup",
     [
         # Standalone methods.
-        {"GALILEO_API_KEY": "test-api-key"},
-        {"GALILEO_JWT_TOKEN": "test-jwt"},
+        {"SPLUNK_AO_API_KEY": "test-api-key"},
+        {"SPLUNK_AO_JWT_TOKEN": "test-jwt"},
         # Paired methods — both halves required.
-        {"GALILEO_SSO_ID_TOKEN": "test-sso-token", "GALILEO_SSO_PROVIDER": "okta"},
-        {"GALILEO_USERNAME": "test-user", "GALILEO_PASSWORD": "test-pass"},
+        {"SPLUNK_AO_SSO_ID_TOKEN": "test-sso-token", "SPLUNK_AO_SSO_PROVIDER": "okta"},
+        {"SPLUNK_AO_USERNAME": "test-user", "SPLUNK_AO_PASSWORD": "test-pass"},
     ],
     ids=["api_key", "jwt_token", "sso_id_token_and_provider", "username_and_password"],
 )
@@ -112,7 +112,7 @@ def test_kwargs_and_env_can_be_mixed(monkeypatch) -> None:
     # Given: sso_id_token in env, sso_provider in kwargs, no cached instance,
     # and _get stubbed out so downstream network calls never happen
     _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("GALILEO_SSO_ID_TOKEN", "test-sso-token")
+    monkeypatch.setenv("SPLUNK_AO_SSO_ID_TOKEN", "test-sso-token")
     monkeypatch.setattr(GalileoPythonConfig, "_instance", None)
     monkeypatch.setattr(GalileoPythonConfig, "_get", lambda *a, **kw: MagicMock(spec=GalileoPythonConfig))
 
@@ -123,10 +123,10 @@ def test_kwargs_and_env_can_be_mixed(monkeypatch) -> None:
 @pytest.mark.parametrize(
     "env_setup,expected_missing,expected_present",
     [
-        ({"GALILEO_SSO_ID_TOKEN": "test-token"}, "GALILEO_SSO_PROVIDER", "GALILEO_SSO_ID_TOKEN"),
-        ({"GALILEO_SSO_PROVIDER": "okta"}, "GALILEO_SSO_ID_TOKEN", "GALILEO_SSO_PROVIDER"),
-        ({"GALILEO_USERNAME": "test-user"}, "GALILEO_PASSWORD", "GALILEO_USERNAME"),
-        ({"GALILEO_PASSWORD": "test-pass"}, "GALILEO_USERNAME", "GALILEO_PASSWORD"),
+        ({"SPLUNK_AO_SSO_ID_TOKEN": "test-token"}, "SPLUNK_AO_SSO_PROVIDER", "SPLUNK_AO_SSO_ID_TOKEN"),
+        ({"SPLUNK_AO_SSO_PROVIDER": "okta"}, "SPLUNK_AO_SSO_ID_TOKEN", "SPLUNK_AO_SSO_PROVIDER"),
+        ({"SPLUNK_AO_USERNAME": "test-user"}, "SPLUNK_AO_PASSWORD", "SPLUNK_AO_USERNAME"),
+        ({"SPLUNK_AO_PASSWORD": "test-pass"}, "SPLUNK_AO_USERNAME", "SPLUNK_AO_PASSWORD"),
     ],
     ids=[
         "sso_id_token_without_provider",

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -171,8 +171,8 @@ class TestConfigurationEnvFileLoading:
         """Test that .env file is loaded and environment variables are set correctly."""
         # Create .env file with test values
         mock_env_file.write_text(
-            'GALILEO_API_KEY="env-file-key"\n'
-            'GALILEO_CONSOLE_URL="https://envfile.galileo.ai"\n'
+            'SPLUNK_AO_API_KEY="env-file-key"\n'
+            'SPLUNK_AO_CONSOLE_URL="https://envfile.galileo.ai"\n'
             'OPENAI_API_KEY="env-file-openai"\n'
         )
 
@@ -189,10 +189,10 @@ class TestConfigurationEnvFileLoading:
     ) -> None:
         """Test that .env file does not override existing environment variables."""
         # Set existing environment variable
-        monkeypatch.setenv("GALILEO_API_KEY", "existing-env-key")
+        monkeypatch.setenv("SPLUNK_AO_API_KEY", "existing-env-key")
 
         # Create .env file with different value
-        mock_env_file.write_text('GALILEO_API_KEY="env-file-key"\n')
+        mock_env_file.write_text('SPLUNK_AO_API_KEY="env-file-key"\n')
 
         # Access property to trigger env file loading
         api_key = Configuration.galileo_api_key
@@ -207,8 +207,8 @@ class TestConfigurationEnvFileLoading:
         mock_env_file.write_text(
             "# This is a comment\n"
             "\n"
-            "GALILEO_API_KEY=key-without-quotes\n"
-            'GALILEO_CONSOLE_URL="url-with-double-quotes"\n'
+            "SPLUNK_AO_API_KEY=key-without-quotes\n"
+            'SPLUNK_AO_CONSOLE_URL="url-with-double-quotes"\n'
             "OPENAI_API_KEY='key-with-single-quotes'\n"
             "  \n"
             "# Another comment\n"
@@ -226,7 +226,7 @@ class TestConfigurationEnvFileLoading:
         self, mock_env_file: Path, clean_env: None, reset_configuration: None
     ) -> None:
         """Test that env file is only loaded once even with multiple property accesses."""
-        mock_env_file.write_text('GALILEO_API_KEY="test-key"\n')
+        mock_env_file.write_text('SPLUNK_AO_API_KEY="test-key"\n')
 
         # Access multiple times
         _ = Configuration.galileo_api_key
@@ -270,8 +270,8 @@ class TestConfigurationConnect:
         _, log_stream = capture_logs
 
         # Set valid configuration
-        monkeypatch.setenv("GALILEO_API_KEY", "valid-key")
-        monkeypatch.setenv("GALILEO_CONSOLE_URL", "https://app.galileo.ai")
+        monkeypatch.setenv("SPLUNK_AO_API_KEY", "valid-key")
+        monkeypatch.setenv("SPLUNK_AO_CONSOLE_URL", "https://app.galileo.ai")
 
         # Connect should succeed without raising
         Configuration.connect()
@@ -292,7 +292,7 @@ class TestConfigurationConnect:
         _, log_stream = capture_logs
 
         # Set valid configuration
-        monkeypatch.setenv("GALILEO_API_KEY", "valid-key")
+        monkeypatch.setenv("SPLUNK_AO_API_KEY", "valid-key")
 
         # Connect should succeed without raising
         Configuration.connect()
@@ -316,14 +316,14 @@ class TestConfigurationConnect:
         _, log_stream = capture_logs
 
         # Set only console URL
-        monkeypatch.setenv("GALILEO_CONSOLE_URL", "https://app.galileo.ai")
+        monkeypatch.setenv("SPLUNK_AO_CONSOLE_URL", "https://app.galileo.ai")
 
         # Should raise ConfigurationError
         with pytest.raises(ConfigurationError) as exc_info:
             Configuration.connect()
 
         # Verify error message provides helpful guidance
-        assert "galileo api key is required" in str(exc_info.value).lower()
+        assert "splunk ao api key is required" in str(exc_info.value).lower()
         assert "Configuration.galileo_api_key" in str(exc_info.value)
 
     @pytest.mark.parametrize(
@@ -350,8 +350,8 @@ class TestConfigurationConnect:
         _, log_stream = capture_logs
 
         # Set valid configuration
-        monkeypatch.setenv("GALILEO_API_KEY", "valid-key")
-        monkeypatch.setenv("GALILEO_CONSOLE_URL", "https://app.galileo.ai")
+        monkeypatch.setenv("SPLUNK_AO_API_KEY", "valid-key")
+        monkeypatch.setenv("SPLUNK_AO_CONSOLE_URL", "https://app.galileo.ai")
 
         # Mock GalileoPythonConfig.get to raise appropriate error
         mock_config_get.side_effect = Exception(error_message)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1336,11 +1336,11 @@ def test_mode_flush_different_mode_no_reset(
 @patch("galileo.logger.logger.LogStreams")
 @patch("galileo.logger.logger.Projects")
 @patch("galileo.logger.logger.Traces")
-@patch.dict("os.environ", {"GALILEO_MODE": "distributed"})
+@patch.dict("os.environ", {"SPLUNK_AO_MODE": "distributed"})
 def test_mode_from_environment_variable(
     mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
 ) -> None:
-    """Test that mode is read from GALILEO_MODE environment variable."""
+    """Test that mode is read from SPLUNK_AO_MODE environment variable."""
     setup_mock_traces_client(mock_traces_client)
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
@@ -1354,7 +1354,7 @@ def test_mode_from_environment_variable(
 @patch("galileo.logger.logger.LogStreams")
 @patch("galileo.logger.logger.Projects")
 @patch("galileo.logger.logger.Traces")
-@patch.dict("os.environ", {"GALILEO_MODE": "distributed"})
+@patch.dict("os.environ", {"SPLUNK_AO_MODE": "distributed"})
 def test_mode_explicit_overrides_environment(
     mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
 ) -> None:

--- a/tests/test_decorator_distributed.py
+++ b/tests/test_decorator_distributed.py
@@ -32,14 +32,14 @@ def reset_context():
 
 @pytest.fixture
 def set_distributed_mode():
-    """Set GALILEO_MODE to distributed for tests."""
-    original = os.getenv("GALILEO_MODE")
-    os.environ["GALILEO_MODE"] = "distributed"
+    """Set SPLUNK_AO_MODE to distributed for tests."""
+    original = os.getenv("SPLUNK_AO_MODE")
+    os.environ["SPLUNK_AO_MODE"] = "distributed"
     yield
     if original is None:
-        os.environ.pop("GALILEO_MODE", None)
+        os.environ.pop("SPLUNK_AO_MODE", None)
     else:
-        os.environ["GALILEO_MODE"] = original
+        os.environ["SPLUNK_AO_MODE"] = original
 
 
 @patch("galileo.logger.logger.LogStreams")

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -219,8 +219,8 @@ class TestExperimentEnvFallback:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test create() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
-        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
+        # Given: SPLUNK_AO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("SPLUNK_AO_PROJECT", "Env Project")
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = mock_project
@@ -269,7 +269,7 @@ class TestExperimentEnvFallback:
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
         """Test create() raises ResourceNotFoundError naming the project that wasn't found."""
-        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
+        # Given: env fallback returns None (project from SPLUNK_AO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
@@ -332,8 +332,8 @@ class TestExperimentEnvFallback:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test get() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
-        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
+        # Given: SPLUNK_AO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("SPLUNK_AO_PROJECT", "Env Project")
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = mock_project
@@ -354,7 +354,7 @@ class TestExperimentEnvFallback:
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
         """Test get() raises ResourceNotFoundError naming the project that wasn't found."""
-        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
+        # Given: env fallback returns None (project from SPLUNK_AO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
@@ -374,8 +374,8 @@ class TestExperimentEnvFallback:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test list() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
-        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
+        # Given: SPLUNK_AO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("SPLUNK_AO_PROJECT", "Env Project")
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = mock_project
@@ -396,7 +396,7 @@ class TestExperimentEnvFallback:
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
         """Test list() raises ResourceNotFoundError naming the project that wasn't found."""
-        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
+        # Given: env fallback returns None (project from SPLUNK_AO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
@@ -418,8 +418,8 @@ class TestExperimentEnvFallback:
         documented ``NotFoundError``. The shared ``_resolve_project`` fixes this.
         """
         # Given: env vars are unset
-        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
-        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT_ID", raising=False)
 
         # When/Then: NotFoundError is raised without instantiating Projects or leaking ValueError
         with pytest.raises(ResourceNotFoundError, match="No project specified"):

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -57,8 +57,8 @@ from tests.testutils.setup import setup_mock_logstreams_client, setup_mock_proje
 @pytest.fixture
 def reset_context(auto_use=True) -> None:
     galileo_context.reset()
-    os.environ.pop("GALILEO_PROJECT", None)
-    os.environ.pop("GALILEO_PROJECT_ID", None)
+    os.environ.pop("SPLUNK_AO_PROJECT", None)
+    os.environ.pop("SPLUNK_AO_PROJECT_ID", None)
 
 
 def project():

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -1302,7 +1302,7 @@ class TestGalileoCallbackIngestionHookWithoutCredentials:
     """SC-54690: GalileoCallback/GalileoAsyncCallback with ingestion_hook should work without API credentials.
 
     When a user provides an ingestion_hook, the handler should not require Galileo API configuration
-    (GALILEO_API_KEY, etc.) because the hook bypasses the API entirely. This test verifies the fix
+    (SPLUNK_AO_API_KEY, etc.) because the hook bypasses the API entirely. This test verifies the fix
     without mocking Projects/LogStreams/Traces, so the real code path is exercised.
     """
 
@@ -1310,10 +1310,10 @@ class TestGalileoCallbackIngestionHookWithoutCredentials:
     def clear_galileo_config(self, monkeypatch):
         """Remove Galileo credentials and reset config to simulate no-API-key scenario."""
         # Given: no Galileo API credentials are configured
-        monkeypatch.delenv("GALILEO_API_KEY", raising=False)
-        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
-        monkeypatch.delenv("GALILEO_LOG_STREAM", raising=False)
-        monkeypatch.setenv("GALILEO_CONSOLE_URL", "https://console.galileo.ai/")
+        monkeypatch.delenv("SPLUNK_AO_API_KEY", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_LOG_STREAM", raising=False)
+        monkeypatch.setenv("SPLUNK_AO_CONSOLE_URL", "https://console.galileo.ai/")
 
         if GalileoPythonConfig._instance is not None:
             GalileoPythonConfig._instance.reset()

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -176,7 +176,7 @@ class TestLogStreamCreate:
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
         """Test create() raises NotFoundError naming the project that wasn't found."""
-        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
+        # Given: env fallback returns None (project from SPLUNK_AO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
@@ -287,7 +287,7 @@ class TestLogStreamGet:
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
         """Test get() raises NotFoundError naming the project that wasn't found."""
-        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
+        # Given: env fallback returns None (project from SPLUNK_AO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
@@ -335,8 +335,8 @@ class TestLogStreamGet:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test get() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
-        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
+        # Given: SPLUNK_AO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("SPLUNK_AO_PROJECT", "Env Project")
         mock_project = MagicMock()
         mock_project.id = "env-project-id"
         mock_project.name = "Env Project"
@@ -439,7 +439,7 @@ class TestLogStreamList:
         self, mock_projects_class: MagicMock, reset_configuration: None
     ) -> None:
         """Test list() raises NotFoundError naming the project that wasn't found."""
-        # Given: env fallback returns None (project from GALILEO_PROJECT env var not found on server)
+        # Given: env fallback returns None (project from SPLUNK_AO_PROJECT env var not found on server)
         mock_projects_service = MagicMock()
         mock_projects_class.return_value = mock_projects_service
         mock_projects_service.get_with_env_fallbacks.return_value = None
@@ -534,8 +534,8 @@ class TestLogStreamList:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test list() uses Projects().get_with_env_fallbacks() when no project is specified."""
-        # Given: GALILEO_PROJECT is set so the resolver delegates to the API
-        monkeypatch.setenv("GALILEO_PROJECT", "Env Project")
+        # Given: SPLUNK_AO_PROJECT is set so the resolver delegates to the API
+        monkeypatch.setenv("SPLUNK_AO_PROJECT", "Env Project")
         mock_project = MagicMock()
         mock_project.id = "env-project-id"
         mock_project.name = "Env Project"
@@ -1114,8 +1114,8 @@ class TestProjectNotFoundErrorBackwardCompat:
         call and raise ``NotFoundError`` directly.
         """
         # Given: env vars are unset and Projects() shouldn't be touched
-        monkeypatch.delenv("GALILEO_PROJECT", raising=False)
-        monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT", raising=False)
+        monkeypatch.delenv("SPLUNK_AO_PROJECT_ID", raising=False)
 
         log_stream = LogStream._create_empty()
         log_stream.name = "Test Stream"

--- a/tests/test_log_streams_metrics.py
+++ b/tests/test_log_streams_metrics.py
@@ -17,7 +17,7 @@ def reset_env_vars():
     """Reset environment variables before each test and restore after."""
     saved = {
         k: os.environ.pop(k, None)
-        for k in ("GALILEO_PROJECT", "GALILEO_PROJECT_ID", "GALILEO_LOG_STREAM", "GALILEO_LOG_STREAM_ID")
+        for k in ("SPLUNK_AO_PROJECT", "SPLUNK_AO_PROJECT_ID", "SPLUNK_AO_LOG_STREAM", "SPLUNK_AO_LOG_STREAM_ID")
     }
     yield
     for k, v in saved.items():
@@ -240,8 +240,8 @@ class TestLogStreamMetrics:
     ) -> None:
         """Test LogStreams.enable_metrics with environment variables."""
         # Set environment variables
-        os.environ["GALILEO_PROJECT"] = "Test Project"
-        os.environ["GALILEO_LOG_STREAM"] = "Test Log Stream"
+        os.environ["SPLUNK_AO_PROJECT"] = "Test Project"
+        os.environ["SPLUNK_AO_LOG_STREAM"] = "Test Log Stream"
 
         # Setup mocks
         mock_projects_instance = mock_projects_class.return_value
@@ -336,8 +336,8 @@ class TestLogStreamMetrics:
     ) -> None:
         """Test enable_metrics function with environment variables (integration test)."""
         # Set environment variables
-        os.environ["GALILEO_PROJECT"] = "Integration Project"
-        os.environ["GALILEO_LOG_STREAM"] = "Integration Stream"
+        os.environ["SPLUNK_AO_PROJECT"] = "Integration Project"
+        os.environ["SPLUNK_AO_LOG_STREAM"] = "Integration Stream"
 
         # Setup mocks
         mock_projects_instance = mock_projects_class.return_value

--- a/tests/test_logger_batch.py
+++ b/tests/test_logger_batch.py
@@ -56,7 +56,7 @@ def test_galileo_logger_exceptions() -> None:
 
 @patch("galileo.logger.logger.Traces")
 def test_disable_galileo_logger(mock_traces_client: Mock, monkeypatch, caplog, enable_galileo_logging) -> None:
-    monkeypatch.setenv("GALILEO_LOGGING_DISABLED", "true")
+    monkeypatch.setenv("SPLUNK_AO_LOGGING_DISABLED", "true")
 
     with caplog.at_level(logging.DEBUG):
         logger = GalileoLogger(project="my_project", log_stream="my_log_stream")
@@ -2269,8 +2269,8 @@ def test_ingestion_hook_without_api_config() -> None:
 def test_ingestion_hook_without_project_or_log_stream(monkeypatch) -> None:
     """Test that ingestion_hook allows initialization without project/log_stream."""
     # Given: no project or log_stream in environment
-    monkeypatch.delenv("GALILEO_PROJECT", raising=False)
-    monkeypatch.delenv("GALILEO_LOG_STREAM", raising=False)
+    monkeypatch.delenv("SPLUNK_AO_PROJECT", raising=False)
+    monkeypatch.delenv("SPLUNK_AO_LOG_STREAM", raising=False)
 
     # Given: an ingestion hook
     hook = Mock()

--- a/tests/test_logger_distributed.py
+++ b/tests/test_logger_distributed.py
@@ -34,7 +34,7 @@ def test_galileo_logger_exceptions() -> None:
 
 @patch("galileo.logger.logger.Traces")
 def test_disable_galileo_logger(mock_traces_client: Mock, monkeypatch, caplog) -> None:
-    monkeypatch.setenv("GALILEO_LOGGING_DISABLED", "true")
+    monkeypatch.setenv("SPLUNK_AO_LOGGING_DISABLED", "true")
 
     with caplog.at_level(logging.WARNING):
         logger = GalileoLogger(project="my_project", log_stream="my_log_stream", mode="distributed")

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -2016,10 +2016,10 @@ class TestCodeMetricValidationConfiguration:
         """Test that Configuration values can be set via environment variables."""
         from galileo.configuration import Configuration
 
-        monkeypatch.setenv("GALILEO_CODE_VALIDATION_TIMEOUT", "90.0")
-        monkeypatch.setenv("GALILEO_CODE_VALIDATION_INITIAL_DELAY", "3.0")
-        monkeypatch.setenv("GALILEO_CODE_VALIDATION_MAX_DELAY", "45.0")
-        monkeypatch.setenv("GALILEO_CODE_VALIDATION_BACKOFF_MULTIPLIER", "1.8")
+        monkeypatch.setenv("SPLUNK_AO_CODE_VALIDATION_TIMEOUT", "90.0")
+        monkeypatch.setenv("SPLUNK_AO_CODE_VALIDATION_INITIAL_DELAY", "3.0")
+        monkeypatch.setenv("SPLUNK_AO_CODE_VALIDATION_MAX_DELAY", "45.0")
+        monkeypatch.setenv("SPLUNK_AO_CODE_VALIDATION_BACKOFF_MULTIPLIER", "1.8")
 
         assert Configuration.code_validation_timeout == 90.0
         assert Configuration.code_validation_initial_delay == 3.0

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -40,7 +40,7 @@ class TestGalileoOTLPExporter:
     @pytest.fixture
     def clear_env_vars(self):
         """Clear relevant environment variables and context vars for clean test state."""
-        env_vars = ["GALILEO_API_KEY", "GALILEO_CONSOLE_URL", "GALILEO_PROJECT", "GALILEO_LOG_STREAM"]
+        env_vars = ["SPLUNK_AO_API_KEY", "SPLUNK_AO_CONSOLE_URL", "SPLUNK_AO_PROJECT", "SPLUNK_AO_LOG_STREAM"]
         original_values = {var: os.environ.pop(var, None) for var in env_vars}
         _project_context.set(None)
         _log_stream_context.set(None)
@@ -79,7 +79,7 @@ class TestGalileoOTLPExporter:
 
         # Test that params override env vars
         mock_otlp_init.reset_mock()
-        with patch.dict(os.environ, {"GALILEO_PROJECT": "env-project", "GALILEO_LOG_STREAM": "env-logstream"}):
+        with patch.dict(os.environ, {"SPLUNK_AO_PROJECT": "env-project", "SPLUNK_AO_LOG_STREAM": "env-logstream"}):
             exporter = GalileoOTLPExporter(project="param-project", logstream="param-logstream")
             assert exporter.project == "param-project"  # Param wins over env
 
@@ -87,7 +87,7 @@ class TestGalileoOTLPExporter:
     @patch("galileo.otel.OTLPSpanExporter.__init__", return_value=None)
     def test_init_with_env_variables(self, mock_otlp_init, mock_config, clear_env_vars):
         """Test initialization using environment variables."""
-        with patch.dict(os.environ, {"GALILEO_PROJECT": "env-project", "GALILEO_LOG_STREAM": "env-logstream"}):
+        with patch.dict(os.environ, {"SPLUNK_AO_PROJECT": "env-project", "SPLUNK_AO_LOG_STREAM": "env-logstream"}):
             exporter = GalileoOTLPExporter()
             assert exporter.project == "env-project"
             assert exporter.logstream == "env-logstream"
@@ -381,8 +381,8 @@ class TestOTelContextIntegration:
     def test_processor_on_start_sets_span_attributes(self, mock_processor_deps, reset_decorator_context, monkeypatch):
         """Test on_start sets context attributes on spans, handling None values."""
         # Pin env vars for this test to avoid flakiness from parallel workers
-        monkeypatch.setenv("GALILEO_PROJECT", "test-project")
-        monkeypatch.setenv("GALILEO_LOG_STREAM", "test-log-stream")
+        monkeypatch.setenv("SPLUNK_AO_PROJECT", "test-project")
+        monkeypatch.setenv("SPLUNK_AO_LOG_STREAM", "test-log-stream")
 
         # Given: all context vars set (experiment_id takes priority over logstream)
         _project_context.set("test-project")
@@ -410,7 +410,7 @@ class TestOTelContextIntegration:
         _session_id_context.set(None)
 
         monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setenv("GALILEO_LOG_STREAM", "test-log-stream")
+        monkeypatch.setenv("SPLUNK_AO_LOG_STREAM", "test-log-stream")
         try:
             processor2 = GalileoSpanProcessor()
             mock_span2 = Mock()
@@ -420,7 +420,7 @@ class TestOTelContextIntegration:
             assert mock_span2.set_attribute.call_count == 2
             actual_calls = {(args[0], args[1]) for args, _ in mock_span2.set_attribute.call_args_list}
             assert ("galileo.project.name", "test-project") in actual_calls
-            # Falls back to GALILEO_LOG_STREAM env var
+            # Falls back to SPLUNK_AO_LOG_STREAM env var
             assert ("galileo.logstream.name", "test-log-stream") in actual_calls
         finally:
             monkeypatch.undo()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -10,8 +10,8 @@ from galileo.resources.models.project_type import ProjectType
 
 @pytest.fixture(autouse=True)
 def reset_env_vars() -> None:
-    os.environ.pop("GALILEO_PROJECT", None)
-    os.environ.pop("GALILEO_PROJECT_ID", None)
+    os.environ.pop("SPLUNK_AO_PROJECT", None)
+    os.environ.pop("SPLUNK_AO_PROJECT_ID", None)
 
 
 class TestProjects:
@@ -72,8 +72,8 @@ class TestProjects:
         mock_response.parsed = None
         get_project_projects_project_id_get.return_value = mock_response
 
-        with patch.dict("os.environ", {"GALILEO_PROJECT": "  "}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "  "}):
+        with patch.dict("os.environ", {"SPLUNK_AO_PROJECT": "  "}):
+            with patch.dict("os.environ", {"SPLUNK_AO_PROJECT_ID": "  "}):
                 result = Projects().get_with_env_fallbacks(id="123")
                 get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
                 assert result is None
@@ -87,7 +87,7 @@ class TestProjects:
         mock_response.parsed = None
         get_project_projects_project_id_get.return_value = mock_response
 
-        with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "123"}):
+        with patch.dict("os.environ", {"SPLUNK_AO_PROJECT_ID": "123"}):
             result = Projects().get_with_env_fallbacks()
             get_project_projects_project_id_get.assert_called_once_with(project_id="123", client=ANY)
             assert result is None
@@ -112,21 +112,21 @@ class TestProjects:
         mock_response.parsed = []
         get_projects_projects_get.return_value = mock_response
 
-        with patch.dict("os.environ", {"GALILEO_PROJECT": "  "}):
-            with patch.dict("os.environ", {"GALILEO_PROJECT_ID": "  "}):
+        with patch.dict("os.environ", {"SPLUNK_AO_PROJECT": "  "}):
+            with patch.dict("os.environ", {"SPLUNK_AO_PROJECT_ID": "  "}):
                 result = Projects().get_with_env_fallbacks(name="my_project")
                 get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
                 assert result is None
 
     @patch("galileo.projects.get_projects_projects_get.sync_detailed")
     def test_get_project_with_name_from_env_var_gets_project_by_name(self, get_projects_projects_get: Mock) -> None:
-        os.environ.pop("GALILEO_PROJECT_ID", None)
+        os.environ.pop("SPLUNK_AO_PROJECT_ID", None)
         mock_response = Mock()
         mock_response.status_code = httpx.codes.OK
         mock_response.parsed = []
         get_projects_projects_get.return_value = mock_response
 
-        with patch.dict("os.environ", {"GALILEO_PROJECT": "my_project"}):
+        with patch.dict("os.environ", {"SPLUNK_AO_PROJECT": "my_project"}):
             result = Projects().get_with_env_fallbacks()
             get_projects_projects_get.assert_called_once_with(project_name="my_project", client=ANY, type_=ANY)
             assert result is None

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -248,14 +248,14 @@ def test_pause_stage_by_names(mock_projects_cls: Mock, mock_get: Mock, mock_api:
 
 @patch("galileo.stages.create_stage_projects_project_id_stages_post.sync")
 def test_stage_creation_with_project_id_and_project_name_env_var(mock_api: Mock, monkeypatch) -> None:
-    monkeypatch.setenv("GALILEO_PROJECT", "proj")
+    monkeypatch.setenv("SPLUNK_AO_PROJECT", "proj")
 
     rules = [Rule(metric="m1", operator=RuleOperator.eq, target_value="v1")]
     rulesets = [Ruleset(rules=rules)]
     stage_name = "test-central-stage-with-rules"
     mock_api.return_value = _api_stage_db_factory(name=stage_name, stage_type=StageType.central)
 
-    # The project_id passed here should override the GALILEO_PROJECT env var
+    # The project_id passed here should override the SPLUNK_AO_PROJECT env var
     stage_response = create_protect_stage(
         project_id=FIXED_PROJECT_ID, name=stage_name, prioritized_rulesets=rulesets, stage_type=StageType.central
     )
@@ -280,14 +280,14 @@ def test_stage_creation_with_project_id_and_project_name_env_var(mock_api: Mock,
 
 @patch("galileo.stages.create_stage_projects_project_id_stages_post.sync")
 def test_stage_creation_with_project_id_and_project_id_env_var(mock_api: Mock, monkeypatch) -> None:
-    monkeypatch.setenv("GALILEO_PROJECT_ID", str(FIXED_PROJECT_ID))
+    monkeypatch.setenv("SPLUNK_AO_PROJECT_ID", str(FIXED_PROJECT_ID))
 
     rules = [Rule(metric="m1", operator=RuleOperator.eq, target_value="v1")]
     rulesets = [Ruleset(rules=rules)]
     stage_name = "test-central-stage-with-rules"
     mock_api.return_value = _api_stage_db_factory(name=stage_name, stage_type=StageType.central)
 
-    # The project_id passed here should override the GALILEO_PROJECT_ID env var
+    # The project_id passed here should override the SPLUNK_AO_PROJECT_ID env var
     stage_response = create_protect_stage(
         project_id=FIXED_PROJECT_ID, name=stage_name, prioritized_rulesets=rulesets, stage_type=StageType.central
     )
@@ -312,14 +312,14 @@ def test_stage_creation_with_project_id_and_project_id_env_var(mock_api: Mock, m
 
 @patch("galileo.stages.create_stage_projects_project_id_stages_post.sync")
 def test_stage_creation_with_project_name_and_project_id_env_var(mock_api: Mock, monkeypatch) -> None:
-    monkeypatch.setenv("GALILEO_PROJECT_ID", "proj")
+    monkeypatch.setenv("SPLUNK_AO_PROJECT_ID", "proj")
 
     rules = [Rule(metric="m1", operator=RuleOperator.eq, target_value="v1")]
     rulesets = [Ruleset(rules=rules)]
     stage_name = "test-central-stage-with-rules"
     mock_api.return_value = _api_stage_db_factory(name=stage_name, stage_type=StageType.central)
 
-    # The project_name passed here should override the GALILEO_PROJECT_ID env var
+    # The project_name passed here should override the SPLUNK_AO_PROJECT_ID env var
     stage_response = create_protect_stage(
         project_name="project name", name=stage_name, prioritized_rulesets=rulesets, stage_type=StageType.central
     )

--- a/tests/utils/test_telemetry_toggle.py
+++ b/tests/utils/test_telemetry_toggle.py
@@ -4,8 +4,8 @@ from galileo.utils.decorators import galileo_logging_enabled
 def test_galileo_logging_enabled(monkeypatch) -> None:
     assert galileo_logging_enabled() is True
 
-    monkeypatch.setenv("GALILEO_LOGGING_DISABLED", "true")
+    monkeypatch.setenv("SPLUNK_AO_LOGGING_DISABLED", "true")
     assert galileo_logging_enabled() is False
 
-    monkeypatch.setenv("GALILEO_LOGGING_DISABLED", "1")
+    monkeypatch.setenv("SPLUNK_AO_LOGGING_DISABLED", "1")
     assert galileo_logging_enabled() is False


### PR DESCRIPTION
# User description
## ⚠️ DO NOT MERGE

This PR is opened for **early review only**.

> **Repository migration notice:** Once the Splunk Agent Observability project is formally
> open-sourced, this code will be re-homed to
> **[signalfx/splunk-ao-python](https://github.com/signalfx/splunk-ao-python)** on GitHub.
> This PR will be closed and re-opened (or cherry-picked) against that repository.
> Companion PRs are opened for `sdk-examples` → `signalfx/splunk-ao-python-examples` and
> `e2e-testing` → the internal Splunk AO QA repo.

---

## Summary

Renames all `GALILEO_*` environment variables to `SPLUNK_AO_*` as part of the
[Splunk Agent Observability](https://splunk.atlassian.net/browse/HYBIM-713) rebrand.

**Jira tickets:** [HYBIM-713](https://splunk.atlassian.net/browse/HYBIM-713) · [HYBIM-727](https://splunk.atlassian.net/browse/HYBIM-727)

**Spec doc:** [`docs/SPLUNK_AO_ENV_RENAME.md`](docs/SPLUNK_AO_ENV_RENAME.md)

### Variable mapping

| Old | New |
|-----|-----|
| `GALILEO_API_KEY` | `SPLUNK_AO_API_KEY` |
| `GALILEO_CONSOLE_URL` | `SPLUNK_AO_CONSOLE_URL` |
| `GALILEO_PROJECT` | `SPLUNK_AO_PROJECT` |
| `GALILEO_PROJECT_ID` | `SPLUNK_AO_PROJECT_ID` |
| `GALILEO_LOG_STREAM` | `SPLUNK_AO_LOG_STREAM` |
| `GALILEO_LOG_STREAM_ID` | `SPLUNK_AO_LOG_STREAM_ID` |
| `GALILEO_JWT_TOKEN` | `SPLUNK_AO_JWT_TOKEN` |
| `GALILEO_SSO_ID_TOKEN` | `SPLUNK_AO_SSO_ID_TOKEN` |
| `GALILEO_SSO_PROVIDER` | `SPLUNK_AO_SSO_PROVIDER` |
| `GALILEO_USERNAME` | `SPLUNK_AO_USERNAME` |
| `GALILEO_PASSWORD` | `SPLUNK_AO_PASSWORD` |
| `GALILEO_MODE` | `SPLUNK_AO_MODE` |
| `GALILEO_LOGGING_DISABLED` | `SPLUNK_AO_LOGGING_DISABLED` |
| `GALILEO_INGEST_BETA_DISABLED` | `SPLUNK_AO_INGEST_BETA_DISABLED` |

### Key design decisions

- **Hard cut-over** — no backward-compatibility shim for external consumers.
- **`galileo-core` bridge** — `GalileoPythonConfig._bridge_env_vars()` transparently copies
  `SPLUNK_AO_*` → `GALILEO_*` at startup so the private `galileo-core` dependency continues to
  work until it is updated separately.
- **`GALILEO_HEADER_PREFIX` excluded** — tracked in [HYBIM-729](https://splunk.atlassian.net/browse/HYBIM-729).

## Test plan

- [x] `poetry run pytest` — 2015 passed, 5 skipped
- [x] E2E tests (`e2e-testing/py-sdk-and-ui`) — targeted tests passed
- [x] `langchain-agent` example — runs end-to-end, exit 0
- [x] `strands-agents` example — runs end-to-end, exit 0

Made with [Cursor](https://cursor.com)

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Rebrand env var surfaces to Splunk AO names across configuration metadata, helpers, endpoints, docs, and the test suite so the SDK, logger, experiments, prompts, and telemetry toggles only refer to <code>SPLUNK_AO_*</code> names. Add the <code>GalileoPythonConfig</code> compatibility bridge plus CI resilience so <code>galileo-core</code> can keep reading legacy names until it migrates, and highlight the updated auth guidance everywhere.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/597?tool=ast&topic=Env+rename+rollout>Env rename rollout</a>
        </td><td>Update every user-facing configuration surface, helper, logger, experiment/log stream/prompt flow, docs/example, and test fixture to use <code>SPLUNK_AO_*</code> variables instead of the old <code>GALILEO_*</code> prefixes so the Splunk AO rebrand is reflected end-to-end.<details><summary>Modified files (40)</summary><ul><li>.github/workflows/test.yaml</li>
<li>docs/SPLUNK_AO_ENV_RENAME.md</li>
<li>src/galileo/README_API_CLIENT.md</li>
<li>src/galileo/agent_control.py</li>
<li>src/galileo/configuration.py</li>
<li>src/galileo/decorator.py</li>
<li>src/galileo/exceptions.py</li>
<li>src/galileo/experiment.py</li>
<li>src/galileo/experiments.py</li>
<li>src/galileo/log_stream.py</li>
<li>src/galileo/log_streams.py</li>
<li>src/galileo/logger/logger.py</li>
<li>src/galileo/metric.py</li>
<li>src/galileo/middleware/tracing.py</li>
<li>src/galileo/otel.py</li>
<li>src/galileo/projects.py</li>
<li>src/galileo/prompt.py</li>
<li>src/galileo/shared/exceptions.py</li>
<li>src/galileo/utils/decorators/telemetry_toggle.py</li>
<li>src/galileo/utils/env_helpers.py</li>
<li>src/galileo/utils/singleton.py</li>
<li>tests/conftest.py</li>
<li>tests/shared/test_project_resolver.py</li>
<li>tests/test_agent_control.py</li>
<li>tests/test_config.py</li>
<li>tests/test_configuration.py</li>
<li>tests/test_decorator.py</li>
<li>tests/test_decorator_distributed.py</li>
<li>tests/test_experiment.py</li>
<li>tests/test_experiments.py</li>
<li>tests/test_langchain.py</li>
<li>tests/test_log_stream.py</li>
<li>tests/test_log_streams_metrics.py</li>
<li>tests/test_logger_batch.py</li>
<li>tests/test_logger_distributed.py</li>
<li>tests/test_metric.py</li>
<li>tests/test_otel.py</li>
<li>tests/test_projects.py</li>
<li>tests/test_stages.py</li>
<li>tests/utils/test_telemetry_toggle.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/597?tool=ast&topic=Compatibility+bridge>Compatibility bridge</a>
        </td><td>Bridge <code>SPLUNK_AO_*</code> inputs into legacy <code>GALILEO_*</code> vars inside <code>GalileoPythonConfig</code>, refresh auth/error messaging, and tweak CI tooling so the private <code>galileo-core</code> dependency continues to authenticate during the hard cut-over while the build flow stays robust.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/test.yaml</li>
<li>src/galileo/config.py</li>
<li>tests/test_config.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/597?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>