### PR TITLE
chore(deps): bump galileo-core to ^4.5.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1311,13 +1311,13 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "galileo-core"
-version = "4.4.0"
+version = "4.5.0"
 description = ""
 optional = false
 python-versions = ">=3.10.0"
 groups = ["main", "test"]
 files = [
-    {file = "galileo_core-4.4.0-py3-none-any.whl", hash = "sha256:eb7995c43fe09583127b807cc9635941f623f5b08207bae95362ce63460c74e8"},
+    {file = "galileo_core-4.5.0-py3-none-any.whl", hash = "sha256:226d45cc328d661ff3c81dbd517ded8707a8dbd5f33f477b11c646e3ee190a9d"},
 ]
 
 [package.dependencies]
@@ -6570,4 +6570,4 @@ otel = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-sdk"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10,<3.15"
-content-hash = "3bff29246f1eadbc86fc6a1e8b56ea2cf44e4463b515b0fdcf63d2b4282c8edd"
+content-hash = "55127f13f8ac528de401386c538280c26208c34b2cdb2f52153c34377e18d00b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ langchain = { version = ">=0.0.0,<2.0.0", optional = true }
 openai = { version = ">=2.8.0,<3.0.0", optional = true }
 openai-agents = { version = ">=0.4.0,<1.0.0", optional = true }
 litellm = { version = ">=1.83.14,<2.0.0", optional = true, python = ">=3.10,<3.14" }
-galileo-core = "^4.4.0"
+galileo-core = "^4.5.0"
 starlette = { version = ">=0.27.0", optional = true }
 backoff = "^2.2.1"
 crewai = { version = ">=0.152.0,<2.0.0", optional = true, python = ">=3.10,<3.14" }
@@ -54,7 +54,7 @@ pytest-xdist = "^3.7.0"
 pytest-socket = "^0.7"
 pytest-asyncio = "^1.0.0"
 requests-mock = "^1.11.0"
-galileo-core = { extras = ["testing"], version = "^4.4.0" }
+galileo-core = { extras = ["testing"], version = "^4.5.0" }
 
 pytest-env = "^1.1.5"
 pytest-timeout = "^2.3"


### PR DESCRIPTION
# User description
## What

Bumps the `galileo-core` dependency constraint from `^4.4.0` → `^4.5.0` (both the main and test/`testing`-extra entries) and regenerates `poetry.lock`.

## Why

The custom HTTP headers feature merged in #629 relies on `galileo-core`'s new `extra_headers` config field (now released in [galileo-core 4.5.0](https://pypi.org/project/galileo-core/4.5.0/), from orbit #1376). Until this bump, `pyproject.toml` still allowed `^4.4.0`, so a fresh resolve could lock to a core release **without** `extra_headers` — in which case setting `GALILEO_EXTRA_HEADERS` silently no-ops on every egress path (the `getattr(config, "extra_headers", None)` fallbacks in `logger.py`/`traces.py` degrade to `None`, and core-backed calls omit the headers), and a gateway like IBM APIC just returns 401 — a hard-to-diagnose failure.

Raising the minimum to `4.5.0` makes the dependency match the feature's actual requirement.

This addresses the non-blocking post-merge follow-up Fernando (@fercor-cisco) raised on #629.

## Notes / follow-up

- Now that core is pinned to a release that guarantees `extra_headers`, the defensive `getattr(config, "extra_headers", None)` fallbacks in `logger.py`/`traces.py` could be simplified to direct attribute access. Left as a separate change to keep this PR a pure dependency bump.

## Testing

- `poetry check --lock` → `All set!`
- Lock diff is limited to the `galileo-core` version/hash and the metadata content-hash (regenerated with the same Poetry 2.2.0 that produced the existing lock, so no unrelated marker churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Raise the <code>galileo-core</code> dependency constraint in <code>pyproject.toml</code> so the core SDK and its <code>testing</code> extra resolve to a release that provides <code>extra_headers</code>. Regenerate <code>poetry.lock</code> to pin <code>galileo-core</code> <code>4.5.0</code> and keep dependency resolution aligned.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bin@galileo.ai</td><td>chore(deps): bump gali...</td><td>July 30, 2026</td></tr>
<tr><td>ci@rungalileo.io</td><td>chore(release): v2.5.1</td><td>July 16, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/rungalileo/galileo-python/630?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>