### PR TITLE
feat: support custom HTTP headers (API gateway / IBM APIC)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,8 +455,31 @@ fix:, perf:, chore:, docs:, style:, refactor:
 | `GALILEO_PROJECT` | No | Default project name |
 | `GALILEO_LOG_STREAM` | No | Default log stream name |
 | `GALILEO_LOGGING_DISABLED` | No | Disable trace collection |
+| `GALILEO_EXTRA_HEADERS` | No | JSON object of extra HTTP headers sent with every API request (e.g. for an IBM APIC gateway). See "Custom HTTP Headers" below. |
 
 *Required for non-production environments
+
+### Custom HTTP Headers (API gateways / IBM APIC)
+
+When the Galileo API is fronted by a gateway (e.g. IBM APIC) that requires additional
+headers such as `ibm_client_id` / `ibm_client_secret` on every request, set
+`GALILEO_EXTRA_HEADERS` to a JSON object, or pass `extra_headers=...` programmatically.
+The headers are applied to **all** egress paths — resource management, batch trace
+ingestion, the distributed ingest service, and the pre-auth login/healthcheck calls.
+Galileo's own auth and content headers always win on key collisions.
+
+```bash
+export GALILEO_EXTRA_HEADERS='{"ibm_client_id": "my_client_id", "ibm_client_secret": "my_client_secret"}'
+```
+
+```python
+from galileo.config import GalileoPythonConfig
+
+# Programmatic equivalent (kwarg maps to the GalileoConfig field inherited from galileo-core)
+GalileoPythonConfig.get(
+    extra_headers={"ibm_client_id": "my_client_id", "ibm_client_secret": "my_client_secret"}
+)
+```
 
 ## References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,8 +465,10 @@ When the Galileo API is fronted by a gateway (e.g. IBM APIC) that requires addit
 headers such as `ibm_client_id` / `ibm_client_secret` on every request, set
 `GALILEO_EXTRA_HEADERS` to a JSON object, or pass `extra_headers=...` programmatically.
 The headers are applied to **all** egress paths — resource management, batch trace
