### PR TITLE
feat(rebrand): [DO NOT MERGE]HYBIM-728 Renaming SDK Identifiers from galileo to splunk_ao

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ src/galileo/
 ├── prompts.py               # Prompt service (current API)
 ├── projects.py              # Project service (current API)
 ├── log_streams.py           # LogStream service (current API)
-├── decorator.py             # @log decorator and galileo_context
+├── decorator.py             # @log decorator and splunk_ao_context
 └── config.py                # GalileoPythonConfig configuration
 ```
 
@@ -74,7 +74,7 @@ src/galileo/
 
 **GalileoLogger** (`src/galileo/logger/logger.py`): Central class for uploading traces to Galileo. Supports batch and streaming modes. Manages traces, spans (LLM, retriever, tool, workflow, agent), and sessions.
 
-**Decorators** (`src/galileo/decorator.py`): The `@log` decorator and `galileo_context` context manager for automatic function tracing. Uses ContextVars for thread-safe nested span tracking.
+**Decorators** (`src/galileo/decorator.py`): The `@log` decorator and `splunk_ao_context` context manager for automatic function tracing. Uses ContextVars for thread-safe nested span tracking.
 
 **Handlers** (`src/galileo/handlers/`): Framework-specific integrations:
 - `langchain/` - LangChain callback handler (`GalileoCallback`)
@@ -167,7 +167,7 @@ results = run_experiment(
 ### Logging with Decorators
 
 ```python
-from galileo import log, galileo_context
+from galileo import log, splunk_ao_context
 
 # Auto-trace function calls
 @log
@@ -181,7 +181,7 @@ def retrieve_docs(query: str):
     return ["doc1", "doc2"]
 
 # Context manager for explicit control
-with galileo_context(project="my-project", log_stream="prod"):
+with splunk_ao_context(project="my-project", log_stream="prod"):
     my_workflow()
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Note: if you would like to point to an environment other than `app.galileo.ai`, 
 ```python
 import os
 
-from galileo import galileo_context
+from galileo import splunk_ao_context
 from galileo.openai import openai
 
 # If you've set your GALILEO_PROJECT and GALILEO_LOG_STREAM env vars, you can skip this step
-galileo_context.init(project="your-project-name", log_stream="your-log-stream-name")
+splunk_ao_context.init(project="your-project-name", log_stream="your-log-stream-name")
 
 # Initialize the Galileo wrapped OpenAI client
 client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
@@ -61,7 +61,7 @@ def call_openai():
 call_openai()
 
 # This will upload the trace to Galileo
-galileo_context.flush()
+splunk_ao_context.flush()
 ```
 
 You can also use the `@log` decorator to log spans. Here's how to create a workflow span with two nested LLM spans:
@@ -75,7 +75,7 @@ def make_nested_call():
     call_openai()
 
 # If you've set your GALILEO_PROJECT and GALILEO_LOG_STREAM env vars, you can skip this step
-galileo_context.init(project="your-project-name", log_stream="your-log-stream-name")
+splunk_ao_context.init(project="your-project-name", log_stream="your-log-stream-name")
 
 # This will create a trace with a workflow span and two nested LLM spans containing the OpenAI calls
 make_nested_call()
@@ -107,27 +107,27 @@ def tool_call(input: str = "tool call input"):
 tool_call(input="question")
 
 # This will upload the trace to Galileo
-galileo_context.flush()
+splunk_ao_context.flush()
 ```
 
-In some cases, you may want to wrap a block of code to start and flush a trace automatically. You can do this using the `galileo_context` context manager:
+In some cases, you may want to wrap a block of code to start and flush a trace automatically. You can do this using the `splunk_ao_context` context manager:
 
 ```python
-from galileo import galileo_context
+from galileo import splunk_ao_context
 
 # This will log a block of code to the project and log stream specified in the context manager
-with galileo_context():
+with splunk_ao_context():
     content = make_nested_call()
     print(content)
 ```
 
-`galileo_context` also allows you specify a separate project and log stream for the trace:
+`splunk_ao_context` also allows you specify a separate project and log stream for the trace:
 
 ```python
-from galileo import galileo_context
+from galileo import splunk_ao_context
 
 # This will log to the project and log stream specified in the context manager
-with galileo_context(project="gen-ai-project", log_stream="test2"):
+with splunk_ao_context(project="gen-ai-project", log_stream="test2"):
     content = make_nested_call()
     print(content)
 ```
@@ -162,9 +162,9 @@ current Galileo log stream as the runtime target:
 
 ```python
 import agent_control
-from galileo import galileo_context, get_agent_control_target
+from galileo import splunk_ao_context, get_agent_control_target
 
-galileo_context.init(project="my-project", log_stream="prod")
+splunk_ao_context.init(project="my-project", log_stream="prod")
 
 target = get_agent_control_target()
 
