### PR TITLE
feat: Add jsonl_flat export format

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26606,6 +26606,7 @@ components:
       enum:
         - csv
         - jsonl
+        - jsonl_flat
       title: LLMExportFormat
     LLMIntegration:
       type: string

--- a/src/galileo/export.py
+++ b/src/galileo/export.py
@@ -61,7 +61,7 @@ class ExportClient:
             ),
         )
 
-        if export_format == LLMExportFormat.JSONL:
+        if export_format in (LLMExportFormat.JSONL, LLMExportFormat.JSONL_FLAT):
             for line in response_iterator:
                 if line:
                     yield json.loads(line)

--- a/src/galileo/resources/models/llm_export_format.py
+++ b/src/galileo/resources/models/llm_export_format.py
@@ -4,6 +4,7 @@ from enum import Enum
 class LLMExportFormat(str, Enum):
     CSV = "csv"
     JSONL = "jsonl"
+    JSONL_FLAT = "jsonl_flat"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -252,6 +252,33 @@ def test_export_records_csv(mock_export_records_stream):
     assert request_body.export_format == LLMExportFormat.CSV
 
 
+@patch("galileo.export.export_records_stream")
+def test_export_records_jsonl_flat(mock_export_records_stream):
+    # Given: flat JSONL lines (one JSON object per line, no nesting)
+    project_id = str(uuid4())
+    records = [{"id": "1", "type": "llm"}, {"id": "2", "type": "trace"}]
+    mock_export_records_stream.return_value = iter(json.dumps(r) for r in records)
+
+    # When: export_records is called with JSONL_FLAT
+    result = list(
+        export_records(
+            project_id=project_id,
+            root_type=RootType.SESSION,
+            export_format=LLMExportFormat.JSONL_FLAT,
+            filters=[],
+            sort=LogRecordsSortClause(column_id="created_at", ascending=False),
+            log_stream_id=str(uuid4()),
+        )
+    )
+
+    # Then: each line is parsed into a flat dict with no wrapping
+    assert len(result) == 2
+    assert result[0] == {"id": "1", "type": "llm"}
+    assert result[1] == {"id": "2", "type": "trace"}
+    request_body = mock_export_records_stream.call_args.kwargs["body"]
+    assert request_body.export_format == LLMExportFormat.JSONL_FLAT
+
+
 @pytest.mark.parametrize("redact_param", [True, False])
 @patch("galileo.export.export_records_stream")
 def test_export_records_redact(mock_export_records_stream, redact_param):


### PR DESCRIPTION
# User description
**Shortcut:**
sc-65493

**Description:**

**Tests:**

- [ ] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a <code>jsonl_flat</code> export format by updating the API spec and <code>LLMExportFormat</code> so clients can request flattening without re-building the tree. Adapt <code>export_records</code> streaming handling to consume both <code>jsonl</code> and <code>jsonl_flat</code> newline-delimited JSON lines and cover the new path with tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/621?tool=ast&topic=Export+format>Export format</a>
        </td><td>Add <code>jsonl_flat</code> to the LLM export schema and enum so the endpoint advertises the flattened JSONL option for Verizon’s export flow.<details><summary>Modified files (2)</summary><ul><li>openapi.yaml</li>
<li>src/galileo/resources/models/llm_export_format.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david@galileo.ai</td><td>feat: Add jsonl_flat e...</td><td>July 01, 2026</td></tr>
<tr><td>thiago.bomfin@galileo.ai</td><td>fix: schema patches (#...</td><td>April 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/621?tool=ast&topic=Flat+export+flow>Flat export flow</a>
        </td><td>Enable the export client and regression tests to treat <code>jsonl_flat</code> responses as newline-delimited JSON, matching the streaming behavior for existing JSONL exports.<details><summary>Modified files (2)</summary><ul><li>src/galileo/export.py</li>
<li>tests/test_export.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david@galileo.ai</td><td>feat: Add jsonl_flat e...</td><td>July 01, 2026</td></tr>
<tr><td>AnkushMalaker</td><td>feat(export): expose i...</td><td>June 17, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/621?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>