-ingestion, the distributed ingest service, and the pre-auth login/healthcheck calls.
-Galileo's own auth and content headers always win on key collisions.
+ingestion, the distributed ingest service (including its `/ingest/healthz`
+availability probe), and the pre-auth login/healthcheck calls.
+Galileo's own auth and content headers always win on key collisions, matched
+case-insensitively so a differently-cased duplicate can't slip a second copy onto the wire.
 
 ```bash
 export GALILEO_EXTRA_HEADERS='{"ibm_client_id": "my_client_id", "ibm_client_secret": "my_client_secret"}'

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -108,9 +108,21 @@ DEFAULT_TERMINATE_TIMEOUT_SECONDS = 90
 _SLOW_SHUTDOWN_WARN_THRESHOLD_SECONDS = 1.0
 STUB_TRACE_NAME = "stub_trace"  # Name for stub traces created from distributed tracing headers
 
-# Cached result of the ingest service healthz probe. Key "result" is absent until first check.
+# Cached results of the ingest service healthz probe, keyed by the effective probe configuration
+# (see `_ingest_cache_key`) so a change in api_url or extra_headers re-probes instead of reusing a
+# result gathered under a different gateway/auth. Empty until the first check for a given config.
 _ingest_service_cache: dict[str, bool] = {}
 _logger = logging.getLogger("galileo.logger")
+
+
+def _ingest_cache_key(api_url: str, extra_headers: dict[str, str] | None) -> str:
+    """Build a stable cache key from the values that determine the healthz probe's outcome.
+
+    The ingest URL and the headers sent on the probe both affect whether the gateway accepts it, so
+    both are part of the key. Headers are sorted for order-independence.
+    """
+    headers = tuple(sorted((extra_headers or {}).items()))
+    return f"{api_url}|{headers}"
 
 
 class GalileoLogger(TracesLogger):
@@ -396,35 +408,40 @@ class GalileoLogger(TracesLogger):
     def _is_ingest_service_available(cls) -> bool:
         """Check whether the ingest service is reachable, caching the result for the process lifetime.
 
-        The cache is bypassed (and cleared) whenever GALILEO_INGEST_BETA_DISABLED is set so that
-        toggling the flag within the same process takes effect immediately.
+        The cache is keyed by the effective probe configuration (api_url + extra_headers) so that a
+        later ``GalileoPythonConfig.reset()`` or ``get(extra_headers=...)`` that changes where/how we
+        probe re-runs the check instead of reusing an availability result gathered under a different
+        gateway or set of auth headers. The cache is bypassed (and cleared) whenever
+        GALILEO_INGEST_BETA_DISABLED is set so that toggling the flag within the same process takes
+        effect immediately.
         """
         if os.environ.get("GALILEO_INGEST_BETA_DISABLED", "").lower() in ("1", "true", "yes"):
             _ingest_service_cache.clear()
             return False
 
-        if "result" not in _ingest_service_cache:
+        config = GalileoPythonConfig.get()
+        api_url = str(config.api_url).rstrip("/")
+        if "localhost" in api_url:
+            api_url = api_url.replace("8088", "8081")
+        # Forward customer-supplied extra headers (e.g. IBM APIC gateway credentials) on the probe
+        # too. A gateway that enforces those headers on every request — health checks included —
+        # would otherwise 401 this call and make the ingest service look unavailable. `extra_headers`
+        # is provided by newer galileo-core; fall back to None for older core releases.
+        extra_headers = getattr(config, "extra_headers", None)
+        cache_key = _ingest_cache_key(api_url, extra_headers)
+
+        if cache_key not in _ingest_service_cache:
             try:
-                config = GalileoPythonConfig.get()
-                api_url = str(config.api_url).rstrip("/")
-                if "localhost" in api_url:
-                    api_url = api_url.replace("8088", "8081")
-                # Forward customer-supplied extra headers (e.g. IBM APIC gateway
-                # credentials) on the probe too. A gateway that enforces those headers on
-                # every request — health checks included — would otherwise 401 this call
-                # and make the ingest service look unavailable. `extra_headers` is provided
-                # by newer galileo-core; fall back to None for older core releases.
-                extra_headers = getattr(config, "extra_headers", None)
                 resp = httpx.get(f"{api_url}/ingest/healthz", timeout=2.0, headers=extra_headers or None)
-                _ingest_service_cache["result"] = resp.is_success
-                if _ingest_service_cache["result"]:
+                _ingest_service_cache[cache_key] = resp.is_success
+                if _ingest_service_cache[cache_key]:
                     _logger.info("Ingest service healthy at %s, using IngestTraces client", api_url)
                 else:
                     _logger.debug("Ingest service healthz returned %s, using standard client", resp.status_code)
             except Exception:
-                _ingest_service_cache["result"] = False
+                _ingest_service_cache[cache_key] = False
                 _logger.debug("Ingest service healthz check failed, using standard client")
-        return _ingest_service_cache["result"]
+        return _ingest_service_cache[cache_key]
 
     @nop_sync
     def _create_traces_client(self) -> Traces | IngestTraces:

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -446,7 +446,9 @@ class GalileoLogger(TracesLogger):
                     api_key=api_key,
                     log_stream_id=self.log_stream_id,
                     experiment_id=self.experiment_id,
-                    extra_headers=config.extra_headers,
+                    # `extra_headers` is provided by newer galileo-core; fall back to
+                    # None so the SDK keeps working against older core releases.
+                    extra_headers=getattr(config, "extra_headers", None),
                 )
             _logger.debug("No API key available, falling back to standard Traces client")
 

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -446,6 +446,7 @@ class GalileoLogger(TracesLogger):
                     api_key=api_key,
                     log_stream_id=self.log_stream_id,
                     experiment_id=self.experiment_id,
+                    extra_headers=config.extra_headers,
                 )
             _logger.debug("No API key available, falling back to standard Traces client")
 

--- a/src/galileo/logger/logger.py
+++ b/src/galileo/logger/logger.py
@@ -405,10 +405,17 @@ class GalileoLogger(TracesLogger):
 
         if "result" not in _ingest_service_cache:
             try:
-                api_url = str(GalileoPythonConfig.get().api_url).rstrip("/")
+                config = GalileoPythonConfig.get()
+                api_url = str(config.api_url).rstrip("/")
                 if "localhost" in api_url:
                     api_url = api_url.replace("8088", "8081")
-                resp = httpx.get(f"{api_url}/ingest/healthz", timeout=2.0)
+                # Forward customer-supplied extra headers (e.g. IBM APIC gateway
+                # credentials) on the probe too. A gateway that enforces those headers on
+                # every request — health checks included — would otherwise 401 this call
+                # and make the ingest service look unavailable. `extra_headers` is provided
+                # by newer galileo-core; fall back to None for older core releases.
+                extra_headers = getattr(config, "extra_headers", None)
+                resp = httpx.get(f"{api_url}/ingest/healthz", timeout=2.0, headers=extra_headers or None)
                 _ingest_service_cache["result"] = resp.is_success
                 if _ingest_service_cache["result"]:
                     _logger.info("Ingest service healthy at %s, using IngestTraces client", api_url)

--- a/src/galileo/traces.py
+++ b/src/galileo/traces.py
@@ -178,12 +178,17 @@ class IngestTraces:
         api_key: str,
         log_stream_id: str | None = None,
         experiment_id: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         self.project_id = project_id
         self.log_stream_id = log_stream_id
         self.experiment_id = experiment_id
         self.base_url = base_url.rstrip("/")
+        # Apply customer-supplied extra headers first (e.g. for an API gateway such as
+        # Cisco APIC) so Galileo's own headers always win on key collisions. This mirrors
+        # the precedence used by galileo_core.ApiClient for the standard API path.
         self._headers = {
+            **(extra_headers or {}),
             "Content-Type": "application/json",
             "Galileo-API-Key": api_key,
             "X-Galileo-SDK": get_sdk_header(),

--- a/src/galileo/traces.py
+++ b/src/galileo/traces.py
@@ -187,8 +187,15 @@ class IngestTraces:
         # Apply customer-supplied extra headers first (e.g. for an API gateway such as
         # Cisco APIC) so Galileo's own headers always win on key collisions. This mirrors
         # the precedence used by galileo_core.ApiClient for the standard API path.
+        #
+        # HTTP header names are case-insensitive, so we drop any extra header whose name
+        # case-insensitively collides with one of Galileo's reserved headers. A plain dict
+        # merge would only override exact-case duplicates, letting e.g. a caller-supplied
+        # ``content-type`` and Galileo's ``Content-Type`` both reach the wire.
+        reserved = {"content-type", "galileo-api-key", "x-galileo-sdk"}
+        safe_extra = {k: v for k, v in (extra_headers or {}).items() if k.strip().lower() not in reserved}
         self._headers = {
-            **(extra_headers or {}),
+            **safe_extra,
             "Content-Type": "application/json",
             "Galileo-API-Key": api_key,
             "X-Galileo-SDK": get_sdk_header(),

--- a/tests/test_logger_distributed.py
+++ b/tests/test_logger_distributed.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 import pytest
 
+import galileo.logger.logger as logger_module
 from galileo.logger import GalileoLogger
 from galileo.logger.logger import GalileoLoggerException
 from galileo.schema.trace import SpansIngestRequest, SpanUpdateRequest, TracesIngestRequest, TraceUpdateRequest
@@ -116,6 +117,30 @@ def test_distributed_logger_uses_ingest_client_when_ingest_service_is_available(
     assert logger._traces_client is mock_ingest_traces_client.return_value
     mock_ingest_traces_client.assert_called_once()
     mock_traces_client.assert_not_called()
+
+
+def test_is_ingest_service_available_forwards_extra_headers() -> None:
+    # Given: a config carrying customer extra headers (e.g. IBM APIC gateway credentials)
+    # and a cleared availability cache so the probe actually runs.
+    logger_module._ingest_service_cache.clear()
+    extra_headers = {"X-IBM-Client-Id": "id", "X-IBM-Client-Secret": "secret"}
+    mock_config = Mock()
+    mock_config.api_url = "https://gateway.example.com"
+    mock_config.extra_headers = extra_headers
+
+    with (
+        patch.object(logger_module.GalileoPythonConfig, "get", return_value=mock_config),
+        patch("galileo.logger.logger.httpx.get") as mock_get,
+    ):
+        mock_get.return_value = Mock(is_success=True, status_code=200)
+
+        # When: the ingest availability probe runs
+        assert GalileoLogger._is_ingest_service_available() is True
+
+    # Then: the probe forwards the extra headers so a header-enforcing gateway accepts it
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["headers"] == extra_headers
+    logger_module._ingest_service_cache.clear()
 
 
 @patch("galileo.logger.logger.LogStreams")

--- a/tests/test_logger_distributed.py
+++ b/tests/test_logger_distributed.py
@@ -120,8 +120,7 @@ def test_distributed_logger_uses_ingest_client_when_ingest_service_is_available(
 
 
 def test_is_ingest_service_available_forwards_extra_headers() -> None:
-    # Given: a config carrying customer extra headers (e.g. IBM APIC gateway credentials)
-    # and a cleared availability cache so the probe actually runs.
+    # Given: a config carrying customer extra headers and a cleared availability cache.
     logger_module._ingest_service_cache.clear()
     extra_headers = {"X-IBM-Client-Id": "id", "X-IBM-Client-Secret": "secret"}
     mock_config = Mock()
@@ -134,12 +133,43 @@ def test_is_ingest_service_available_forwards_extra_headers() -> None:
     ):
         mock_get.return_value = Mock(is_success=True, status_code=200)
 
-        # When: the ingest availability probe runs
+        # When: the ingest availability probe runs.
         assert GalileoLogger._is_ingest_service_available() is True
 
-    # Then: the probe forwards the extra headers so a header-enforcing gateway accepts it
+    # Then: the probe forwards the extra headers so a header-enforcing gateway accepts it.
     mock_get.assert_called_once()
     assert mock_get.call_args.kwargs["headers"] == extra_headers
+    logger_module._ingest_service_cache.clear()
+
+
+def test_is_ingest_service_available_reprobes_when_config_changes() -> None:
+    # Given: the availability cache is empty and the healthz endpoint is reachable.
+    logger_module._ingest_service_cache.clear()
+    first_config = Mock()
+    first_config.api_url = "https://gateway-a.example.com"
+    first_config.extra_headers = {"X-IBM-Client-Id": "a"}
+
+    second_config = Mock()
+    second_config.api_url = "https://gateway-a.example.com"
+    second_config.extra_headers = {"X-IBM-Client-Id": "b"}  # same URL, different headers.
+
+    with (
+        patch("galileo.logger.logger.httpx.get") as mock_get,
+        patch.object(logger_module.GalileoPythonConfig, "get") as mock_config_get,
+    ):
+        mock_get.return_value = Mock(is_success=True, status_code=200)
+
+        # When: the probe runs twice for the same URL but with different extra headers.
+        mock_config_get.return_value = first_config
+        assert GalileoLogger._is_ingest_service_available() is True
+        mock_config_get.return_value = second_config
+        assert GalileoLogger._is_ingest_service_available() is True
+
+    # Then: the cache is keyed by config, so the second (different-headers) call re-probes
+    # instead of reusing the first result, and each probe carries its own headers.
+    assert mock_get.call_count == 2
+    assert mock_get.call_args_list[0].kwargs["headers"] == {"X-IBM-Client-Id": "a"}
+    assert mock_get.call_args_list[1].kwargs["headers"] == {"X-IBM-Client-Id": "b"}
     logger_module._ingest_service_cache.clear()
 
 

--- a/tests/test_traces_client_headers.py
+++ b/tests/test_traces_client_headers.py
@@ -81,6 +81,25 @@ class TestIngestTracesExtraHeaders:
         assert client._headers["Galileo-API-Key"] == "KEY"
         assert client._headers["Content-Type"] == "application/json"
 
+    def test_extra_headers_case_insensitive_collision_dropped(self) -> None:
+        # Given/When: extra headers that collide with Galileo's own headers only by case
+        # (HTTP header names are case-insensitive), plus surrounding whitespace.
+        client = IngestTraces(
+            project_id="p",
+            base_url="http://ingest/",
+            api_key="KEY",
+            extra_headers={"content-type": "text/evil", " Galileo-API-Key ": "evil", "X-GALILEO-SDK": "evil"},
+        )
+
+        # Then: Galileo's canonical headers win and the colliding variants never reach the wire.
+        assert client._headers["Content-Type"] == "application/json"
+        assert client._headers["Galileo-API-Key"] == "KEY"
+        assert "content-type" not in client._headers
+        assert " Galileo-API-Key " not in client._headers
+        assert "X-GALILEO-SDK" not in client._headers
+        # X-Galileo-SDK is set by Galileo, not the caller's "evil" value.
+        assert client._headers["X-Galileo-SDK"] != "evil"
+
     def test_no_extra_headers_by_default(self) -> None:
         # Given/When: an IngestTraces client with no extra headers
         client = IngestTraces(project_id="p", base_url="http://ingest/", api_key="KEY")

--- a/tests/test_traces_client_headers.py
+++ b/tests/test_traces_client_headers.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from galileo.traces import Traces
+from galileo.traces import IngestTraces, Traces
 from galileo.utils.headers_data import get_package_version
 from galileo_core.constants.request_method import RequestMethod
 
@@ -48,3 +48,43 @@ class TestTracesHeaders:
         assert header_value.startswith(f"galileo-python/{get_package_version()}")
         # Should contain the method name (e.g., "_make_async_request@galileo.traces")
         assert "@galileo.traces" in header_value
+
+
+class TestIngestTracesExtraHeaders:
+    """Test that IngestTraces applies customer-supplied extra headers (e.g. IBM APIC)."""
+
+    def test_extra_headers_included(self) -> None:
+        # Given/When: an IngestTraces client configured with extra headers
+        client = IngestTraces(
+            project_id="p",
+            base_url="http://ingest/",
+            api_key="KEY",
+            extra_headers={"ibm_client_id": "my_client_id", "ibm_client_secret": "my_client_secret"},
+        )
+
+        # Then: the extra headers are present alongside Galileo's own headers
+        assert client._headers["ibm_client_id"] == "my_client_id"
+        assert client._headers["ibm_client_secret"] == "my_client_secret"
+        assert client._headers["Galileo-API-Key"] == "KEY"
+        assert client._headers["Content-Type"] == "application/json"
+
+    def test_extra_headers_cannot_override_galileo_headers(self) -> None:
+        # Given/When: extra headers that collide with Galileo's own headers
+        client = IngestTraces(
+            project_id="p",
+            base_url="http://ingest/",
+            api_key="KEY",
+            extra_headers={"Galileo-API-Key": "evil", "Content-Type": "text/evil"},
+        )
+
+        # Then: Galileo's own headers win on collision
+        assert client._headers["Galileo-API-Key"] == "KEY"
+        assert client._headers["Content-Type"] == "application/json"
+
+    def test_no_extra_headers_by_default(self) -> None:
+        # Given/When: an IngestTraces client with no extra headers
+        client = IngestTraces(project_id="p", base_url="http://ingest/", api_key="KEY")
+
+        # Then: only Galileo's own headers are present
+        assert "ibm_client_id" not in client._headers
+        assert client._headers["Galileo-API-Key"] == "KEY"


### PR DESCRIPTION
# User description
## Summary

Adds support for sending customer-defined HTTP headers on **every** request the SDK makes to the Galileo API. This is required when the Galileo API is fronted by an API gateway (e.g. **IBM APIC**) that expects client credentials such as `ibm_client_id` / `ibm_client_secret` on each call.

The feature is header-agnostic: the customer defines both the header names and values via a single config knob.

## What changed (this repo)

The distributed/streaming ingestion client (`IngestTraces`) builds its own `httpx.AsyncClient` and bypasses `galileo-core`'s `ApiClient`, so it needs the headers wired in explicitly:

- `IngestTraces` now accepts `extra_headers` and merges them into its request headers, with Galileo's own headers (`Galileo-API-Key`, `Content-Type`, `X-Galileo-SDK`) taking precedence on key collisions.
- `GalileoLogger._create_traces_client` passes `config.extra_headers`.
- `GalileoPythonConfig` inherits the new `extra_headers` field from `galileo-core`, so the standard API and batch-ingestion paths are already covered by the core change.

## Configuration (customer-facing)

```bash
export GALILEO_EXTRA_HEADERS='{"ibm_client_id": "my_client_id", "ibm_client_secret": "my_client_secret"}'
```

or programmatically:

```python
from galileo.config import GalileoPythonConfig
GalileoPythonConfig.get(extra_headers={"ibm_client_id": "...", "ibm_client_secret": "..."})
```

## Dependency

⚠️ Depends on the matching `galileo-core` change: **rungalileo/orbit#1376** (`feat(core): support custom extra headers on every request`). That PR adds the `extra_headers` field to `ApiClient` / `GalileoConfig` and applies it to all core egress paths (resource management, batch ingestion, and pre-auth login/healthcheck). This SDK PR only covers the distributed-ingestion path that bypasses core, and must land/release after the core change is published to PyPI.

## Testing

- Added `TestIngestTracesExtraHeaders` in `tests/test_traces_client_headers.py` covering: extra headers present, Galileo headers win on collision, and default (no extra headers).
- Runtime-verified the header merge with the concrete IBM APIC headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add support for customer-defined HTTP headers across the SDK&#x27;s distributed ingest flow by wiring <code>extra_headers</code> into <code>IngestTraces</code>, <code>GalileoLogger</code>, and the ingest health probe. Update the configuration docs and tests so gateway credentials like <code>ibm_client_id</code> / <code>ibm_client_secret</code> are sent on every relevant request while Galileo&#x27;s own headers still win on collisions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/629?tool=ast&topic=Custom+headers>Custom headers</a>
        </td><td>Propagate customer headers through <code>IngestTraces</code> and <code>GalileoLogger</code>, and key the ingest health check cache by <code>api_url</code> plus <code>extra_headers</code> so gateway-authenticated probes rerun correctly.<details><summary>Modified files (3)</summary><ul><li>AGENTS.md</li>
<li>src/galileo/logger/logger.py</li>
<li>src/galileo/traces.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bin@galileo.ai</td><td>fix(logger): key inges...</td><td>July 30, 2026</td></tr>
<tr><td>david@galileo.ai</td><td>fix: Handle checking/u...</td><td>June 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-python/629?tool=ast&topic=Header+tests>Header tests</a>
        </td><td>Cover extra-header merging, collision handling, and probe cache behavior with tests for the ingest client and logger health check.<details><summary>Modified files (2)</summary><ul><li>tests/test_logger_distributed.py</li>
<li>tests/test_traces_client_headers.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bin@galileo.ai</td><td>fix(logger): key inges...</td><td>July 30, 2026</td></tr>
<tr><td>namrata.ghadi@galileo.ai</td><td>feat: add agentcontrol...</td><td>May 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/629?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>