@@ -178,7 +178,7 @@ agent_control.init(
 ```
 
 The helper resolves an explicit log stream ID, `GALILEO_LOG_STREAM_ID`, or an
-already-initialized `galileo_context` logger. It does not import the Agent
+already-initialized `splunk_ao_context` logger. It does not import the Agent
 Control SDK or resolve log stream names over the network. If you use a direct
 Agent Control client instead of `agent_control.init(...)`, pass
 `target.target_type` and `target.target_id` on each evaluation call.
@@ -210,10 +210,10 @@ In some cases (like long-running processes), it may be necessary to explicitly f
 ```python
 import os
 
-from galileo import galileo_context
+from galileo import splunk_ao_context
 from galileo.openai import openai
 
-galileo_context.init(project="your-project-name", log_stream="your-log-stream-name")
+splunk_ao_context.init(project="your-project-name", log_stream="your-log-stream-name")
 
 # Initialize the Galileo wrapped OpenAI client
 client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
@@ -230,7 +230,7 @@ def call_openai():
 call_openai()
 
 # This will upload the trace to Galileo
-galileo_context.flush()
+splunk_ao_context.flush()
 ```
 
 Using the Langchain callback handler:
@@ -404,16 +404,16 @@ logger.conclude()
 logger.flush()
 ```
 
-All of this can also be done using the `galileo_context` context manager:
+All of this can also be done using the `splunk_ao_context` context manager:
 
 ```python
-from galileo import galileo_context
+from galileo import splunk_ao_context
 
-session_id = galileo_context.start_session(name="my-session-name")
+session_id = splunk_ao_context.start_session(name="my-session-name")
 
 # OR
 
-galileo_context.set_session(session_id=session_id)
+splunk_ao_context.set_session(session_id=session_id)
 
 ```
 

--- a/galileo-a2a/README.md
+++ b/galileo-a2a/README.md
@@ -44,12 +44,12 @@ pip install galileo-a2a
 ## Quick Start
 
 ```python
-from galileo.otel import GalileoSpanProcessor, add_galileo_span_processor
+from galileo.otel import GalileoSpanProcessor, add_splunk_ao_span_processor
 from galileo_a2a import A2AInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 
 provider = TracerProvider()
-add_galileo_span_processor(provider, GalileoSpanProcessor())
+add_splunk_ao_span_processor(provider, GalileoSpanProcessor())
 A2AInstrumentor().instrument(tracer_provider=provider, agent_name="orchestrator")
 ```
 
@@ -119,7 +119,7 @@ from a2a.types import (
     AgentCapabilities, AgentCard, AgentSkill, Message, Role,
     TaskState, TaskStatus, TaskStatusUpdateEvent, TextPart,
 )
-from galileo.otel import GalileoSpanProcessor, add_galileo_span_processor
+from galileo.otel import GalileoSpanProcessor, add_splunk_ao_span_processor
 from galileo_a2a import A2AInstrumentor
 from langchain.agents import create_agent
 from langchain_core.tools import tool
@@ -132,7 +132,7 @@ from typing_extensions import TypedDict
 
 # ---- Only 4 lines needed for full distributed tracing ----
 provider = TracerProvider()
-add_galileo_span_processor(provider, GalileoSpanProcessor())
+add_splunk_ao_span_processor(provider, GalileoSpanProcessor())
 A2AInstrumentor().instrument(tracer_provider=provider, agent_name="orchestrator")
 LangchainInstrumentor().instrument(tracer_provider=provider)
 

--- a/galileo-a2a/examples/two_agent_demo.py
+++ b/galileo-a2a/examples/two_agent_demo.py
@@ -51,7 +51,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from starlette.applications import Starlette
 from typing_extensions import TypedDict
 
-from galileo.otel import GalileoSpanProcessor, add_galileo_span_processor
+from galileo.otel import GalileoSpanProcessor, add_splunk_ao_span_processor
 from galileo_a2a import A2AInstrumentor
 
 load_dotenv(Path(__file__).parent / ".env")
@@ -61,7 +61,7 @@ load_dotenv(Path(__file__).parent / ".env")
 # ---------------------------------------------------------------------------
 
 provider = TracerProvider()
-add_galileo_span_processor(provider, GalileoSpanProcessor())
+add_splunk_ao_span_processor(provider, GalileoSpanProcessor())
 A2AInstrumentor().instrument(tracer_provider=provider, agent_name="orchestrator")
 LangchainInstrumentor().instrument(tracer_provider=provider)
 

--- a/galileo-a2a/src/galileo_a2a/instrumentor.py
+++ b/galileo-a2a/src/galileo_a2a/instrumentor.py
@@ -32,11 +32,11 @@ class A2AInstrumentor(BaseInstrumentor):  # type: ignore[misc]
     Example::
 
         from opentelemetry.sdk.trace import TracerProvider
-        from galileo.otel import GalileoSpanProcessor, add_galileo_span_processor
+        from galileo.otel import GalileoSpanProcessor, add_splunk_ao_span_processor
         from galileo_a2a import A2AInstrumentor
 
         provider = TracerProvider()
-        add_galileo_span_processor(provider, GalileoSpanProcessor())
+        add_splunk_ao_span_processor(provider, GalileoSpanProcessor())
         A2AInstrumentor().instrument(tracer_provider=provider, agent_name="my-agent")
 
         # To disable message content capture (e.g. for PII compliance):

--- a/galileo-adk/README.md
+++ b/galileo-adk/README.md
@@ -164,13 +164,13 @@ if __name__ == "__main__":
 
 ### Retriever Spans
 
-By default, all `FunctionTool` calls are logged as tool spans. To log a retriever function as a **retriever span** (enabling RAG quality metrics in Galileo), decorate it with `@galileo_retriever`:
+By default, all `FunctionTool` calls are logged as tool spans. To log a retriever function as a **retriever span** (enabling RAG quality metrics in Galileo), decorate it with `@splunk_ao_retriever`:
 
 ```python
-from galileo_adk import galileo_retriever
+from galileo_adk import splunk_ao_retriever
 from google.adk.tools import FunctionTool
 
-@galileo_retriever
+@splunk_ao_retriever
 def search_docs(query: str) -> str:
     """Search the knowledge base."""
     results = my_vector_db.search(query)

--- a/galileo-adk/src/galileo_adk/__init__.py
+++ b/galileo-adk/src/galileo_adk/__init__.py
@@ -1,13 +1,13 @@
 __version__ = "2.0.1"
 
 from galileo_adk.callback import GalileoADKCallback
-from galileo_adk.decorator import galileo_retriever
+from galileo_adk.decorator import splunk_ao_retriever
 from galileo_adk.observer import get_custom_metadata
 from galileo_adk.plugin import GalileoADKPlugin
 
 __all__ = [
     "GalileoADKPlugin",
     "GalileoADKCallback",
-    "galileo_retriever",
+    "splunk_ao_retriever",
     "get_custom_metadata",
 ]

--- a/galileo-adk/src/galileo_adk/data_converters.py
+++ b/galileo-adk/src/galileo_adk/data_converters.py
@@ -18,7 +18,7 @@ def generate_tool_call_id(name: str, index: int = 0) -> str:
     return f"call_{name}_{index}_{uuid.uuid4().hex[:8]}"
 
 
-def convert_adk_content_to_galileo_messages(content: Any) -> list[Message]:
+def convert_adk_content_to_splunk_ao_messages(content: Any) -> list[Message]:
     """Convert ADK Content to list of Galileo Messages, preserving part order.
 
     Tracks call IDs for function calls and links them to their responses.
@@ -158,7 +158,7 @@ def _map_adk_role_to_galileo(adk_role: str) -> MessageRole:
     return _ADK_ROLE_TO_GALILEO.get(adk_role.lower(), MessageRole.user)
 
 
-def convert_adk_tools_to_galileo_format(tools: Any) -> list[dict[str, Any]]:
+def convert_adk_tools_to_splunk_ao_format(tools: Any) -> list[dict[str, Any]]:
     """Convert ADK tools to OpenAI-compatible format."""
     galileo_tools: list[dict[str, Any]] = []
     for tool in tools:

--- a/galileo-adk/src/galileo_adk/decorator.py
+++ b/galileo-adk/src/galileo_adk/decorator.py
@@ -6,20 +6,20 @@ from collections.abc import Callable
 from typing import Any
 
 
-def galileo_retriever(func: Callable[..., Any]) -> Callable[..., Any]:
+def splunk_ao_retriever(func: Callable[..., Any]) -> Callable[..., Any]:
     """Mark a function as a retriever for Galileo observability.
 
-    When a function decorated with @galileo_retriever is wrapped in a
+    When a function decorated with @splunk_ao_retriever is wrapped in a
     FunctionTool, Galileo will log it as a retriever span (node_type="retriever")
     instead of a tool span, enabling RAG quality metrics.
 
     Example
     -------
-    >>> from galileo_adk import galileo_retriever
-    >>> @galileo_retriever
+    >>> from galileo_adk import splunk_ao_retriever
+    >>> @splunk_ao_retriever
     ... def my_search(query: str) -> str:
     ...     return search_docs(query)
     >>> tool = FunctionTool(my_search)
     """
-    func._galileo_is_retriever = True  # type: ignore[attr-defined]
+    func._splunk_ao_is_retriever = True  # type: ignore[attr-defined]
     return func

--- a/galileo-adk/src/galileo_adk/observer.py
+++ b/galileo-adk/src/galileo_adk/observer.py
@@ -10,13 +10,13 @@ from collections.abc import Callable
 from typing import Any
 from uuid import UUID
 
-from galileo import galileo_context
+from galileo import splunk_ao_context
 from galileo.handlers.base_handler import GalileoBaseHandler
 from galileo.schema.trace import TracesIngestRequest
 from galileo.utils.serialization import serialize_to_str
 from galileo_adk.data_converters import (
-    convert_adk_content_to_galileo_messages,
-    convert_adk_tools_to_galileo_format,
+    convert_adk_content_to_splunk_ao_messages,
+    convert_adk_tools_to_splunk_ao_format,
     extract_text_from_adk_content,
 )
 from galileo_adk.span_manager import SpanManager
@@ -155,7 +155,7 @@ class GalileoObserver:
             )
         else:
             self._trace_builder = None
-            galileo_logger = galileo_context.get_logger_instance(project=project, log_stream=log_stream)
+            galileo_logger = splunk_ao_context.get_logger_instance(project=project, log_stream=log_stream)
             self._handler = GalileoBaseHandler(
                 galileo_logger=galileo_logger,
                 start_new_trace=True,
@@ -392,12 +392,12 @@ class GalileoObserver:
 
         Detection uses two strategies:
         1. isinstance check against google.adk.tools.retrieval.BaseRetrievalTool
-        2. Custom functions decorated with @galileo_retriever (sets _galileo_is_retriever on func)
+        2. Custom functions decorated with @splunk_ao_retriever (sets _splunk_ao_is_retriever on func)
         """
         if _BaseRetrievalTool is not None and isinstance(tool, _BaseRetrievalTool):
             return True
         func = getattr(tool, "func", None)
-        return bool(func is not None and getattr(func, "_galileo_is_retriever", False))
+        return bool(func is not None and getattr(func, "_splunk_ao_is_retriever", False))
 
     def on_tool_start(
         self,
@@ -468,13 +468,13 @@ class GalileoObserver:
             return []
         messages = []
         for content in llm_request.contents:
-            messages.extend(convert_adk_content_to_galileo_messages(content))
+            messages.extend(convert_adk_content_to_splunk_ao_messages(content))
         return messages
 
     def _extract_llm_output(self, llm_response: Any) -> list[Any]:
         """Extract LLM output as list of Messages to preserve all parts including tool_calls."""
         if llm_response and hasattr(llm_response, "content"):
-            return convert_adk_content_to_galileo_messages(llm_response.content)
+            return convert_adk_content_to_splunk_ao_messages(llm_response.content)
         return []
 
     def _extract_model_name(self, llm_request: Any) -> str | None:
@@ -494,7 +494,7 @@ class GalileoObserver:
         if hasattr(llm_request, "config") and llm_request.config:
             tools = getattr(llm_request.config, "tools", None)
             if tools:
-                return convert_adk_tools_to_galileo_format(tools)
+                return convert_adk_tools_to_splunk_ao_format(tools)
         return None
 
     def _extract_usage_metadata(self, llm_response: Any) -> dict[str, Any]:

--- a/galileo-adk/tests/conftest.py
+++ b/galileo-adk/tests/conftest.py
@@ -51,7 +51,7 @@ def mock_decode_jwt() -> Generator[MagicMock, None, None]:
 
 @pytest.fixture
 def mock_projects(mock_request: Callable) -> Generator[None, None, None]:
-    """Mock the projects endpoint used by galileo_context.get_logger_instance().
+    """Mock the projects endpoint used by splunk_ao_context.get_logger_instance().
 
     ProjectDB schema requires:
     - id, created_by, created_by_user (UserInfo), runs, created_at, updated_at

--- a/galileo-adk/tests/test_callback.py
+++ b/galileo-adk/tests/test_callback.py
@@ -123,7 +123,7 @@ class TestGalileoADKCallback:
         assert callback._handler is not None
 
     def test_initialization_with_project_and_log_stream(self) -> None:
-        with patch("galileo_adk.observer.galileo_context") as mock_context:
+        with patch("galileo_adk.observer.splunk_ao_context") as mock_context:
             mock_logger = MagicMock()
             mock_context.get_logger_instance.return_value = mock_logger
 

--- a/galileo-adk/tests/test_data_converters.py
+++ b/galileo-adk/tests/test_data_converters.py
@@ -9,7 +9,7 @@ from galileo_adk.data_converters import (
     _try_direct_attributes,
     _try_function_declarations,
     _try_to_dict,
-    convert_adk_content_to_galileo_messages,
+    convert_adk_content_to_splunk_ao_messages,
 )
 
 
@@ -28,7 +28,7 @@ class MockContent:
 class TestConvertADKContent:
     def test_text_part(self) -> None:
         content = MockContent([MockPart(text="hello")])
-        messages = convert_adk_content_to_galileo_messages(content)
+        messages = convert_adk_content_to_splunk_ao_messages(content)
         assert len(messages) == 1
         assert messages[0].content == "hello"
         assert messages[0].role == MessageRole.user
@@ -36,7 +36,7 @@ class TestConvertADKContent:
     def test_inline_data_part(self) -> None:
         inline = MockPart(mime_type="image/png", data=b"\x89PNG")
         content = MockContent([MockPart(inline_data=inline)])
-        messages = convert_adk_content_to_galileo_messages(content)
+        messages = convert_adk_content_to_splunk_ao_messages(content)
         assert len(messages) == 1
         payload = json.loads(messages[0].content)
         assert payload["type"] == "inline_data"
@@ -46,7 +46,7 @@ class TestConvertADKContent:
     def test_file_data_part(self) -> None:
         file_d = MockPart(file_uri="gs://bucket/file.pdf", mime_type="application/pdf")
         content = MockContent([MockPart(file_data=file_d)])
-        messages = convert_adk_content_to_galileo_messages(content)
+        messages = convert_adk_content_to_splunk_ao_messages(content)
         assert len(messages) == 1
         payload = json.loads(messages[0].content)
         assert payload["type"] == "file_data"
@@ -55,7 +55,7 @@ class TestConvertADKContent:
     def test_function_call_part(self) -> None:
         func_call = MockPart(name="search", args={"query": "weather"})
         content = MockContent([MockPart(function_call=func_call)], role="model")
-        messages = convert_adk_content_to_galileo_messages(content)
+        messages = convert_adk_content_to_splunk_ao_messages(content)
         assert len(messages) == 1
         assert messages[0].role == MessageRole.assistant
         assert messages[0].content == ""
@@ -67,7 +67,7 @@ class TestConvertADKContent:
     def test_function_response_part(self) -> None:
         func_resp = MockPart(name="search", response={"result": "sunny"})
         content = MockContent([MockPart(function_response=func_resp)])
-        messages = convert_adk_content_to_galileo_messages(content)
+        messages = convert_adk_content_to_splunk_ao_messages(content)
         assert len(messages) == 1
         assert messages[0].role == MessageRole.tool
         payload = json.loads(messages[0].content)
@@ -81,7 +81,7 @@ class TestConvertADKContent:
             MockPart(text="Step 2"),
         ]
         content = MockContent(parts, role="model")
-        messages = convert_adk_content_to_galileo_messages(content)
+        messages = convert_adk_content_to_splunk_ao_messages(content)
         assert len(messages) == 4
         assert messages[0].content == "Step 1"
         assert messages[1].role == MessageRole.assistant
@@ -92,11 +92,11 @@ class TestConvertADKContent:
 
     def test_empty_content(self) -> None:
         content = MockContent([])
-        assert convert_adk_content_to_galileo_messages(content) == []
+        assert convert_adk_content_to_splunk_ao_messages(content) == []
 
     def test_unknown_part_skipped(self) -> None:
         content = MockContent([MockPart(unknown_field="value")])
-        assert convert_adk_content_to_galileo_messages(content) == []
+        assert convert_adk_content_to_splunk_ao_messages(content) == []
 
     def test_multiple_function_calls_same_name_with_unique_ids(self) -> None:
         """Multiple function calls with same name but unique IDs should link correctly."""
@@ -107,7 +107,7 @@ class TestConvertADKContent:
             MockPart(function_response=MockPart(id="call_2", name="search", response="result_2")),
         ]
         content = MockContent(parts, role="model")
-        messages = convert_adk_content_to_galileo_messages(content)
+        messages = convert_adk_content_to_splunk_ao_messages(content)
 
         assert len(messages) == 4
         # First call and its response should share the same call_id
@@ -126,7 +126,7 @@ class TestConvertADKContent:
             MockPart(function_response=MockPart(name="calc", response=42)),
         ]
         content = MockContent(parts, role="model")
-        messages = convert_adk_content_to_galileo_messages(content)
+        messages = convert_adk_content_to_splunk_ao_messages(content)
 
         assert len(messages) == 2
         # Without ADK ids, responses can't link to calls (different part indices)

--- a/galileo-adk/tests/test_retriever.py
+++ b/galileo-adk/tests/test_retriever.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import pytest
 
-from galileo_adk.decorator import galileo_retriever
+from galileo_adk.decorator import splunk_ao_retriever
 from galileo_adk.observer import GalileoObserver
 
 from .mocks import MockTool, MockToolContext
@@ -42,26 +42,26 @@ def observer() -> GalileoObserver:
 
 
 class TestGalileoRetrieverDecorator:
-    """Tests for the @galileo_retriever decorator."""
+    """Tests for the @splunk_ao_retriever decorator."""
 
     def test_decorator_sets_attribute(self) -> None:
         # Given: a plain function
         def my_search(query: str) -> str:
             return "results"
 
-        # When: decorating with @galileo_retriever
-        decorated = galileo_retriever(my_search)
+        # When: decorating with @splunk_ao_retriever
+        decorated = splunk_ao_retriever(my_search)
 
-        # Then: the function has _galileo_is_retriever = True
-        assert getattr(decorated, "_galileo_is_retriever", False) is True
+        # Then: the function has _splunk_ao_is_retriever = True
+        assert getattr(decorated, "_splunk_ao_is_retriever", False) is True
 
     def test_decorator_preserves_function(self) -> None:
         # Given: a function with specific behavior
         def my_search(query: str) -> str:
             return f"results for {query}"
 
-        # When: decorating with @galileo_retriever
-        decorated = galileo_retriever(my_search)
+        # When: decorating with @splunk_ao_retriever
+        decorated = splunk_ao_retriever(my_search)
 
         # Then: the function still works as expected
         assert decorated("test") == "results for test"
@@ -69,12 +69,12 @@ class TestGalileoRetrieverDecorator:
 
     def test_decorator_syntax(self) -> None:
         # Given/When: using decorator syntax
-        @galileo_retriever
+        @splunk_ao_retriever
         def my_search(query: str) -> str:
             return "results"
 
         # Then: the function is marked as a retriever
-        assert getattr(my_search, "_galileo_is_retriever", False) is True
+        assert getattr(my_search, "_splunk_ao_is_retriever", False) is True
 
 
 class TestIsRetrieverTool:
@@ -113,8 +113,8 @@ class TestIsRetrieverTool:
         assert result is True
 
     def test_decorated_function_tool_is_detected(self, observer: GalileoObserver) -> None:
-        # Given: a function decorated with @galileo_retriever wrapped in FunctionTool
-        @galileo_retriever
+        # Given: a function decorated with @splunk_ao_retriever wrapped in FunctionTool
+        @splunk_ao_retriever
         def my_search(query: str) -> str:
             return "results"
 
@@ -127,7 +127,7 @@ class TestIsRetrieverTool:
         assert result is True
 
     def test_undecorated_function_tool_is_not_retriever(self, observer: GalileoObserver) -> None:
-        # Given: a function NOT decorated with @galileo_retriever wrapped in FunctionTool
+        # Given: a function NOT decorated with @splunk_ao_retriever wrapped in FunctionTool
         def my_calculator(expression: str) -> str:
             return "42"
 
@@ -165,8 +165,8 @@ class TestOnToolStartRetriever:
     """Tests for on_tool_start retriever span creation."""
 
     def test_decorated_retriever_creates_retriever_span(self, observer: GalileoObserver) -> None:
-        # Given: a function decorated with @galileo_retriever wrapped in FunctionTool
-        @galileo_retriever
+        # Given: a function decorated with @splunk_ao_retriever wrapped in FunctionTool
+        @splunk_ao_retriever
         def my_search(query: str) -> str:
             return "results"
 
@@ -190,7 +190,7 @@ class TestOnToolStartRetriever:
 
     def test_retriever_tool_extracts_query_from_tool_args(self, observer: GalileoObserver) -> None:
         # Given: a retriever tool with a "query" key in tool_args
-        @galileo_retriever
+        @splunk_ao_retriever
         def my_search(query: str) -> str:
             return "results"
 
@@ -212,7 +212,7 @@ class TestOnToolStartRetriever:
 
     def test_retriever_tool_falls_back_when_no_query_key(self, observer: GalileoObserver) -> None:
         # Given: a retriever tool without a "query" key in tool_args
-        @galileo_retriever
+        @splunk_ao_retriever
         def my_search(search_text: str) -> str:
             return "results"
 

--- a/src/galileo/__init__.py
+++ b/src/galileo/__init__.py
@@ -4,7 +4,7 @@ from galileo.agent_control import AgentControlTarget, AgentControlTargetUnresolv
 from galileo.collaborator import Collaborator, CollaboratorRole
 from galileo.configuration import Configuration
 from galileo.dataset import Dataset
-from galileo.decorator import GalileoDecorator, galileo_context, log, start_session
+from galileo.decorator import GalileoDecorator, splunk_ao_context, log, start_session
 from galileo.exceptions import (
     AuthenticationError,
     BadRequestError,
@@ -149,7 +149,6 @@ __all__ = [
     "create_protect_stage",
     "delete_api_key",
     "enable_console_logging",
-    "galileo_context",
     "get_agent_control_target",
     "get_protect_stage",
     "get_tracing_headers",
@@ -160,6 +159,7 @@ __all__ = [
     "pause_protect_stage",
     "resume_protect_stage",
     "setup_agent_control_bridge",
+    "splunk_ao_context",
     "start_session",
     "update_protect_stage",
 ]

--- a/src/galileo/agent_control.py
+++ b/src/galileo/agent_control.py
@@ -13,7 +13,7 @@ import threading
 from dataclasses import dataclass
 from uuid import UUID
 
-from galileo.decorator import galileo_context
+from galileo.decorator import splunk_ao_context
 from galileo.utils.env_helpers import _get_log_stream_or_default, _get_project_or_default
 from galileo.utils.singleton import GalileoLoggerSingleton
 
@@ -61,7 +61,7 @@ def get_agent_control_target(
     1. Explicit ``target_id``.
     2. Explicit ``log_stream_id`` for ``log_stream`` targets.
     3. ``GALILEO_LOG_STREAM_ID`` for ``log_stream`` targets.
-    4. An already-initialized ``galileo_context`` logger.
+    4. An already-initialized ``splunk_ao_context`` logger.
 
     This helper does not resolve log stream names over the network. If only a
     log stream name is available, resolve it with the Galileo SDK first and pass
@@ -113,7 +113,7 @@ def get_agent_control_target(
         "Could not resolve Galileo log stream ID for Agent Control. Provide one of:\n"
         "  1. target_id=<uuid> or log_stream_id=<uuid> argument\n"
         "  2. GALILEO_LOG_STREAM_ID environment variable\n"
-        "  3. An initialized galileo_context with a resolved log stream ID"
+        "  3. An initialized splunk_ao_context with a resolved log stream ID"
     )
 
 
@@ -131,8 +131,8 @@ def _strip_optional_string(value: str | None) -> str | None:
 
 
 def _resolve_log_stream_from_cached_context() -> AgentControlTarget | None:
-    current_project = _get_project_or_default(galileo_context.get_current_project())
-    current_log_stream = _get_log_stream_or_default(galileo_context.get_current_log_stream())
+    current_project = _get_project_or_default(splunk_ao_context.get_current_project())
+    current_log_stream = _get_log_stream_or_default(splunk_ao_context.get_current_log_stream())
     current_thread_name = threading.current_thread().name
 
     # Read cached logger state directly so this helper never creates or resolves

--- a/src/galileo/constants/__init__.py
+++ b/src/galileo/constants/__init__.py
@@ -8,7 +8,7 @@ DEFAULT_API_URL = "https://api.galileo.ai/"
 DEFAULT_CONSOLE_URL = "https://app.galileo.ai/"
 
 # HTTP header prefix for all Galileo headers
-GALILEO_HEADER_PREFIX = "X-Galileo"
+SPLUNK_AO_HEADER_PREFIX = "X-Galileo"
 
 # Type definitions
 LoggerModeType = Literal["batch", "distributed"]
@@ -19,6 +19,6 @@ __all__ = (
     "DEFAULT_LOG_STREAM_NAME",
     "DEFAULT_MODE",
     "DEFAULT_PROJECT_NAME",
-    "GALILEO_HEADER_PREFIX",
+    "SPLUNK_AO_HEADER_PREFIX",
     "LoggerModeType",
 )

--- a/src/galileo/constants/tracing.py
+++ b/src/galileo/constants/tracing.py
@@ -1,8 +1,8 @@
 """Constants for distributed tracing."""
 
-from galileo.constants import GALILEO_HEADER_PREFIX
+from galileo.constants import SPLUNK_AO_HEADER_PREFIX
 
 # HTTP header names for propagating distributed tracing context
-# These headers follow the pattern of namespaced custom headers (X-Galileo-*)
-TRACE_ID_HEADER = f"{GALILEO_HEADER_PREFIX}-Trace-ID"
-PARENT_ID_HEADER = f"{GALILEO_HEADER_PREFIX}-Parent-ID"
+# These headers follow the pattern of namespaced custom headers (Splunk-AO-*)
+TRACE_ID_HEADER = f"{SPLUNK_AO_HEADER_PREFIX}-Trace-ID"
+PARENT_ID_HEADER = f"{SPLUNK_AO_HEADER_PREFIX}-Parent-ID"

--- a/src/galileo/decorator.py
+++ b/src/galileo/decorator.py
@@ -29,16 +29,16 @@ How to use decorators:
 
 3. Using context manager for grouping related operations:
    ```python
-   from galileo import galileo_context
+   from galileo import splunk_ao_context
 
-   with galileo_context(project="my-project", log_stream="production"):
+   with splunk_ao_context(project="my-project", log_stream="production"):
        result1 = my_function()
        result2 = another_function()
    ```
 
 Setup requirements:
 - Galileo API key must be set (via environment variable GALILEO_API_KEY or programmatically)
-- Project and Log Stream names should be defined if using the `log` decorator (either via environment variables GALILEO_PROJECT and GALILEO_LOG_STREAM, or via `galileo_context.init()`)
+- Project and Log Stream names should be defined if using the `log` decorator (either via environment variables GALILEO_PROJECT and GALILEO_LOG_STREAM, or via `splunk_ao_context.init()`)
 
 For more examples and detailed usage, see the Galileo SDK documentation.
 """
@@ -194,7 +194,7 @@ class GalileoDecorator:
 
         This allows usage like:
         ```python
-        with galileo_context(project="my_project", log_stream="my_stream"):
+        with splunk_ao_context(project="my_project", log_stream="my_stream"):
             # Code to be traced
         ```
 
@@ -1285,13 +1285,13 @@ class GalileoDecorator:
         self.get_logger_instance().set_session(session_id)
 
 
-galileo_context = GalileoDecorator()
-log = galileo_context.log
-start_session = galileo_context.start_session
+splunk_ao_context = GalileoDecorator()
+log = splunk_ao_context.log
+start_session = splunk_ao_context.start_session
 
 
 @contextmanager
-def galileo_dataset_context(
+def splunk_ao_dataset_context(
     *,
     dataset_input: str | None = None,
     dataset_output: str | None = None,
@@ -1315,10 +1315,10 @@ def galileo_dataset_context(
 
     Examples
     --------
-    >>> from galileo.decorator import galileo_dataset_context
+    >>> from galileo.decorator import splunk_ao_dataset_context
     >>>
     >>> # Set ground truth for a single agent call
-    >>> with galileo_dataset_context(
+    >>> with splunk_ao_dataset_context(
     ...     dataset_input="What is the capital of France?",
     ...     dataset_output="Paris",
     ...     dataset_metadata={"source": "geography_quiz"}
@@ -1327,7 +1327,7 @@ def galileo_dataset_context(
     >>>
     >>> # Use with experiment datasets
     >>> for row in dataset:
-    ...     with galileo_dataset_context(
+    ...     with splunk_ao_dataset_context(
     ...         dataset_input=row["input"],
     ...         dataset_output=row["expected_output"],
     ...     ):

--- a/src/galileo/experiments.py
+++ b/src/galileo/experiments.py
@@ -10,7 +10,7 @@ from attrs import field as _attrs_field
 
 from galileo.config import GalileoPythonConfig
 from galileo.datasets import Dataset, convert_dataset_row_to_record
-from galileo.decorator import galileo_context, galileo_dataset_context, log
+from galileo.decorator import splunk_ao_context, splunk_ao_dataset_context, log
 from galileo.experiment_tags import upsert_experiment_tag
 from galileo.projects import Project, Projects
 from galileo.prompts import PromptTemplate
@@ -234,7 +234,7 @@ class Experiments:
         if dataset_obj is None and records is None:
             raise ValueError("Either dataset_obj or records must be provided")
         results = []
-        galileo_context.init(project=project_obj.name, experiment_id=experiment_obj.id, local_metrics=local_metrics)
+        splunk_ao_context.init(project=project_obj.name, experiment_id=experiment_obj.id, local_metrics=local_metrics)
 
         def logged_process_func(row: DatasetRecord) -> Callable:
             return log(name=experiment_obj.name, dataset_record=row)(func)
@@ -244,10 +244,10 @@ class Experiments:
             _logger.info(f"Processing {len(records)} rows from dataset")
             for row in records:
                 results.append(process_row(row, logged_process_func(row)))
-                galileo_context.reset_trace_context()
+                splunk_ao_context.reset_trace_context()
                 if getsizeof(results) > MAX_REQUEST_SIZE_BYTES or len(results) >= MAX_INGEST_BATCH_SIZE:
                     _logger.info("Flushing logger due to size limit")
-                    galileo_context.flush(on_error=on_error)
+                    splunk_ao_context.flush(on_error=on_error)
                     results = []
         # For dataset object, paginate through content
         elif dataset_obj is not None:
@@ -267,16 +267,16 @@ class Experiments:
 
                     for row in batch_records:
                         results.append(process_row(row, logged_process_func(row)))
-                        galileo_context.reset_trace_context()
+                        splunk_ao_context.reset_trace_context()
                         if getsizeof(results) > MAX_REQUEST_SIZE_BYTES or len(results) >= MAX_INGEST_BATCH_SIZE:
                             _logger.info("Flushing logger due to size limit")
-                            galileo_context.flush(on_error=on_error)
+                            splunk_ao_context.flush(on_error=on_error)
                             results = []
 
                     starting_token += len(batch_records)
 
         # flush the logger
-        galileo_context.flush(on_error=on_error)
+        splunk_ao_context.flush(on_error=on_error)
 
         _logger.info(f" {len(results)} rows processed for experiment {experiment_obj.name}.")
 
@@ -292,9 +292,9 @@ def process_row(row: DatasetRecord, process_func: Callable) -> str:
     try:
         # Set dataset context for OTEL spans (ground truth for scorers)
         # This ensures OTEL-instrumented frameworks get dataset fields attached to their spans
-        with galileo_dataset_context(dataset_input=row.input, dataset_output=row.output, dataset_metadata=row.metadata):
+        with splunk_ao_dataset_context(dataset_input=row.input, dataset_output=row.output, dataset_metadata=row.metadata):
             output = process_func(row.deserialized_input)
-            log = galileo_context.get_logger_instance()
+            log = splunk_ao_context.get_logger_instance()
             log.conclude(output)
     except Exception as exc:
         output = f"error during executing: {process_func.__name__}: {exc}"

--- a/src/galileo/handlers/base_handler.py
+++ b/src/galileo/handlers/base_handler.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
-from galileo import galileo_context
+from galileo import splunk_ao_context
 from galileo.logger import GalileoLogger
 from galileo.schema.handlers import INTEGRATION, NODE_TYPE, Node
 from galileo.schema.trace import TracesIngestRequest
@@ -44,7 +44,7 @@ class GalileoBaseHandler:
         flush_on_chain_end: bool = True,
         ingestion_hook: Callable[[TracesIngestRequest], None] | None = None,
     ):
-        self._galileo_logger: GalileoLogger = galileo_logger or galileo_context.get_logger_instance(
+        self._galileo_logger: GalileoLogger = galileo_logger or splunk_ao_context.get_logger_instance(
             ingestion_hook=ingestion_hook
         )
         if galileo_logger and ingestion_hook:

--- a/src/galileo/handlers/openai_agents/handler.py
+++ b/src/galileo/handlers/openai_agents/handler.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 from agents import Span, Trace, TracingProcessor
 from agents.tracing import ResponseSpanData, get_current_span, get_trace_provider
 
-from galileo import GalileoLogger, galileo_context
+from galileo import GalileoLogger, splunk_ao_context
 from galileo.schema.handlers import Node
 from galileo.utils import _get_timestamp
 from galileo.utils.openai_agents import (
@@ -52,7 +52,7 @@ class GalileoTracingProcessor(TracingProcessor):
         flush_on_trace_end : bool
             Whether to automatically flush the log batch to Galileo when a trace ends.
         """
-        self._galileo_logger: GalileoLogger = galileo_logger or galileo_context.get_logger_instance()
+        self._galileo_logger: GalileoLogger = galileo_logger or splunk_ao_context.get_logger_instance()
         self._flush_on_trace_end: bool = flush_on_trace_end
         self._nodes: dict[str, Node] = {}
         self._last_output: Any = None
@@ -492,7 +492,7 @@ class GalileoTracingProcessor(TracingProcessor):
         return serialize_to_str(item_dict.get("output") or item_dict.get("results"))
 
     @staticmethod
-    def add_galileo_custom_span(span: GalileoSpan) -> Span[GalileoCustomSpan]:
+    def add_splunk_ao_custom_span(span: GalileoSpan) -> Span[GalileoCustomSpan]:
         """Add a Galileo custom span to the trace."""
         trace_provider = get_trace_provider()
         current_span = get_current_span()

--- a/src/galileo/log_stream.py
+++ b/src/galileo/log_stream.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from galileo.config import GalileoPythonConfig
-from galileo.decorator import galileo_context
+from galileo.decorator import splunk_ao_context
 from galileo.export import ExportClient
 from galileo.log_streams import LogStreams
 from galileo.resources.api.trace import (
@@ -820,7 +820,7 @@ class LogStream(StateManagementMixin):
         """
         Get a galileo context manager for this log stream.
 
-        This is a convenient method that returns a pre-configured galileo_context
+        This is a convenient method that returns a pre-configured splunk_ao_context
         for this log stream, eliminating the need to specify project and log stream names.
 
         Returns
@@ -838,7 +838,7 @@ class LogStream(StateManagementMixin):
                 # Your logging code here
                 response = openai_client.chat.completions.create(...)
         """
-        return galileo_context(project=self.project.name if self.project else None, log_stream=self.name)
+        return splunk_ao_context(project=self.project.name if self.project else None, log_stream=self.name)
 
     def _get_columns(self, api_func: Any, error_msg: str) -> LogRecordsAvailableColumnsResponse:
         """Helper method to retrieve available columns from the API."""

--- a/src/galileo/log_streams.py
+++ b/src/galileo/log_streams.py
@@ -68,9 +68,9 @@ class LogStream(LogStreamResponse):
 
     # Use a log stream with the context manager
     from galileo.openai import openai
-    from galileo import galileo_context
+    from galileo import splunk_ao_context
 
-    with galileo_context(project="My AI Project", log_stream="Production Logs"):
+    with splunk_ao_context(project="My AI Project", log_stream="Production Logs"):
         response = openai.chat.completions.create(
             model="gpt-4o",
             messages=[{"role": "user", "content": "Hello, world!"}]

--- a/src/galileo/openai/__init__.py
+++ b/src/galileo/openai/__init__.py
@@ -25,10 +25,10 @@ response = openai.chat.completions.create(
 # All prompts and responses are automatically logged to Galileo
 print(response.choices[0].message.content)
 
-# You can also use it with the galileo_context for more control
-from galileo import galileo_context
+# You can also use it with the splunk_ao_context for more control
+from galileo import splunk_ao_context
 
-with galileo_context(project="my-project", log_stream="my-log-stream"):
+with splunk_ao_context(project="my-project", log_stream="my-log-stream"):
     response = openai.chat.completions.create(
         model="gpt-4o",
         messages=[
@@ -46,11 +46,11 @@ from typing import Any
 import httpx
 from wrapt import wrap_function_wrapper  # type: ignore[import-untyped]
 
-from galileo.decorator import galileo_context
+from galileo.decorator import splunk_ao_context
 from galileo.logger import GalileoLogger
 from galileo.openai.extractors import (
     OpenAiArgsExtractor,
-    convert_to_galileo_message,
+    convert_to_splunk_ao_message,
     extract_data_from_default_response,
     extract_input_data_from_kwargs,
     has_pending_function_calls,
@@ -114,24 +114,24 @@ OPENAI_CLIENT_METHODS = [
 ]
 
 
-def _galileo_wrapper(func: Callable) -> Callable:
-    def _with_galileo(open_ai_definitions: OpenAiModuleDefinition, initialize: Callable) -> Callable:
+def _splunk_ao_wrapper(func: Callable) -> Callable:
+    def _with_splunk_ao(open_ai_definitions: OpenAiModuleDefinition, initialize: Callable) -> Callable:
         def wrapper(wrapped: Callable, instance: Any, args: dict, kwargs: dict) -> Any:
             return func(open_ai_definitions, initialize, wrapped, args, kwargs)
 
         return wrapper
 
-    return _with_galileo
+    return _with_splunk_ao
 
 
-@_galileo_wrapper
+@_splunk_ao_wrapper
 def _wrap(
     open_ai_resource: OpenAiModuleDefinition, initialize: Callable, wrapped: Callable, args: dict, kwargs: dict
 ) -> Any:
     start_time = _get_timestamp()
     arg_extractor = OpenAiArgsExtractor(*args, **kwargs)
 
-    input_data = extract_input_data_from_kwargs(open_ai_resource, start_time, arg_extractor.get_galileo_args())
+    input_data = extract_input_data_from_kwargs(open_ai_resource, start_time, arg_extractor.get_splunk_ao_args())
 
     galileo_logger = _safe_initialize_logger(initialize)
     if galileo_logger is None:
@@ -145,9 +145,9 @@ def _wrap(
         # We will conclude it at the end
         # convert to list of galileo messages since we can't send list of messages to span and want consistency
         if isinstance(input_data.input, list):
-            trace_input_messages = [convert_to_galileo_message(msg) for msg in input_data.input]
+            trace_input_messages = [convert_to_splunk_ao_message(msg) for msg in input_data.input]
         else:
-            trace_input_messages = [convert_to_galileo_message(input_data.input)]
+            trace_input_messages = [convert_to_splunk_ao_message(input_data.input)]
 
         # Serialize with "messages" wrapper for UI compatibility
         trace_input = {"messages": [msg.model_dump(exclude_none=True) for msg in trace_input_messages]}
@@ -187,9 +187,9 @@ def _wrap(
 
         # convert to list of galileo messages since we can't send a regular list to span input
         if isinstance(input_data.input, list):
-            span_input = [convert_to_galileo_message(msg) for msg in input_data.input]
+            span_input = [convert_to_splunk_ao_message(msg) for msg in input_data.input]
         else:
-            span_input = [convert_to_galileo_message(input_data.input)]
+            span_input = [convert_to_splunk_ao_message(input_data.input)]
 
         # Process Responses API output items sequentially if present
         final_conversation_context = span_input.copy()
@@ -226,7 +226,7 @@ def _wrap(
             )
         else:
             # For non-Responses API (chat or completion), create the main span as before
-            span_output = convert_to_galileo_message(completion, "assistant")
+            span_output = convert_to_splunk_ao_message(completion, "assistant")
 
             # Add a span to the current trace or span (if this is a nested trace)
             span = galileo_logger.add_llm_span(
@@ -262,9 +262,9 @@ def _wrap(
                 # For other APIs, add the final span output
                 full_conversation = []
                 if isinstance(input_data.input, list):
-                    full_conversation.extend([convert_to_galileo_message(msg) for msg in input_data.input])
+                    full_conversation.extend([convert_to_splunk_ao_message(msg) for msg in input_data.input])
                 else:
-                    full_conversation.append(convert_to_galileo_message(input_data.input))
+                    full_conversation.append(convert_to_splunk_ao_message(input_data.input))
                 full_conversation.append(span_output)
 
             # Serialize with "messages" wrapper for UI compatibility
@@ -312,7 +312,7 @@ class OpenAIGalileo:
         Optional[GalileoLogger]
             The initialized Galileo logger instance.
         """
-        self._galileo_logger = galileo_context.get_logger_instance()
+        self._galileo_logger = splunk_ao_context.get_logger_instance()
 
         return self._galileo_logger
 

--- a/src/galileo/openai/extractors.py
+++ b/src/galileo/openai/extractors.py
@@ -199,7 +199,7 @@ class OpenAiArgsExtractor:
         }
         self.kwargs = kwargs
 
-    def get_galileo_args(self) -> dict[str, Any]:
+    def get_splunk_ao_args(self) -> dict[str, Any]:
         return {**self.args, **self.kwargs}
 
     def get_openai_args(self) -> dict[str, Any]:
@@ -215,7 +215,7 @@ class OpenAiArgsExtractor:
         return self.kwargs
 
 
-def convert_to_galileo_message(data: Any, default_role: str = "user") -> Message:
+def convert_to_splunk_ao_message(data: Any, default_role: str = "user") -> Message:
     """Convert OpenAI response data to a Galileo Message object."""
     if hasattr(data, "type") and data.type == "function_call":
         tool_call = ToolCall(
@@ -585,7 +585,7 @@ def process_output_items(
 
     # Add the final response message
     if final_message_content:
-        response_message = convert_to_galileo_message(final_message_content, "assistant")
+        response_message = convert_to_splunk_ao_message(final_message_content, "assistant")
         consolidated_output_messages.append(response_message)
 
     # Create the final consolidated output for the LLM span with content and reasoning
@@ -594,7 +594,7 @@ def process_output_items(
         # Otherwise, serialize the array of Messages and reasoning objects into a string
         if final_message_content:
             # Simple case: just a message with no reasoning
-            consolidated_output = convert_to_galileo_message(final_message_content, "assistant")
+            consolidated_output = convert_to_splunk_ao_message(final_message_content, "assistant")
         else:
             # Complex case: serialize the array of Messages and reasoning objects
             # WORKAROUND: Serialize into a string since LLM span output
@@ -613,7 +613,7 @@ def process_output_items(
             messages_serialized = json.dumps(serialized_items, indent=2)
 
             # Create a single Message with the serialized array as content
-            consolidated_output = convert_to_galileo_message(messages_serialized, "assistant")
+            consolidated_output = convert_to_splunk_ao_message(messages_serialized, "assistant")
 
         # Add tool calls if present
         if final_tool_calls:

--- a/src/galileo/openai/response_generator.py
+++ b/src/galileo/openai/response_generator.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from galileo import GalileoLogger
 from galileo.openai.extractors import (
-    convert_to_galileo_message,
+    convert_to_splunk_ao_message,
     extract_streamed_openai_response,
     has_pending_function_calls,
     process_function_call_outputs,
@@ -110,9 +110,9 @@ class ResponseGeneratorSync:
         )
 
         if isinstance(self.input_data.input, list):
-            span_input = [convert_to_galileo_message(msg) for msg in self.input_data.input]
+            span_input = [convert_to_splunk_ao_message(msg) for msg in self.input_data.input]
         else:
-            span_input = [convert_to_galileo_message(self.input_data.input)]
+            span_input = [convert_to_splunk_ao_message(self.input_data.input)]
 
         # probably can create a shared function for handling both streaming and non-streaming
         # Process Responses API output items sequentially if present (same as non-streaming)
@@ -142,7 +142,7 @@ class ResponseGeneratorSync:
                 )
             else:
                 # Fallback: create basic span if no output items
-                span_output = convert_to_galileo_message(completion, "assistant")
+                span_output = convert_to_splunk_ao_message(completion, "assistant")
                 span = self.logger.add_llm_span(
                     input=span_input,
                     output=span_output,
@@ -161,7 +161,7 @@ class ResponseGeneratorSync:
                 span.metrics.num_cached_input_tokens = usage.get("cached_tokens", 0) if usage else 0
         else:
             # For non-Responses API (chat or completion), create the main span as before
-            span_output = convert_to_galileo_message(completion, "assistant")
+            span_output = convert_to_splunk_ao_message(completion, "assistant")
 
             # Add a span to the current trace or span (if this is a nested trace)
             span = self.logger.add_llm_span(
@@ -195,10 +195,10 @@ class ResponseGeneratorSync:
                 # For other APIs, add the final span output
                 full_conversation = []
                 if isinstance(self.input_data.input, list):
-                    full_conversation.extend([convert_to_galileo_message(msg) for msg in self.input_data.input])
+                    full_conversation.extend([convert_to_splunk_ao_message(msg) for msg in self.input_data.input])
                 else:
-                    full_conversation.append(convert_to_galileo_message(self.input_data.input))
-                full_conversation.append(convert_to_galileo_message(completion, "assistant"))
+                    full_conversation.append(convert_to_splunk_ao_message(self.input_data.input))
+                full_conversation.append(convert_to_splunk_ao_message(completion, "assistant"))
 
             # Serialize with "messages" wrapper for UI compatibility
             trace_output = {"messages": [msg.model_dump(exclude_none=True) for msg in full_conversation]}

--- a/src/galileo/otel.py
+++ b/src/galileo/otel.py
@@ -211,7 +211,7 @@ class GalileoSpanProcessor(SpanProcessor):
     >>> from opentelemetry.sdk.trace import TracerProvider
     >>> tracer_provider = TracerProvider()
     >>> processor = GalileoSpanProcessor(project="my-project")
-    >>> add_galileo_span_processor(tracer_provider, processor)
+    >>> add_splunk_ao_span_processor(tracer_provider, processor)
     """
 
     def __init__(
@@ -312,7 +312,7 @@ class GalileoSpanProcessor(SpanProcessor):
         return self._processor
 
 
-def add_galileo_span_processor(tracer_provider: TracerProvider, processor: GalileoSpanProcessor) -> None:
+def add_splunk_ao_span_processor(tracer_provider: TracerProvider, processor: GalileoSpanProcessor) -> None:
     """Add the Galileo span processor to the tracer provider."""
     tracer_provider.add_span_processor(processor)
     _TRACE_PROVIDER_CONTEXT_VAR.set(tracer_provider)
@@ -401,7 +401,7 @@ def _set_workflow_span_attributes(span: trace.Span, galileo_span: WorkflowSpan) 
 
 
 @contextmanager
-def start_galileo_span(galileo_span: GalileoSpan) -> Generator[trace.Span, Any, None]:
+def start_splunk_ao_span(galileo_span: GalileoSpan) -> Generator[trace.Span, Any, None]:
     tracer_provider = _TRACE_PROVIDER_CONTEXT_VAR.get()
     if tracer_provider is None:
         tracer_provider = trace.get_tracer_provider()

--- a/src/galileo/tracing.py
+++ b/src/galileo/tracing.py
@@ -1,6 +1,6 @@
 """Utilities for distributed tracing with Galileo."""
 
-from galileo.decorator import galileo_context
+from galileo.decorator import splunk_ao_context
 
 
 def get_tracing_headers() -> dict[str, str]:
@@ -42,4 +42,4 @@ def get_tracing_headers() -> dict[str, str]:
             )
     ```
     """
-    return galileo_context.get_logger_instance().get_tracing_headers()
+    return splunk_ao_context.get_logger_instance().get_tracing_headers()

--- a/src/galileo/utils/decorators/__init__.py
+++ b/src/galileo/utils/decorators/__init__.py
@@ -14,15 +14,15 @@ from galileo.utils.decorators.exception_handling import (
     retry_on_transient_http_error,
     warn_catch_exception,
 )
-from galileo.utils.decorators.telemetry_toggle import galileo_logging_enabled, nop_async, nop_sync
+from galileo.utils.decorators.telemetry_toggle import nop_async, nop_sync, splunk_ao_logging_enabled
 
 __all__ = [
     "INFRASTRUCTURE_EXCEPTIONS",
     "RETRYABLE_STATUS_CODES",
     "async_warn_catch_exception",
-    "galileo_logging_enabled",
     "nop_async",
     "nop_sync",
     "retry_on_transient_http_error",
+    "splunk_ao_logging_enabled",
     "warn_catch_exception",
 ]

--- a/src/galileo/utils/decorators/telemetry_toggle.py
+++ b/src/galileo/utils/decorators/telemetry_toggle.py
@@ -14,7 +14,7 @@ from typing import Any
 _logger = logging.getLogger(__name__)
 
 
-def galileo_logging_enabled() -> bool:
+def splunk_ao_logging_enabled() -> bool:
     """
     Check if Galileo logging/telemetry is enabled.
 
@@ -46,7 +46,7 @@ def nop_sync(f: Callable) -> Callable:
 
     @functools.wraps(f)
     def decorated(*args: Any, **kwargs: Any) -> Any:
-        if galileo_logging_enabled():
+        if splunk_ao_logging_enabled():
             return f(*args, **kwargs)
         _logger.debug(f"Bypassing logging for {f.__name__}. Logging is currently disabled.")
         return None
@@ -74,7 +74,7 @@ def nop_async(f: Callable) -> Callable:
 
     @functools.wraps(f)
     async def decorated(*args: Any, **kwargs: Any) -> Any:
-        if galileo_logging_enabled():
+        if splunk_ao_logging_enabled():
             return await f(*args, **kwargs)
         _logger.debug(f"Bypassing logging for {f.__name__}. Logging is currently disabled.")
         return None

--- a/src/galileo/utils/headers_data.py
+++ b/src/galileo/utils/headers_data.py
@@ -61,7 +61,7 @@ def get_method_name() -> str:
 
 
 def get_sdk_header() -> str:
-    """Build the X-Galileo-SDK header value."""
+    """Build the Splunk-AO-SDK header value."""
     version = get_package_version()
     method_name = get_method_name()
 

--- a/tests/test_agent_control.py
+++ b/tests/test_agent_control.py
@@ -6,7 +6,7 @@ import pytest
 
 from galileo import AgentControlTarget, AgentControlTargetUnresolvedError, get_agent_control_target
 from galileo.constants import DEFAULT_LOG_STREAM_NAME, DEFAULT_PROJECT_NAME
-from galileo.decorator import galileo_context
+from galileo.decorator import splunk_ao_context
 from galileo.utils.singleton import GalileoLoggerSingleton
 
 
@@ -20,14 +20,14 @@ def reset_agent_control_helper_state(monkeypatch):
     GalileoLoggerSingleton().reset_all()
     monkeypatch.setattr(GalileoLoggerSingleton, "get_all_loggers", lambda self: {})
     monkeypatch.setattr(
-        galileo_context, "get_logger_instance", lambda *args, **kwargs: SimpleNamespace(flush=lambda: None)
+        splunk_ao_context, "get_logger_instance", lambda *args, **kwargs: SimpleNamespace(flush=lambda: None)
     )
-    galileo_context.reset()
+    splunk_ao_context.reset()
 
     yield
 
     # Then: context and singleton state are restored for following tests
-    galileo_context.reset()
+    splunk_ao_context.reset()
     GalileoLoggerSingleton().reset_all()
 
 
@@ -128,7 +128,7 @@ def test_get_agent_control_target_uses_cached_context_logger(monkeypatch) -> Non
     _stub_cached_logger(monkeypatch, logger)
 
     # When: resolving an Agent Control target
-    with galileo_context(project="project-a", log_stream="stream-a"):
+    with splunk_ao_context(project="project-a", log_stream="stream-a"):
         target = get_agent_control_target()
 
     # Then: the helper reads the resolved IDs without creating a new logger

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -5,7 +5,7 @@ from uuid import UUID
 import pytest
 from pydantic import BaseModel
 
-from galileo import Message, MessageRole, galileo_context, log, start_session
+from galileo import Message, MessageRole, splunk_ao_context, log, start_session
 from galileo.decorator import _session_id_context
 from galileo.schema.content_blocks import DataContentBlock, TextContentBlock
 from galileo_core.schemas.logging.span import AgentSpan, LlmSpan, RetrieverSpan, ToolSpan, WorkflowSpan
@@ -16,9 +16,9 @@ from tests.testutils.setup import setup_mock_logstreams_client, setup_mock_proje
 
 @pytest.fixture
 def reset_context():
-    galileo_context.reset()
+    splunk_ao_context.reset()
     yield
-    galileo_context.reset()
+    splunk_ao_context.reset()
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -31,27 +31,27 @@ def test_decorator_context_reset(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
     @log(span_type="llm")
     def llm_call(query: str) -> str:
         return "response"
 
-    assert galileo_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_trace() is None
 
     llm_call(query="input")
 
-    assert len(galileo_context.get_logger_instance().traces) == 1
-    assert galileo_context.get_current_trace() is not None
-    assert galileo_context.get_current_project() == "project-X"
-    assert galileo_context.get_current_log_stream() == "log-stream-X"
+    assert len(splunk_ao_context.get_logger_instance().traces) == 1
+    assert splunk_ao_context.get_current_trace() is not None
+    assert splunk_ao_context.get_current_project() == "project-X"
+    assert splunk_ao_context.get_current_log_stream() == "log-stream-X"
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
 
-    assert len(galileo_context.get_logger_instance().traces) == 0
-    assert galileo_context.get_current_trace() is None
-    assert galileo_context.get_current_project() is None
-    assert galileo_context.get_current_log_stream() is None
+    assert len(splunk_ao_context.get_logger_instance().traces) == 0
+    assert splunk_ao_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_project() is None
+    assert splunk_ao_context.get_current_log_stream() is None
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -64,15 +64,15 @@ def test_decorator_context_init(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
-    assert galileo_context.get_current_project() == "project-X"
-    assert galileo_context.get_current_log_stream() == "log-stream-X"
+    assert splunk_ao_context.get_current_project() == "project-X"
+    assert splunk_ao_context.get_current_log_stream() == "log-stream-X"
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
 
-    assert galileo_context.get_current_project() is None
-    assert galileo_context.get_current_log_stream() is None
+    assert splunk_ao_context.get_current_project() is None
+    assert splunk_ao_context.get_current_log_stream() is None
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -89,13 +89,13 @@ def test_decorator_context_flush(
     def llm_call(query: str) -> str:
         return "response"
 
-    assert galileo_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_trace() is None
 
     llm_call(query="input")
 
-    assert galileo_context.get_current_trace() is not None
+    assert splunk_ao_context.get_current_trace() is not None
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     # Check if ingest_traces (async) was called instead of ingest_traces
     if mock_traces_client_instance.ingest_traces.call_args is not None:
@@ -105,8 +105,8 @@ def test_decorator_context_flush(
 
     assert len(payload.traces) == 1
     assert len(payload.traces[0].spans) == 1
-    assert galileo_context.get_current_trace() is None
-    assert galileo_context.get_current_span_stack() == []
+    assert splunk_ao_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_span_stack() == []
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -119,43 +119,43 @@ def test_decorator_context_flush_specific_project_and_log_stream(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
     @log(span_type="llm")
     def llm_call(query: str) -> str:
         return "response"
 
-    assert galileo_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_trace() is None
 
     llm_call(query="input")
 
-    assert galileo_context.get_current_trace() is not None
+    assert splunk_ao_context.get_current_trace() is not None
 
-    galileo_context.init(project="project-Y", log_stream="log-stream-Y")
+    splunk_ao_context.init(project="project-Y", log_stream="log-stream-Y")
 
-    assert galileo_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_trace() is None
 
     llm_call(query="input")
 
-    assert galileo_context.get_current_trace() is not None
+    assert splunk_ao_context.get_current_trace() is not None
 
-    galileo_context.flush(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.flush(project="project-X", log_stream="log-stream-X")
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1
     assert len(payload.traces[0].spans) == 1
 
-    assert galileo_context.get_current_trace() is not None
+    assert splunk_ao_context.get_current_trace() is not None
 
-    galileo_context.flush(project="project-Y", log_stream="log-stream-Y")
+    splunk_ao_context.flush(project="project-Y", log_stream="log-stream-Y")
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1
     assert len(payload.traces[0].spans) == 1
 
-    assert galileo_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_trace() is None
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -172,37 +172,37 @@ def test_decorator_context_flush_all(
     def llm_call(query: str) -> str:
         return "response"
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
     llm_call(query="input_X")
 
-    trace_X = galileo_context.get_current_trace()
+    trace_X = splunk_ao_context.get_current_trace()
     assert trace_X.input == '{"query": "input_X"}'
 
-    logger_X = galileo_context.get_logger_instance(project="project-X", log_stream="log-stream-X")
+    logger_X = splunk_ao_context.get_logger_instance(project="project-X", log_stream="log-stream-X")
     assert len(logger_X.traces) == 1
 
-    galileo_context.init(project="project-Y", log_stream="log-stream-Y")
+    splunk_ao_context.init(project="project-Y", log_stream="log-stream-Y")
 
     llm_call(query="input_Y")
 
-    trace_Y = galileo_context.get_current_trace()
+    trace_Y = splunk_ao_context.get_current_trace()
     assert trace_Y.input == '{"query": "input_Y"}'
 
-    logger_Y = galileo_context.get_logger_instance(project="project-Y", log_stream="log-stream-Y")
+    logger_Y = splunk_ao_context.get_logger_instance(project="project-Y", log_stream="log-stream-Y")
     assert len(logger_Y.traces) == 1
 
     # Flush both loggers
-    galileo_context.flush_all()
+    splunk_ao_context.flush_all()
 
-    logger_X = galileo_context.get_logger_instance(project="project-X", log_stream="log-stream-X")
+    logger_X = splunk_ao_context.get_logger_instance(project="project-X", log_stream="log-stream-X")
     assert len(logger_X.traces) == 0
 
-    logger_Y = galileo_context.get_logger_instance(project="project-Y", log_stream="log-stream-Y")
+    logger_Y = splunk_ao_context.get_logger_instance(project="project-Y", log_stream="log-stream-Y")
     assert len(logger_Y.traces) == 0
 
-    assert galileo_context.get_current_trace() is None
-    assert galileo_context.get_current_span_stack() == []
+    assert splunk_ao_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_span_stack() == []
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -220,7 +220,7 @@ def test_decorator_llm_span(
         return "response"
 
     llm_call(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -247,7 +247,7 @@ def test_decorator_workflow_span_output_int(
         return arg1 + arg2
 
     my_function(1, 2)
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -276,7 +276,7 @@ def test_decorator_workflow_span_io_object(
     my_function(
         Message(content="system prompt", role=MessageRole.system), Message(content="query", role=MessageRole.user)
     )
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -311,7 +311,7 @@ def test_decorator_tool_span_io_object(
     my_function(
         Message(content="system prompt", role=MessageRole.system), Message(content="query", role=MessageRole.user)
     )
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -344,7 +344,7 @@ def test_decorator_agent_span(
         return f"{arg1} {arg2}"
 
     my_function("arg1", "arg2")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -371,7 +371,7 @@ def test_decorator_agent_span_with_agent_type(
         return f"{arg1} {arg2}"
 
     my_function("arg1", "arg2")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -403,7 +403,7 @@ def test_decorator_agent_span_with_nested_span(
         return my_tool_function(arg1)
 
     my_function("arg1", "arg2")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -440,7 +440,7 @@ def test_decorator_nested_span(
         return llm_call(query=nested_query)
 
     output = nested_call(nested_query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -477,7 +477,7 @@ def test_decorator_multiple_nested_spans(
         return "new response"
 
     output = nested_call(nested_query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -509,7 +509,7 @@ def test_decorator_retriever_span_str(
         return "response1"
 
     retriever_call(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -533,7 +533,7 @@ def test_decorator_retriever_span_list_str(
         return ["response1", "response2"]
 
     retriever_call(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -560,7 +560,7 @@ def test_decorator_retriever_span_list_dict(
         return [{"content": "response1", "metadata": {"key": "value"}}, {"content": "response2", "metadata": None}]
 
     retriever_call(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -587,7 +587,7 @@ def test_decorator_retriever_span_list_document(
         return [Document(content="response1", metadata={"key": "value"}), Document(content="response2", metadata=None)]
 
     retriever_call(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -616,7 +616,7 @@ def test_decorator_we_should_create_trace_but_reraise_exception(
     with pytest.raises(Exception):
         foo()
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -639,14 +639,14 @@ def test_decorator_start_session(
         return "response"
 
     foo()
-    galileo_context.start_session(
+    splunk_ao_context.start_session(
         name="test-session", previous_session_id="6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9e", external_id="test"
     )
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     assert logger.session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -673,11 +673,11 @@ def test_standalone_start_session(
         name="test-session", previous_session_id="6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9e", external_id="test"
     )
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     assert logger.session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
     assert session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -699,12 +699,12 @@ def test_decorator_start_session_empty_values(
         return "response"
 
     foo()
-    galileo_context.start_session()
+    splunk_ao_context.start_session()
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     assert logger.session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -726,16 +726,16 @@ def test_decorator_clear_session(
         return "response"
 
     foo()
-    galileo_context.start_session(name="test-session")
+    splunk_ao_context.start_session(name="test-session")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     assert logger.session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
 
-    galileo_context.clear_session()
+    splunk_ao_context.clear_session()
 
     assert logger.session_id is None
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -757,12 +757,12 @@ def test_decorator_set_session(
         return "response"
 
     foo()
-    galileo_context.set_session(session_id="6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c")
+    splunk_ao_context.set_session(session_id="6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     assert logger.session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -804,7 +804,7 @@ def test_decorator_input_serialization_deserialization(
     complex_input = {"nested": {"key": "value", "number": 42}, "list": [1, 2, 3], "string": "test"}
 
     my_function(complex_input=complex_input)
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -832,7 +832,7 @@ def test_decorator_llm_span_list_output_serialization(
         return ["response1", "response2", "response3"]
 
     llm_call_returning_list(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -858,7 +858,7 @@ def test_decorator_llm_span_tuple_output_serialization(
         return ("response1", "response2")
 
     llm_call_returning_tuple(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -885,7 +885,7 @@ def test_decorator_llm_span_dict_output_preserved(
         return {"response": "value", "number": 42}
 
     llm_call_returning_dict(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -917,7 +917,7 @@ def test_decorator_workflow_span_complex_output_serialization(
         }
 
     workflow_with_complex_output(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -945,7 +945,7 @@ def test_decorator_pydantic_model_input_serialization(
 
     test_model = TestPydanticModel(name="test", value=42)
     process_model(model=test_model)
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -973,7 +973,7 @@ def test_decorator_pydantic_model_output_serialization(
         return TestPydanticModel(name=name, value=value)
 
     create_model(name="output_test", value=123)
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -1000,7 +1000,7 @@ def test_decorator_null_output_handling(
         return None
 
     function_returning_none(query="input")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -1026,7 +1026,7 @@ def test_decorator_tool_span_output_serialization(
         return {"tool_result": input_data, "status": "success", "items": [1, 2, 3]}
 
     tool_with_complex_output(input_data="test")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -1054,7 +1054,7 @@ def test_decorator_agent_span_output_serialization(
         return {"agent_response": query, "confidence": 0.95, "actions": ["analyze", "respond"]}
 
     agent_with_complex_output(query="test query")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     span = payload.traces[0].spans[0]
@@ -1088,7 +1088,7 @@ def test_decorator_workflow_content_blocks_output_preserved(
 
     # When: the workflow is executed and flushed
     workflow_returning_content_blocks(query="analyze this")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     # Then: content blocks are preserved as a list on the trace (not stringified)
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
@@ -1123,7 +1123,7 @@ def test_decorator_workflow_message_list_output_serialized(
 
     # When: the workflow is executed and flushed
     workflow_returning_messages(query="chat")
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     # Then: messages are serialized to string on the trace (not preserved as list)
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
@@ -1149,9 +1149,9 @@ def test_mode_context_init_default(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
-    assert galileo_context.get_current_mode() == "batch"
+    assert splunk_ao_context.get_current_mode() == "batch"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1165,9 +1165,9 @@ def test_mode_context_init_explicit(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="distributed")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="distributed")
 
-    assert galileo_context.get_current_mode() == "distributed"
+    assert splunk_ao_context.get_current_mode() == "distributed"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1181,8 +1181,8 @@ def test_mode_context_call_default(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    with galileo_context(project="project-X", log_stream="log-stream-X"):
-        assert galileo_context.get_current_mode() == "batch"
+    with splunk_ao_context(project="project-X", log_stream="log-stream-X"):
+        assert splunk_ao_context.get_current_mode() == "batch"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1196,8 +1196,8 @@ def test_mode_context_call_explicit(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    with galileo_context(project="project-X", log_stream="log-stream-X", mode="distributed"):
-        assert galileo_context.get_current_mode() == "distributed"
+    with splunk_ao_context(project="project-X", log_stream="log-stream-X", mode="distributed"):
+        assert splunk_ao_context.get_current_mode() == "distributed"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1212,15 +1212,15 @@ def test_mode_context_nested_push_pop(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # Set initial mode
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
-    assert galileo_context.get_current_mode() == "batch"
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
+    assert splunk_ao_context.get_current_mode() == "batch"
 
     # Enter nested context with different mode
-    with galileo_context(project="project-Y", log_stream="log-stream-Y", mode="distributed"):
-        assert galileo_context.get_current_mode() == "distributed"
+    with splunk_ao_context(project="project-Y", log_stream="log-stream-Y", mode="distributed"):
+        assert splunk_ao_context.get_current_mode() == "distributed"
 
     # After exiting, mode should be restored
-    assert galileo_context.get_current_mode() == "batch"
+    assert splunk_ao_context.get_current_mode() == "batch"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1235,22 +1235,22 @@ def test_mode_context_multiple_nested_levels(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # Set initial mode
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
-    assert galileo_context.get_current_mode() == "batch"
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
+    assert splunk_ao_context.get_current_mode() == "batch"
 
     # First nested level
-    with galileo_context(project="project-Y", log_stream="log-stream-Y", mode="distributed"):
-        assert galileo_context.get_current_mode() == "distributed"
+    with splunk_ao_context(project="project-Y", log_stream="log-stream-Y", mode="distributed"):
+        assert splunk_ao_context.get_current_mode() == "distributed"
 
         # Second nested level - defaults back to batch
-        with galileo_context(project="project-Z", log_stream="log-stream-Z"):
-            assert galileo_context.get_current_mode() == "batch"
+        with splunk_ao_context(project="project-Z", log_stream="log-stream-Z"):
+            assert splunk_ao_context.get_current_mode() == "batch"
 
         # Back to first nested level
-        assert galileo_context.get_current_mode() == "distributed"
+        assert splunk_ao_context.get_current_mode() == "distributed"
 
     # Back to original
-    assert galileo_context.get_current_mode() == "batch"
+    assert splunk_ao_context.get_current_mode() == "batch"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1264,11 +1264,11 @@ def test_mode_context_reset(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="distributed")
-    assert galileo_context.get_current_mode() == "distributed"
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="distributed")
+    assert splunk_ao_context.get_current_mode() == "distributed"
 
-    galileo_context.reset()
-    assert galileo_context.get_current_mode() == "batch"
+    splunk_ao_context.reset()
+    assert splunk_ao_context.get_current_mode() == "batch"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1283,23 +1283,23 @@ def test_mode_flush_with_explicit_mode(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # Initialize with batch mode
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
 
     @log(span_type="llm")
     def llm_call(query: str) -> str:
         return "response"
 
     llm_call(query="input")
-    assert galileo_context.get_current_trace() is not None
+    assert splunk_ao_context.get_current_trace() is not None
 
     # Flush with explicit mode
-    galileo_context.flush(project="project-X", log_stream="log-stream-X", mode="batch")
+    splunk_ao_context.flush(project="project-X", log_stream="log-stream-X", mode="batch")
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
     assert len(payload.traces) == 1
 
     # Trace context should be reset since we flushed the current context
-    assert galileo_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_trace() is None
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1314,23 +1314,23 @@ def test_mode_flush_different_mode_no_reset(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # Initialize with batch mode
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
 
     @log(span_type="llm")
     def llm_call(query: str) -> str:
         return "response"
 
     llm_call(query="input")
-    current_trace = galileo_context.get_current_trace()
+    current_trace = splunk_ao_context.get_current_trace()
     assert current_trace is not None
 
     # Flush with a different mode shouldn't reset the current trace context
     # Since the logger instances are different
-    galileo_context.flush(project="project-X", log_stream="log-stream-X", mode="distributed")
+    splunk_ao_context.flush(project="project-X", log_stream="log-stream-X", mode="distributed")
 
     # Current trace should still exist since we didn't flush the batch mode instance
-    assert galileo_context.get_current_trace() is not None
-    assert galileo_context.get_current_trace() == current_trace
+    assert splunk_ao_context.get_current_trace() is not None
+    assert splunk_ao_context.get_current_trace() == current_trace
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1346,9 +1346,9 @@ def test_mode_from_environment_variable(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # When mode is not specified, it should use the environment variable
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
-    assert galileo_context.get_current_mode() == "distributed"
+    assert splunk_ao_context.get_current_mode() == "distributed"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1364,9 +1364,9 @@ def test_mode_explicit_overrides_environment(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # Explicit mode should override environment variable
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
 
-    assert galileo_context.get_current_mode() == "batch"
+    assert splunk_ao_context.get_current_mode() == "batch"
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1381,11 +1381,11 @@ def test_get_logger_instance_with_explicit_mode(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # Initialize with batch mode
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
 
     # Get logger instance with different mode
-    logger_batch = galileo_context.get_logger_instance(project="project-X", log_stream="log-stream-X", mode="batch")
-    logger_distributed = galileo_context.get_logger_instance(
+    logger_batch = splunk_ao_context.get_logger_instance(project="project-X", log_stream="log-stream-X", mode="batch")
+    logger_distributed = splunk_ao_context.get_logger_instance(
         project="project-X", log_stream="log-stream-X", mode="distributed"
     )
 
@@ -1408,7 +1408,7 @@ def test_multiple_workflow_calls_create_one_trace_with_multiple_spans(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X", mode="batch")
 
     @log(span_type="workflow")
     def process_query(query: str) -> str:
@@ -1425,7 +1425,7 @@ def test_multiple_workflow_calls_create_one_trace_with_multiple_spans(
     assert result3 == "Processed: query 3"
 
     # Before flush, verify only 1 trace was created with 3 workflow spans
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     assert len(logger.traces) == 1, f"Expected 1 trace, got {len(logger.traces)}"
 
     # Verify the single trace has 3 workflow spans
@@ -1438,7 +1438,7 @@ def test_multiple_workflow_calls_create_one_trace_with_multiple_spans(
     assert trace.spans[2].input == '{"query": "query 3"}'
 
     # Flush the trace
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     # Verify ingest_traces was called with 1 trace containing 3 spans
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
@@ -1446,7 +1446,7 @@ def test_multiple_workflow_calls_create_one_trace_with_multiple_spans(
     assert len(payload.traces[0].spans) == 3
 
     # After flush, trace context should be cleared
-    assert galileo_context.get_current_trace() is None
+    assert splunk_ao_context.get_current_trace() is None
     assert len(logger.traces) == 0
 
 
@@ -1467,9 +1467,9 @@ def test_session_id_context_manager(
     def foo() -> str:
         return "response"
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
-    with galileo_context(session_id=test_session_id):
-        assert galileo_context.get_logger_instance().session_id == test_session_id
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
+    with splunk_ao_context(session_id=test_session_id):
+        assert splunk_ao_context.get_logger_instance().session_id == test_session_id
         foo()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
@@ -1491,19 +1491,19 @@ def test_session_id_nested_context_stacking(
     session_2 = "3c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9d"
 
     # No session initially
-    assert galileo_context.get_logger_instance().session_id is None
+    assert splunk_ao_context.get_logger_instance().session_id is None
 
-    with galileo_context(project="p1", log_stream="s1", session_id=session_1):
-        assert galileo_context.get_logger_instance().session_id == session_1
+    with splunk_ao_context(project="p1", log_stream="s1", session_id=session_1):
+        assert splunk_ao_context.get_logger_instance().session_id == session_1
 
-        with galileo_context(project="p2", log_stream="s2", session_id=session_2):
-            assert galileo_context.get_logger_instance().session_id == session_2
+        with splunk_ao_context(project="p2", log_stream="s2", session_id=session_2):
+            assert splunk_ao_context.get_logger_instance().session_id == session_2
 
         # Restored after nested context exits
-        assert galileo_context.get_logger_instance().session_id == session_1
+        assert splunk_ao_context.get_logger_instance().session_id == session_1
 
     # Cleared after all contexts exit
-    assert galileo_context.get_logger_instance().session_id is None
+    assert splunk_ao_context.get_logger_instance().session_id is None
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1517,19 +1517,19 @@ def test_session_id_cleared_on_reset_and_init(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
-    galileo_context.start_session(name="test-session")
-    assert galileo_context.get_logger_instance().session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.start_session(name="test-session")
+    assert splunk_ao_context.get_logger_instance().session_id == "6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9c"
 
     # Reset clears session
-    galileo_context.reset()
-    assert galileo_context.get_logger_instance().session_id is None
+    splunk_ao_context.reset()
+    assert splunk_ao_context.get_logger_instance().session_id is None
 
     # Re-init also clears session
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
-    galileo_context.start_session(name="test-session")
-    galileo_context.init(project="project-Y", log_stream="log-stream-Y")
-    assert galileo_context.get_logger_instance().session_id is None
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.start_session(name="test-session")
+    splunk_ao_context.init(project="project-Y", log_stream="log-stream-Y")
+    assert splunk_ao_context.get_logger_instance().session_id is None
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -1545,12 +1545,12 @@ def test_start_session_overrides_context_session(
 
     context_session = "6d4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9d"
 
-    with galileo_context(project="test-project", log_stream="test-stream", session_id=context_session):
-        assert galileo_context.get_logger_instance().session_id == context_session
+    with splunk_ao_context(project="test-project", log_stream="test-stream", session_id=context_session):
+        assert splunk_ao_context.get_logger_instance().session_id == context_session
 
         # start_session overrides context session
-        new_session_id = galileo_context.start_session(name="new-session")
-        assert galileo_context.get_logger_instance().session_id == new_session_id
+        new_session_id = splunk_ao_context.start_session(name="new-session")
+        assert splunk_ao_context.get_logger_instance().session_id == new_session_id
         assert _session_id_context.get() == new_session_id
 
 
@@ -1569,7 +1569,7 @@ def test_flush_on_error_called_when_flush_raises(
 
     on_error = Mock()
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
     @log(span_type="llm")
     def llm_call(query: str) -> str:
@@ -1578,7 +1578,7 @@ def test_flush_on_error_called_when_flush_raises(
     llm_call(query="input")
 
     # When: flush is called with on_error
-    galileo_context.flush(on_error=on_error)
+    splunk_ao_context.flush(on_error=on_error)
 
     # Then: on_error is invoked with the exception; no warning is raised
     on_error.assert_called_once()
@@ -1597,7 +1597,7 @@ def test_flush_warns_when_flush_raises_without_on_error(
     setup_mock_logstreams_client(mock_logstreams_client)
     mock_traces_client_instance.ingest_traces.side_effect = RuntimeError("network error")
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
     @log(span_type="llm")
     def llm_call(query: str) -> str:
@@ -1608,7 +1608,7 @@ def test_flush_warns_when_flush_raises_without_on_error(
     # When/Then: flush does not raise; a warning is logged instead
 
     with patch("galileo.decorator._logger") as mock_logger:
-        galileo_context.flush()
+        splunk_ao_context.flush()
         mock_logger.warning.assert_called_once()
         assert "flush failed" in mock_logger.warning.call_args[0][0]
 
@@ -1628,7 +1628,7 @@ def test_flush_on_error_callback_raises_is_swallowed(
     def bad_callback(exc: Exception) -> None:
         raise ValueError("callback failed")
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
     @log(span_type="llm")
     def llm_call(query: str) -> str:
@@ -1638,7 +1638,7 @@ def test_flush_on_error_callback_raises_is_swallowed(
 
     # When/Then: flush does not raise even though the callback raises
     with patch("galileo.decorator._logger") as mock_logger:
-        galileo_context.flush(on_error=bad_callback)  # must not raise
+        splunk_ao_context.flush(on_error=bad_callback)  # must not raise
         mock_logger.warning.assert_called_once()
         assert "on_error callback raised" in mock_logger.warning.call_args[0][0]
 
@@ -1655,7 +1655,7 @@ def test_flush_on_error_logs_at_debug_not_warning(
     setup_mock_logstreams_client(mock_logstreams_client)
     mock_traces_client_instance.ingest_traces.side_effect = RuntimeError("network error")
 
-    galileo_context.init(project="project-X", log_stream="log-stream-X")
+    splunk_ao_context.init(project="project-X", log_stream="log-stream-X")
 
     @log(span_type="llm")
     def llm_call(query: str) -> str:
@@ -1665,7 +1665,7 @@ def test_flush_on_error_logs_at_debug_not_warning(
 
     # When: flush is called with on_error
     with patch("galileo.decorator._logger") as mock_logger:
-        galileo_context.flush(on_error=Mock())
+        splunk_ao_context.flush(on_error=Mock())
 
         # Then: debug is called, not warning
         mock_logger.debug.assert_called_once()

--- a/tests/test_decorator_distributed.py
+++ b/tests/test_decorator_distributed.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from galileo import Message, MessageRole, galileo_context, log
+from galileo import Message, MessageRole, splunk_ao_context, log
 from galileo.constants.tracing import PARENT_ID_HEADER, TRACE_ID_HEADER
 from galileo.decorator import _parent_id_context, _trace_id_context
 from galileo.schema.content_blocks import DataContentBlock, TextContentBlock
@@ -25,9 +25,9 @@ from tests.testutils.setup import (
 @pytest.fixture
 def reset_context():
     """Reset the decorator context before each test."""
-    galileo_context.reset()
+    splunk_ao_context.reset()
     yield
-    galileo_context.reset()
+    splunk_ao_context.reset()
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def test_decorator_get_tracing_headers(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
     @log(span_type="workflow")
     def orchestrator(query: str) -> dict:
@@ -72,7 +72,7 @@ def test_decorator_get_tracing_headers(
     assert PARENT_ID_HEADER in headers
 
     # Verify the trace ID matches the logger's trace
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     assert headers[TRACE_ID_HEADER] == str(logger.traces[0].id)
 
 
@@ -91,7 +91,7 @@ def test_decorator_with_middleware_context(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
     # Simulate middleware setting context variables
     trace_id = "12345678-1234-4678-9abc-123456789abc"
@@ -109,7 +109,7 @@ def test_decorator_with_middleware_context(
     assert result == "processed: test input"
 
     # Verify logger was created with distributed tracing context
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     assert logger.mode == "distributed"
     assert len(logger.traces) == 1
 
@@ -133,9 +133,9 @@ def test_decorator_updates_trace_with_output_and_duration(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     @log(span_type="workflow")
@@ -196,7 +196,7 @@ def test_decorator_server_side_does_not_conclude_trace(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
     # Simulate middleware setting context variables (server receiving trace_id/span_id)
     trace_id = "12345678-1234-4678-9abc-123456789abc"
@@ -205,7 +205,7 @@ def test_decorator_server_side_does_not_conclude_trace(
     _trace_id_context.set(trace_id)
     _parent_id_context.set(parent_id)
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     @log(span_type="workflow")
@@ -244,10 +244,10 @@ def test_decorator_client_and_server_side_behavior(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
     # CLIENT SIDE: Start a new trace
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture_client = setup_thread_pool_request_capture(logger)
 
     @log(span_type="workflow")
@@ -288,8 +288,8 @@ def test_decorator_client_and_server_side_behavior(
     assert client_trace_request.is_complete, "Trace should be marked complete"
 
     # Reset context for server-side test
-    galileo_context.reset()
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.reset()
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
     # SERVER SIDE: Receive distributed tracing headers
     trace_id = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
@@ -298,7 +298,7 @@ def test_decorator_client_and_server_side_behavior(
     _trace_id_context.set(trace_id)
     _parent_id_context.set(parent_id)
 
-    logger_server = galileo_context.get_logger_instance()
+    logger_server = splunk_ao_context.get_logger_instance()
     capture_server = setup_thread_pool_request_capture(logger_server)
 
     @log(span_type="workflow")
@@ -335,9 +335,9 @@ def test_decorator_workflow_span_output_is_set(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     @log(span_type="workflow")
@@ -385,9 +385,9 @@ def test_decorator_both_trace_and_workflow_span_have_output(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     # @log without span_type creates a workflow span, and starts a trace if needed
@@ -451,9 +451,9 @@ def test_decorator_workflow_span_empty_string_output_is_set(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     @log(span_type="workflow")
@@ -495,9 +495,9 @@ def test_decorator_trace_duration_is_set_and_accumulates(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     @log(span_type="workflow")
@@ -558,9 +558,9 @@ def test_decorator_distributed_content_blocks_preserved_on_trace(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     blocks = [
@@ -604,9 +604,9 @@ def test_decorator_distributed_messages_serialized_on_trace(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     @log(span_type="workflow")
@@ -645,9 +645,9 @@ def test_decorator_distributed_documents_serialized_on_trace(
     setup_mock_projects_client(mock_projects_client)
     setup_mock_logstreams_client(mock_logstreams_client)
 
-    galileo_context.init(project="test-project", log_stream="test-stream")
+    splunk_ao_context.init(project="test-project", log_stream="test-stream")
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     capture = setup_thread_pool_request_capture(logger)
 
     @log(span_type="workflow")

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -14,7 +14,7 @@ from time_machine import travel
 import galileo.experiments
 import galileo.jobs
 import galileo.utils.datasets
-from galileo import galileo_context
+from galileo import splunk_ao_context
 from galileo.decorator import SPAN_TYPE
 from galileo.experiments import (
     Experiments,
@@ -56,7 +56,7 @@ from tests.testutils.setup import setup_mock_logstreams_client, setup_mock_proje
 
 @pytest.fixture
 def reset_context(auto_use=True) -> None:
-    galileo_context.reset()
+    splunk_ao_context.reset()
     os.environ.pop("GALILEO_PROJECT", None)
     os.environ.pop("GALILEO_PROJECT_ID", None)
 
@@ -152,7 +152,7 @@ def prompt_run_settings():
 
 
 def complex_trace_function(input):
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     output = input + " output"
     logger.add_llm_span(input=input, output=output, model="example")
     return output
@@ -1319,7 +1319,7 @@ class TestExperiments:
         on_error = Mock()
 
         # When: run_experiment() is called with a function and on_error (function flow)
-        with patch("galileo.experiments.galileo_context.flush") as mock_flush:
+        with patch("galileo.experiments.splunk_ao_context.flush") as mock_flush:
             run_experiment(
                 experiment_name="test_experiment",
                 project="awesome-new-project",

--- a/tests/test_galileo_context.py
+++ b/tests/test_galileo_context.py
@@ -2,14 +2,14 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from galileo import galileo_context
+from galileo import splunk_ao_context
 from galileo.decorator import _experiment_id_context, _log_stream_context, _project_context
 from tests.testutils.setup import setup_mock_logstreams_client, setup_mock_projects_client, setup_mock_traces_client
 
 
 @pytest.fixture
 def reset_context() -> None:
-    galileo_context.reset()
+    splunk_ao_context.reset()
 
 
 @patch("galileo.logger.logger.LogStreams")
@@ -19,7 +19,7 @@ def test_nested_context_restoration(
     mock_traces_client: Mock, mock_projects_client: Mock, mock_logstreams_client: Mock, reset_context
 ) -> None:
     """
-    Test that nested galileo_context calls correctly restore the previous context.
+    Test that nested splunk_ao_context calls correctly restore the previous context.
     This tests the stack-based approach for context nesting.
     """
     setup_mock_traces_client(mock_traces_client)
@@ -32,19 +32,19 @@ def test_nested_context_restoration(
     assert _experiment_id_context.get() is None
 
     # First level context
-    with galileo_context(project="project1", log_stream="log_stream1"):
+    with splunk_ao_context(project="project1", log_stream="log_stream1"):
         assert _project_context.get() == "project1"
         assert _log_stream_context.get() == "log_stream1"
         assert _experiment_id_context.get() is None
 
         # Second level context
-        with galileo_context(project="project2", log_stream="log_stream2"):
+        with splunk_ao_context(project="project2", log_stream="log_stream2"):
             assert _project_context.get() == "project2"
             assert _log_stream_context.get() == "log_stream2"
             assert _experiment_id_context.get() is None
 
             # Third level context
-            with galileo_context(project="project3", log_stream="log_stream3"):
+            with splunk_ao_context(project="project3", log_stream="log_stream3"):
                 assert _project_context.get() == "project3"
                 assert _log_stream_context.get() == "log_stream3"
                 assert _experiment_id_context.get() is None
@@ -80,19 +80,19 @@ def test_context_update_with_defaults(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # First level context with project and log_stream
-    with galileo_context(project="project1", log_stream="log_stream1"):
+    with splunk_ao_context(project="project1", log_stream="log_stream1"):
         assert _project_context.get() == "project1"
         assert _log_stream_context.get() == "log_stream1"
         assert _experiment_id_context.get() is None
 
         # Second level context with only project updated; log_stream should be default
-        with galileo_context(project="project2"):
+        with splunk_ao_context(project="project2"):
             assert _project_context.get() == "project2"
             assert _log_stream_context.get() is None  # use env default
             assert _experiment_id_context.get() is None
 
             # Third level context with no params: should use defaults
-            with galileo_context():
+            with splunk_ao_context():
                 assert _project_context.get() is None
                 assert _log_stream_context.get() is None
                 assert _experiment_id_context.get() is None

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -10,7 +10,7 @@ from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 
-from galileo import Message, MessageRole, galileo_context
+from galileo import Message, MessageRole, splunk_ao_context
 from galileo.config import GalileoPythonConfig
 from galileo.handlers.langchain import GalileoAsyncCallback, GalileoCallback
 from galileo.handlers.langchain.utils import parse_llm_result, update_root_to_agent
@@ -1035,7 +1035,7 @@ class TestGalileoCallbackWithIngestionHook:
         [
             lambda hook: GalileoCallback(ingestion_hook=hook),
             lambda hook: GalileoCallback(galileo_logger=GalileoLogger(), ingestion_hook=hook),
-            lambda hook: GalileoCallback(galileo_logger=galileo_context.get_logger_instance(), ingestion_hook=hook),
+            lambda hook: GalileoCallback(galileo_logger=splunk_ao_context.get_logger_instance(), ingestion_hook=hook),
         ],
     )
     def test_on_chain_end_with_ingestion_hook(self, callback_builder):

--- a/tests/test_langchain_middleware.py
+++ b/tests/test_langchain_middleware.py
@@ -8,7 +8,7 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.runtime import Runtime
 from pydantic import BaseModel
 
-from galileo import galileo_context
+from galileo import splunk_ao_context
 from galileo.handlers.langchain.middleware import GalileoMiddleware
 from galileo.logger.logger import GalileoLogger
 from tests.testutils.setup import setup_mock_logstreams_client, setup_mock_projects_client, setup_mock_traces_client
@@ -508,7 +508,7 @@ class TestIngestionHook:
         [
             lambda hook: GalileoMiddleware(ingestion_hook=hook),
             lambda hook: GalileoMiddleware(galileo_logger=GalileoLogger(), ingestion_hook=hook),
-            lambda hook: GalileoMiddleware(galileo_logger=galileo_context.get_logger_instance(), ingestion_hook=hook),
+            lambda hook: GalileoMiddleware(galileo_logger=splunk_ao_context.get_logger_instance(), ingestion_hook=hook),
         ],
     )
     def test_ingestion_hook_called(self, middleware_builder) -> None:

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -847,25 +847,25 @@ class TestLogStreamContext:
     """Test suite for LogStream.context() method."""
 
     @patch("galileo.shared.project_resolver.Projects")
-    @patch("galileo.log_stream.galileo_context")
+    @patch("galileo.log_stream.splunk_ao_context")
     @patch("galileo.log_stream.LogStreams")
-    def test_context_returns_galileo_context(
+    def test_context_returns_splunk_ao_context(
         self,
         mock_logstreams_class: MagicMock,
-        mock_galileo_context: MagicMock,
+        mock_splunk_ao_context: MagicMock,
         mock_projects_class: MagicMock,
         reset_configuration: None,
         mock_logstream: MagicMock,
         mock_project: MagicMock,
     ) -> None:
         mock_projects_class.return_value.get_with_env_fallbacks.return_value = mock_project
-        """Test context() returns a properly configured galileo_context."""
+        """Test context() returns a properly configured splunk_ao_context."""
         mock_logstream_service = MagicMock()
         mock_logstreams_class.return_value = mock_logstream_service
         mock_logstream_service.get.return_value = mock_logstream
 
         mock_context = MagicMock()
-        mock_galileo_context.return_value = mock_context
+        mock_splunk_ao_context.return_value = mock_context
 
         # Mock the project property
         with patch("galileo.log_stream.Project") as mock_project_class:
@@ -876,7 +876,7 @@ class TestLogStreamContext:
             log_stream = LogStream.get(name="Test Stream", project_id="test-project-id")
             result = log_stream.context()
 
-            mock_galileo_context.assert_called_once_with(project="Test Project", log_stream="Test Stream")
+            mock_splunk_ao_context.assert_called_once_with(project="Test Project", log_stream="Test Stream")
             assert result == mock_context
 
 

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -7,7 +7,7 @@ from openai import Stream
 from openai.types.chat import ChatCompletionChunk
 from openai.types.responses import ResponseCompletedEvent
 
-from galileo import Message, MessageRole, galileo_context, log
+from galileo import Message, MessageRole, splunk_ao_context, log
 from galileo.openai import OpenAIGalileo, openai
 from galileo_core.schemas.logging.span import LlmSpan, WorkflowSpan
 from tests.testutils.setup import setup_mock_logstreams_client, setup_mock_projects_client, setup_mock_traces_client
@@ -45,7 +45,7 @@ def test_basic_openai_call(
     setup_mock_logstreams_client(mock_logstreams_client)
     openai_create.return_value = create_chat_completion
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     chat_completion = openai.chat.completions.create(
@@ -66,7 +66,7 @@ def test_basic_openai_call(
     response = chat_completion.choices[0].message.content
     assert response == "The mock is working! ;)"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1
@@ -108,7 +108,7 @@ def test_streamed_openai_call(
         cast_to=ChatCompletionChunk, client=openai.OpenAI(), response=Response(status_code=200, content=EventStream())
     )
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     stream = openai.chat.completions.create(
@@ -123,7 +123,7 @@ def test_streamed_openai_call(
     assert response == "Hello"
     assert chunk_count == 3
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1
@@ -158,7 +158,7 @@ def test_openai_api_calls_as_parent_span(
     openai_create.return_value = create_chat_completion
 
     # we want reset context and enable tracing for openai plugin
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     @log()
@@ -171,7 +171,7 @@ def test_openai_api_calls_as_parent_span(
     output = call_openai()
     assert output == "The mock is working! ;)"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
@@ -206,7 +206,7 @@ def test_openai_error_trace(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # we want reset context and enable tracing for openai plugin
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     def call_openai(model: str = "gpt-3.5-turbo"):
@@ -218,7 +218,7 @@ def test_openai_error_trace(
     with pytest.raises(RuntimeError):
         call_openai()
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     openai_create.assert_called_once()
     mock_traces_client_instance.ingest_traces.assert_called()
@@ -243,7 +243,7 @@ def test_openai_error_trace_(
     )
 
     # we want reset context and enable tracing for openai plugin
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     def call_openai(model: str = "gpt-3.5-turbo"):
@@ -255,7 +255,7 @@ def test_openai_error_trace_(
     with pytest.raises(RuntimeError):
         call_openai()
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     openai_create.assert_called_once()
     mock_traces_client_instance.ingest_traces.assert_called()
@@ -283,7 +283,7 @@ def test_client_fails_because_openai_error_trace_no_exp(
     setup_mock_logstreams_client(mock_logstreams_client)
 
     # we want reset context and enable tracing for openai plugin
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     @log
@@ -296,7 +296,7 @@ def test_client_fails_because_openai_error_trace_no_exp(
     with pytest.raises(RuntimeError):
         call_openai()
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     mock_projects_client.assert_called_once()
     openai_create.assert_called_once()
@@ -328,7 +328,7 @@ def test_galileo_api_client_transport_error_not_blocking_user_code(
     setup_mock_logstreams_client(mock_logstreams_client)
     openai_create.return_value = create_chat_completion
     # we want reset context and enable tracing for openai plugin
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     @log()
@@ -339,7 +339,7 @@ def test_galileo_api_client_transport_error_not_blocking_user_code(
         return chat_completion.choices[0].message.content
 
     assert call_openai() == "The mock is working! ;)"
-    galileo_context.flush()
+    splunk_ao_context.flush()
 
     # Projects may be called multiple times as different components try to initialize
     # The key assertion is that user code (openai_create) runs successfully despite SDK errors
@@ -363,10 +363,10 @@ def test_openai_calls_in_active_trace(
     setup_mock_logstreams_client(mock_logstreams_client)
     openai_create.return_value = create_chat_completion
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
-    logger = galileo_context.get_logger_instance()
+    logger = splunk_ao_context.get_logger_instance()
     logger.start_trace("test trace")
 
     openai.chat.completions.create(messages=[{"role": "user", "content": "Say this is a test"}], model="gpt-4o-mini")
@@ -402,7 +402,7 @@ def test_chat_completions_multiple_messages(
     setup_mock_logstreams_client(mock_logstreams_client)
     openai_create.return_value = create_chat_completion
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     input_messages = [
@@ -419,7 +419,7 @@ def test_chat_completions_multiple_messages(
     response_text = response.choices[0].message.content
     assert response_text == "The mock is working! ;)"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1
@@ -462,7 +462,7 @@ def test_basic_responses_api_call(
     setup_mock_logstreams_client(mock_logstreams_client)
     openai_create.return_value = create_responses_response
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     response = openai.responses.create(input="Say this is a test", model="gpt-4o")
@@ -470,7 +470,7 @@ def test_basic_responses_api_call(
     response_text = response.output_text
     assert response_text == "This is a test response"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1
@@ -503,7 +503,7 @@ def test_responses_api_with_tools(
     setup_mock_logstreams_client(mock_logstreams_client)
     openai_create.return_value = create_responses_response_with_tools
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     openai.responses.create(
@@ -523,7 +523,7 @@ def test_responses_api_with_tools(
         ],
     )
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1
@@ -567,7 +567,7 @@ def test_responses_api_multiple_messages(
     setup_mock_logstreams_client(mock_logstreams_client)
     openai_create.return_value = create_responses_response
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     input_messages = [
@@ -585,7 +585,7 @@ def test_responses_api_multiple_messages(
     assert len(response.output) == 1
     assert response.output[0].role == "assistant"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1
@@ -630,7 +630,7 @@ def test_responses_api_streaming(
         response=Response(status_code=200, content=ResponsesEventStream()),
     )
 
-    galileo_context.reset()
+    splunk_ao_context.reset()
     OpenAIGalileo().register_tracing()
 
     stream = openai.responses.create(input="Say hello", model="gpt-4o", stream=True)
@@ -646,7 +646,7 @@ def test_responses_api_streaming(
     assert completed_event is not None
     assert completed_event.response.status == "completed"
 
-    galileo_context.flush()
+    splunk_ao_context.flush()
     payload = mock_traces_client_instance.ingest_traces.call_args[0][0]
 
     assert len(payload.traces) == 1

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -14,7 +14,7 @@ from galileo.decorator import (
     _log_stream_context,
     _project_context,
     _session_id_context,
-    galileo_dataset_context,
+    splunk_ao_dataset_context,
 )
 from galileo.otel import (
     _TRACE_PROVIDER_CONTEXT_VAR,
@@ -23,12 +23,12 @@ from galileo.otel import (
     GalileoOTLPExporter,
     GalileoSpanProcessor,
     _set_tool_span_attributes,
-    start_galileo_span,
+    start_splunk_ao_span,
 )
 from galileo_core.schemas.logging.span import ToolSpan
 
 if OTEL_AVAILABLE:
-    from galileo.otel import _set_workflow_span_attributes, start_galileo_span
+    from galileo.otel import _set_workflow_span_attributes, start_splunk_ao_span
     from galileo_core.schemas.logging.llm import Message, MessageRole
     from galileo_core.schemas.logging.span import WorkflowSpan
     from galileo_core.schemas.shared.document import Document
@@ -570,7 +570,7 @@ class TestSetToolSpanAttributes:
 
 
 class TestStartGalileoSpan:
-    """Test suite for start_galileo_span context manager."""
+    """Test suite for start_splunk_ao_span context manager."""
 
     @pytest.fixture(autouse=True)
     def reset_trace_provider(self):
@@ -580,8 +580,8 @@ class TestStartGalileoSpan:
         _TRACE_PROVIDER_CONTEXT_VAR.set(None)
 
     @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
-    def test_start_galileo_span_dispatches_tool_span(self):
-        """Test that start_galileo_span routes a ToolSpan to _set_tool_span_attributes."""
+    def test_start_splunk_ao_span_dispatches_tool_span(self):
+        """Test that start_splunk_ao_span routes a ToolSpan to _set_tool_span_attributes."""
         # Given: a ToolSpan with all fields populated and a mock tracer provider
         tool_span = ToolSpan(
             name="my-tool",
@@ -598,8 +598,8 @@ class TestStartGalileoSpan:
         mock_provider.get_tracer.return_value = mock_tracer
         _TRACE_PROVIDER_CONTEXT_VAR.set(mock_provider)
 
-        # When: using start_galileo_span with the ToolSpan
-        with start_galileo_span(tool_span) as span:
+        # When: using start_splunk_ao_span with the ToolSpan
+        with start_splunk_ao_span(tool_span) as span:
             assert span is mock_otel_span
 
         # Then: the span has gen_ai.system set and tool-specific attributes
@@ -614,8 +614,8 @@ class TestStartGalileoSpan:
         assert calls["gen_ai.tool.call.id"] == "call-789"
 
     @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
-    def test_start_galileo_span_tool_span_with_none_output(self):
-        """Test that start_galileo_span handles a ToolSpan with None output and tool_call_id."""
+    def test_start_splunk_ao_span_tool_span_with_none_output(self):
+        """Test that start_splunk_ao_span handles a ToolSpan with None output and tool_call_id."""
         # Given: a ToolSpan with only input populated
         tool_span = ToolSpan(name="minimal-tool", input="just input", output=None, tool_call_id=None, status_code=200)
         mock_otel_span = Mock()
@@ -626,8 +626,8 @@ class TestStartGalileoSpan:
         mock_provider.get_tracer.return_value = mock_tracer
         _TRACE_PROVIDER_CONTEXT_VAR.set(mock_provider)
 
-        # When: using start_galileo_span with the minimal ToolSpan
-        with start_galileo_span(tool_span) as span:
+        # When: using start_splunk_ao_span with the minimal ToolSpan
+        with start_splunk_ao_span(tool_span) as span:
             assert span is mock_otel_span
 
         # Then: gen_ai.system, operation name, tool name, tool arguments, and input are set (no output or tool_call_id)
@@ -737,8 +737,8 @@ class TestWorkflowSpanAttributes:
         assert input_call[0][0] == "gen_ai.input.messages"
 
     @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
-    def test_workflow_span_in_start_galileo_span(self, mock_dependencies):
-        """Test that WorkflowSpan is handled in start_galileo_span context manager."""
+    def test_workflow_span_in_start_splunk_ao_span(self, mock_dependencies):
+        """Test that WorkflowSpan is handled in start_splunk_ao_span context manager."""
         # Given: a WorkflowSpan
         workflow_span = WorkflowSpan(name="test-workflow", input="input", output="output", status_code=200)
         mock_span = mock_dependencies["span"]
@@ -754,8 +754,8 @@ class TestWorkflowSpanAttributes:
 
         # Patch get_tracer_provider to return our mock
         with patch("galileo.otel.trace.get_tracer_provider", return_value=mock_trace_provider):
-            # When: using start_galileo_span with WorkflowSpan
-            with start_galileo_span(workflow_span):
+            # When: using start_splunk_ao_span with WorkflowSpan
+            with start_splunk_ao_span(workflow_span):
                 pass
 
         # Then: WorkflowSpan attributes should be set
@@ -765,7 +765,7 @@ class TestWorkflowSpanAttributes:
 
 
 class TestDatasetContext:
-    """Tests for dataset context variables and galileo_dataset_context manager."""
+    """Tests for dataset context variables and splunk_ao_dataset_context manager."""
 
     @pytest.fixture
     def reset_dataset_context(self):
@@ -790,15 +790,15 @@ class TestDatasetContext:
             yield {"exporter": mock_exp, "batch": mock_batch}
 
     @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
-    def test_galileo_dataset_context_sets_values(self, reset_dataset_context):
-        """Test that galileo_dataset_context sets context variables correctly."""
+    def test_splunk_ao_dataset_context_sets_values(self, reset_dataset_context):
+        """Test that splunk_ao_dataset_context sets context variables correctly."""
         # Given: dataset context is initially empty
         assert _dataset_input_context.get(None) is None
         assert _dataset_output_context.get(None) is None
         assert _dataset_metadata_context.get(None) is None
 
         # When: entering the context manager with values
-        with galileo_dataset_context(
+        with splunk_ao_dataset_context(
             dataset_input="test input", dataset_output="expected output", dataset_metadata={"key": "value"}
         ):
             # Then: context variables are set inside the context
@@ -812,15 +812,15 @@ class TestDatasetContext:
         assert _dataset_metadata_context.get(None) is None
 
     @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
-    def test_galileo_dataset_context_nested_contexts(self, reset_dataset_context):
-        """Test that nested galileo_dataset_context managers work correctly."""
+    def test_splunk_ao_dataset_context_nested_contexts(self, reset_dataset_context):
+        """Test that nested splunk_ao_dataset_context managers work correctly."""
         # Given: outer context with initial values
-        with galileo_dataset_context(dataset_input="outer input", dataset_output="outer output"):
+        with splunk_ao_dataset_context(dataset_input="outer input", dataset_output="outer output"):
             assert _dataset_input_context.get() == "outer input"
             assert _dataset_output_context.get() == "outer output"
 
             # When: entering inner context with different values
-            with galileo_dataset_context(dataset_input="inner input", dataset_output="inner output"):
+            with splunk_ao_dataset_context(dataset_input="inner input", dataset_output="inner output"):
                 # Then: inner context values are active
                 assert _dataset_input_context.get() == "inner input"
                 assert _dataset_output_context.get() == "inner output"
@@ -834,11 +834,11 @@ class TestDatasetContext:
         assert _dataset_output_context.get(None) is None
 
     @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
-    def test_galileo_dataset_context_exception_handling(self, reset_dataset_context):
+    def test_splunk_ao_dataset_context_exception_handling(self, reset_dataset_context):
         """Test that context variables are reset even when exception occurs."""
         # Given/When: an exception is raised inside the context
         with pytest.raises(ValueError, match="test error"):
-            with galileo_dataset_context(dataset_input="test", dataset_output="expected"):
+            with splunk_ao_dataset_context(dataset_input="test", dataset_output="expected"):
                 assert _dataset_input_context.get() == "test"
                 raise ValueError("test error")
 
@@ -916,10 +916,10 @@ class TestDatasetContext:
         assert mock_span._resource == mock_merged_resource
 
     @pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not available")
-    def test_galileo_dataset_context_partial_values(self, reset_dataset_context):
-        """Test that galileo_dataset_context works with partial values."""
+    def test_splunk_ao_dataset_context_partial_values(self, reset_dataset_context):
+        """Test that splunk_ao_dataset_context works with partial values."""
         # When: only some values are provided
-        with galileo_dataset_context(dataset_output="expected only"):
+        with splunk_ao_dataset_context(dataset_output="expected only"):
             # Then: only provided values are set
             assert _dataset_input_context.get(None) is None
             assert _dataset_output_context.get() == "expected only"

--- a/tests/utils/test_telemetry_toggle.py
+++ b/tests/utils/test_telemetry_toggle.py
@@ -1,11 +1,11 @@
-from galileo.utils.decorators import galileo_logging_enabled
+from galileo.utils.decorators import splunk_ao_logging_enabled
 
 
-def test_galileo_logging_enabled(monkeypatch) -> None:
-    assert galileo_logging_enabled() is True
+def test_splunk_ao_logging_enabled(monkeypatch) -> None:
+    assert splunk_ao_logging_enabled() is True
 
     monkeypatch.setenv("GALILEO_LOGGING_DISABLED", "true")
-    assert galileo_logging_enabled() is False
+    assert splunk_ao_logging_enabled() is False
 
     monkeypatch.setenv("GALILEO_LOGGING_DISABLED", "1")
-    assert galileo_logging_enabled() is False
+    assert splunk_ao_logging_enabled() is False


### PR DESCRIPTION
# User description
**Description:**
Renames all public function, method, and module-level instance identifiers from galileo_* to splunk_ao_*, and renames the GALILEO_HEADER_PREFIX constant to
SPLUNK_AO_HEADER_PREFIX. All call sites, imports, docstrings, tests, READMEs, and AGENTS.md are updated across src/, tests/, galileo-adk/, and
galileo-a2a/.

What was renamed

Functions / methods / instances

galileo_context → splunk_ao_context
galileo_dataset_context → splunk_ao_dataset_context
galileo_logging_enabled → splunk_ao_logging_enabled
convert_to_galileo_message → convert_to_splunk_ao_message
get_galileo_args → get_splunk_ao_args
add_galileo_span_processor → add_splunk_ao_span_processor
start_galileo_span → start_splunk_ao_span
_galileo_wrapper → _splunk_ao_wrapper
_with_galileo → _with_splunk_ao
add_galileo_custom_span → add_splunk_ao_custom_span
galileo_retriever → splunk_ao_retriever
_galileo_is_retriever → _splunk_ao_is_retriever
convert_adk_content_to_galileo_messages → convert_adk_content_to_splunk_ao_messages
convert_adk_tools_to_galileo_format → convert_adk_tools_to_splunk_ao_format
Constants

GALILEO_HEADER_PREFIX → SPLUNK_AO_HEADER_PREFIX (wire value "X-Galileo" unchanged)
Intentionally left unchanged

Class names (GalileoLogger, GalileoCallback, etc.) — deferred to follow-up
Environment variable strings (GALILEO_API_KEY, GALILEO_PROJECT, etc.) — user-facing config, requires separate deprecation
Wire header values (X-Galileo-Trace-ID, X-Galileo-Parent-ID, X-Galileo-SDK) — backend must be updated first
galileo_core imports — external package, out of scope
src/galileo/resources/ — auto-generated from OpenAPI spec, never edited manually

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Rename the decorator-based context helpers, OpenAI wrapper instrumentation, Agent Control resolution, and tracing utilities to their new <code>splunk_ao_*</code> identifiers so documentation, telemetry toggles, and exported SDK APIs stay consistent with the renamed public surface. Update the Galileo ADK retriever decorator, converter helpers, span processor wiring, and related docs/tests to reference <code>splunk_ao_*</code> so tool spans, headers, and README guidance continue to work under the new names.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/599?tool=ast&topic=ADK+rename>ADK rename</a>
        </td><td>Rename the ADK retriever decorator, helper converters, observer wiring, README guidance, and tests to <code>splunk_ao_*</code> so FunctionTool retriever spans, message conversion, and documentation align with the new naming convention.<details><summary>Modified files (13)</summary><ul><li>galileo-a2a/README.md</li>
<li>galileo-a2a/examples/two_agent_demo.py</li>
<li>galileo-a2a/src/galileo_a2a/instrumentor.py</li>
<li>galileo-adk/README.md</li>
<li>galileo-adk/src/galileo_adk/__init__.py</li>
<li>galileo-adk/src/galileo_adk/data_converters.py</li>
<li>galileo-adk/src/galileo_adk/decorator.py</li>
<li>galileo-adk/src/galileo_adk/observer.py</li>
<li>galileo-adk/tests/conftest.py</li>
<li>galileo-adk/tests/test_callback.py</li>
<li>galileo-adk/tests/test_data_converters.py</li>
<li>galileo-adk/tests/test_retriever.py</li>
<li>tests/utils/test_telemetry_toggle.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/599?tool=ast&topic=Context+rename>Context rename</a>
        </td><td>Replace all <code>galileo_context</code>/dataset helpers, tracing utilities, OpenAI wrapper plumbing, header constants, span processors, and supporting telemetry toggles with their <code>splunk_ao_*</code> counterparts across the SDK, docs, and tests so the renamed public API continues to control logging, tracing, and Agent Control target resolution consistently.<details><summary>Modified files (28)</summary><ul><li>AGENTS.md</li>
<li>README.md</li>
<li>src/galileo/__init__.py</li>
<li>src/galileo/agent_control.py</li>
<li>src/galileo/constants/__init__.py</li>
<li>src/galileo/constants/tracing.py</li>
<li>src/galileo/decorator.py</li>
<li>src/galileo/experiments.py</li>
<li>src/galileo/handlers/openai_agents/handler.py</li>
<li>src/galileo/log_stream.py</li>
<li>src/galileo/log_streams.py</li>
<li>src/galileo/openai/__init__.py</li>
<li>src/galileo/openai/extractors.py</li>
<li>src/galileo/openai/response_generator.py</li>
<li>src/galileo/otel.py</li>
<li>src/galileo/tracing.py</li>
<li>src/galileo/utils/decorators/__init__.py</li>
<li>src/galileo/utils/decorators/telemetry_toggle.py</li>
<li>src/galileo/utils/headers_data.py</li>
<li>tests/test_agent_control.py</li>
<li>tests/test_decorator.py</li>
<li>tests/test_decorator_distributed.py</li>
<li>tests/test_galileo_context.py</li>
<li>tests/test_langchain.py</li>
<li>tests/test_langchain_middleware.py</li>
<li>tests/test_log_stream.py</li>
<li>tests/test_openai.py</li>
<li>tests/test_otel.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/599?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (2)</summary><ul><li>src/galileo/handlers/base_handler.py</li>
<li>tests/test_experiments.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/599?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>